### PR TITLE
Make Danish translation YAML file ready for both Rails 2 and 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Available locales are:
 > tr, uk, vi, zh-CN, zh-TW
 
 Note that all locale files are not yet ready for Rails 3. Currently, following locales are ready for Rails 2 and 3:
-> en-US, eo, es-AR, es-MX, et, fr, fr-CA, fr-CH, gsw-CH, hi-IN, ja, sk, sw, th, zh-CN, zh-TW
+> da, en-US, eo, es-AR, es-MX, et, fr, fr-CA, fr-CH, gsw-CH, hi-IN, ja, sk, sw, th, zh-CN, zh-TW
 
 We always welcome your contributions!
 

--- a/rails/locale/da.yml
+++ b/rails/locale/da.yml
@@ -40,56 +40,15 @@ da:
       # default value for :prompt => true in FormOptionsHelper
       prompt: "Vælg..."
 
-  datetime:
-    distance_in_words:
-      half_a_minute: "et halvt minut"
-      less_than_x_seconds:
-        one:  "mindre end et sekund"
-        other: "mindre end %{count} sekunder"
-      x_seconds:
-        one:  "et sekund"
-        other: "%{count} sekunder"
-      less_than_x_minutes:
-        one:  "mindre end et minut"
-        other: "mindre end %{count} minutter"
-      x_minutes:
-        one:  "et minut"
-        other: "%{count} minutter"
-      about_x_hours:
-        one:  "cirka en time"
-        other: "cirka %{count} timer"
-      x_days:
-        one:  "en dag"
-        other: "%{count} dage"
-      about_x_months:
-        one:  "cirka en måned"
-        other: "cirka %{count} måneder"
-      x_months:
-        one:  "en måned"
-        other: "%{count} måneder"
-      about_x_years:
-        one:  "cirka et år"
-        other: "cirka %{count} år"
-      over_x_years:
-        one:  "mere end et år"
-        other: "mere end %{count} år"
-      almost_x_years:
-        one:   "næsten et år"
-        other: "næsten %{count} år"
-    prompts:
-      second: "Sekund"
-      minute: "Minut"
-      hour: "Time"
-      day: "Dag"
-      month: "Måned"
-      year: "År"
-
   # action_view
   number:
     format:
       separator: ","
       delimiter: "."
       precision: 3
+      significant: false
+      strip_insignificant_zeros: false
+
     currency:
       format:
         format: "%u %n"
@@ -97,16 +56,23 @@ da:
         separator: ","
         delimiter: "."
         precision: 2
+        significant: false
+        strip_insignificant_zeros: false
+
+    percentage:
+      format:
+        delimiter: ""
+
     precision:
       format:
-        # separator:
         delimiter: ""
-        # precision:
+
     human:
       format:
-        # separator: 
         delimiter: ""
-        precision: 1
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
       # Rails 2.2
       #storage_units: [Bytes, KB, MB, GB, TB]
       # Rails 2.3
@@ -122,48 +88,105 @@ da:
           mb: "MB"
           gb: "GB"
           tb: "TB"
-    percentage:
-      format:
-        # separator:
-        delimiter: ""
-        # precision:
+      decimal_units:
+        format: "%n %u"
+        units:
+          unit: ""
+          thousand: Tusind
+          million: Million
+          billion: Milliard
+          trillion: Billion
+          quadrillion: Billiard
 
-  # active_record
+  datetime:
+    distance_in_words:
+      half_a_minute: "et halvt minut"
+      less_than_x_seconds:
+        one:   "mindre end et sekund"
+        other: "mindre end %{count} sekunder"
+      x_seconds:
+        one:   "et sekund"
+        other: "%{count} sekunder"
+      less_than_x_minutes:
+        one:   "mindre end et minut"
+        other: "mindre end %{count} minutter"
+      x_minutes:
+        one:   "et minut"
+        other: "%{count} minutter"
+      about_x_hours:
+        one:   "cirka en time"
+        other: "cirka %{count} timer"
+      x_days:
+        one:   "en dag"
+        other: "%{count} dage"
+      about_x_months:
+        one:   "cirka en måned"
+        other: "cirka %{count} måneder"
+      x_months:
+        one:   "en måned"
+        other: "%{count} måneder"
+      about_x_years:
+        one:   "cirka et år"
+        other: "cirka %{count} år"
+      over_x_years:
+        one:   "mere end et år"
+        other: "mere end %{count} år"
+      almost_x_years:
+        one:   "næsten et år"
+        other: "næsten %{count} år"
+    prompts:
+      year:   "År"
+      month:  "Måned"
+      day:    "Dag"
+      hour:   "Time"
+      minute: "Minut"
+      second: "Sekund"
+
+  helpers:
+    select:
+      prompt: "Vælg..."
+
+    submit:
+      create: "Opret %{model}"
+      update: "Opdater %{model}"
+      submit: "Gem %{model}"
+
+  errors:
+    format: "%{attribute} %{message}"
+
+    messages: &errors_messages
+      inclusion: "er ikke i listen"
+      exclusion: "er reserveret"
+      invalid: "er ikke gyldig"
+      confirmation: "stemmer ikke overens med bekræftelse"
+      accepted: "skal accepteres"
+      empty: "må ikke udelades"
+      blank: "skal udfyldes"
+      too_long: "er for lang (maksimum %{count} tegn)"
+      too_short: "er for kort (minimum %{count} tegn)"
+      wrong_length: "har forkert længde (skulle være %{count} tegn)"
+      not_a_number: "er ikke et tal"
+      not_an_integer: "er ikke et heltal"
+      greater_than: "skal være større end %{count}"
+      greater_than_or_equal_to: "skal være større end eller lig med %{count}"
+      equal_to: "skal være lig med %{count}"
+      less_than: "skal være mindre end %{count}"
+      less_than_or_equal_to: "skal være mindre end eller lig med %{count}"
+      odd: "skal være ulige"
+      even: "skal være lige"
+
   activerecord:
-    errors:
-      messages:
-        inclusion: "er ikke i listen"
-        exclusion: "er reserveret"
-        invalid: "er ikke gyldig"
-        confirmation: "stemmer ikke overens med bekræftelse"
-        accepted: "skal accepteres"
-        empty: "må ikke udelades"
-        blank: "skal udfyldes"
-        too_long: "er for lang (maksimum %{count} tegn)"
-        too_short: "er for kort (minimum %{count} tegn)"
-        wrong_length: "har forkert længde (skulle være %{count} tegn)"
-        taken: "er allerede brugt"
-        not_a_number: "er ikke et tal"
-        not_an_integer: "er ikke et heltal"
-        greater_than: "skal være større end %{count}"
-        greater_than_or_equal_to: "skal være større end eller lig med %{count}"
-        equal_to: "skal være lig med %{count}"
-        less_than: "skal være mindre end %{count}"
-        less_than_or_equal_to: "skal være mindre end eller lig med %{count}"
-        odd: "skal være ulige"
-        even: "skal være lige"
-        record_invalid: "Validering fejlede: %{errors}"
-
-      #template:
-      #  header:
-      #    one:   "En fejl forhindrede %{model} i at blive gemt"
-      #    other:  "%{count} fejl forhindrede denne %{model} i at blive gemt"
-      #  body: "Der var problemer med følgende felter:"
-
-  activemodel:
     errors:
       template:
         header:
           one:   "En fejl forhindrede %{model} i at blive gemt"
-          other:  "%{count} fejl forhindrede denne %{model} i at blive gemt"
+          other: "%{count} fejl forhindrede %{model} i at blive gemt"
         body: "Der var problemer med følgende felter:"
+
+      messages:
+        taken: "er allerede brugt"
+        record_invalid: "Validering fejlede: %{errors}"
+        <<: *errors_messages
+
+      full_messages:
+        format: "%{attribute}%{message}"


### PR DESCRIPTION
Created missing keys, reordered keys to match en-US structure and corrected a broken link and a mistake.
