### PR TITLE
Swedish: gender-insensitive 'invalid' message

### DIFF
--- a/rails/locale/sv-SE.yml
+++ b/rails/locale/sv-SE.yml
@@ -125,7 +125,7 @@
     messages: &errors_messages
       inclusion: "finns inte i listan"
       exclusion: "är reserverat"
-      invalid: "är ogiltigt"
+      invalid: "har fel format"
       confirmation: "stämmer inte överens"
       accepted: "måste vara accepterad"
       empty: "får ej vara tom"


### PR DESCRIPTION
The old "invalid" message, "är ogiltigt" ("is invalid"), is inflected for one of two genders, so it doesn't work for some attribute names. This new message ("has the wrong format") is gender-insensitive.
