### PR TITLE
Fixed spacing typo and shortened abbreviated days for Indonesian translation

### DIFF
--- a/rails/locale/id.yml
+++ b/rails/locale/id.yml
@@ -11,8 +11,8 @@ id:
       long: "%A, %d %B %Y"
       short: "%d.%m.%Y"
  
-    day_names: [Minggu,Senin, Selasa, Rabu, Kamis, Jum'at, Sabtu]
-    abbr_day_names: [Minggu,Senin, Selasa, Rabu, Kamis, Jum'at, Sabtu]
+    day_names: [Minggu, Senin, Selasa, Rabu, Kamis, Jum'at, Sabtu]
+    abbr_day_names: [Min, Sen, Sel, Rab, Kam, Jum, Sab]
     month_names: [~, Januari, Februari, Maret, April, Mei, Juni, Juli, Agustus, September, Oktober, November, Desember]
     abbr_month_names: [~, Jan, Feb, Mar, Apr, Mei, Jun, Jul, Agu, Sep, Okt, Nov, Des]
     order: [:day, :month, :year]


### PR DESCRIPTION
A space is required between values in an array or else the YAML parser will combine them into a single value.

The abbreviated names were also not shortened.
