### PR TITLE
duplicate errors sections

### DIFF
--- a/rails/locale/fr.yml
+++ b/rails/locale/fr.yml
@@ -135,13 +135,6 @@ fr:
       update: "Modifier ce %{model}"
       submit: "Enregistrer ce %{model}"
 
-  errors:
-    template: &errors_template
-      header:
-        one:   "Impossible d'enregistrer ce %{model} : 1 erreur"
-        other: "Impossible d'enregistrer ce %{model} : %{count} erreurs"
-      body: "Veuillez vérifier les champs suivants : "
-
   attributes:
     created_at: "Créé le"
     updated_at: "Modifié le"
@@ -168,6 +161,11 @@ fr:
       less_than_or_equal_to: "doit être inférieur ou égal à %{count}"
       odd: "doit être impair"
       even: "doit être pair"
+    template: &errors_template
+      header:
+        one:   "Impossible d'enregistrer ce %{model} : 1 erreur"
+        other: "Impossible d'enregistrer ce %{model} : %{count} erreurs"
+      body: "Veuillez vérifier les champs suivants : "
 
   activerecord:
     errors:


### PR DESCRIPTION
following section is lost

```
  errors:
    template: &errors_template
      header:
        one:   "Impossible d'enregistrer ce %{model} : 1 erreur"
        other: "Impossible d'enregistrer ce %{model} : %{count} erreurs"
      body: "Veuillez vérifier les champs suivants : "
```

fr-CA and fr-CH have same "defect"

I did not spot "errors.template" in rails master, so we have options :
- drop "errors.template"
- merge it in latter "errors" (as proposed by commit 56ca4dc818acc697efccda697edd08abe0beaa43)

Cheers and happy new year
