### PR TITLE
Italian locale is now ready for Rails 3.

### DIFF
--- a/rails/locale/it.yml
+++ b/rails/locale/it.yml
@@ -82,8 +82,8 @@ it:
       short: "%d %b %H:%M"
       long: "%d %B %Y %H:%M"
           
-    am: 'del mattino'
-    pm: 'della sera'
+    am: 'am'
+    pm: 'pm'
       
   datetime:
     distance_in_words:


### PR DESCRIPTION
Italian locale adapted for rails3.

Here is the output from locale test.
threepwood:davide{~/Development/rails/rails-i18n} # thor locales:test it
The structure is good for Rails 2 and 3.
