### PR TITLE
number_to_currency bug

### DIFF
--- a/rails/locale/de.yml
+++ b/rails/locale/de.yml
@@ -78,9 +78,9 @@ de:
       format:
         unit: '€'
         format: '%n%u'
-        separator: 
-        delimiter: 
-        precision: 
+        separator: ","
+        delimiter: ""
+        precision: 2
     percentage:
       format:
         delimiter: ""


### PR DESCRIPTION
Hi,

I got a ActionView::Template::Error (undefined method `>=' for nil:NilClass) error when i want to use number_to_currency. 

With this commit the bug should be fixed.

tbaa
