### PR TITLE
Day names were mistakenly rotated in day_names and abbr_day_names arrays

### DIFF
--- a/rails/locale/fr.yml
+++ b/rails/locale/fr.yml
@@ -11,8 +11,8 @@ fr:
       default: "%d/%m/%Y"
       short: "%e %b"
       long: "%e %B %Y"
-    day_names: [lundi, mardi, mercredi, jeudi, vendredi, samedi, dimanche]
-    abbr_day_names: [lun, mar, mer, jeu, ven, sam, dim]
+    day_names: [dimanche, lundi, mardi, mercredi, jeudi, vendredi, samedi]
+    abbr_day_names: [dim, lun, mar, mer, jeu, ven, sam]
     month_names: [~, janvier, février, mars, avril, mai, juin, juillet, août, septembre, octobre, novembre, décembre]
     abbr_month_names: [~, jan., fév., mar., avr., mai, juin, juil., août, sept., oct., nov., déc.]
     order: [ :day, :month, :year ]


### PR DESCRIPTION
Dear Sven,

Somebody made a big mistake when he updated the French translation: he rotated the days in the day_names and abbr_day_names arrays!

Thus "Sunday" is now translated as "Lundi" (Monday).

https://github.com/svenfuchs/rails-i18n/commit/6348d3183d890b1b8e141b9464bd9f789d1fa563

I've restored the original order in this commit. 
I also checked fr-CA (OK) and fr-CH (not OK). I can correct fr-CH if you want.

I've added minor corrections (capitalisation) in a different commit. They're not so important, tell me if you want them.

Best regards,
Christian
