### PR TITLE
Updated de locale currency formatting

### DIFF
--- a/rails/locale/de.yml
+++ b/rails/locale/de.yml
@@ -124,9 +124,9 @@ de:
     currency:
       format:
         unit: '€'
-        format: '%n%u'
+        format: '%n %u'
         separator: ","
-        delimiter: ""
+        delimiter: "."
         precision: 2
         significant: false
         strip_insignificant_zeros: false


### PR DESCRIPTION
As per OS'x de (Germany) locale:

![de locale](https://img.skitch.com/20110614-x15kw8jffh62fqu84kchngqiak.png)
