### PR TITLE
Remove unnecessary tab in Mongolian locale file (Fixes #82)

### DIFF
--- a/rails/locale/mn.yml
+++ b/rails/locale/mn.yml
@@ -113,7 +113,7 @@ mn:
 
   datetime:
     distance_in_words:
-      half_a_minute: "хагас минут"	
+      half_a_minute: "хагас минут"
       less_than_x_seconds:
         one: "%{count} секундээс бага"
         other: "%{count} секундээс бага"


### PR DESCRIPTION
This simple commit fixes issue #82 that prevents the rails-i18n gem from being loaded in JRuby.
