### PR TITLE
Updated de-CH currency formatting

### DIFF
--- a/rails/locale/de-CH.yml
+++ b/rails/locale/de-CH.yml
@@ -119,11 +119,11 @@ de-CH:
       delimiter: "'"
     currency:
       format:
-        unit: 'CHF'
+        unit: 'SFr.'
         format: '%u %n'
-        separator:
-        delimiter:
-        precision:
+        separator: '.'
+        delimiter: "'"
+        precision: 2
     percentage:
       format:
         delimiter: ""


### PR DESCRIPTION
As per OS X's settings:

![de-CH locale](https://img.skitch.com/20110614-enjphaegskdwy37yrkqjp6ct6g.png)
