### PR TITLE
Fix issue in it due to new psyck yaml parser in Rails 3.1

### DIFF
--- a/rails/locale/it.yml
+++ b/rails/locale/it.yml
@@ -217,6 +217,8 @@ it:
         less_than_or_equal_to: "deve essere meno o uguale a %{count}"
         odd: "deve essere dispari"
         even: "deve essere pari"
+        taken: "è già in uso"
+        record_invalid: "Validazione fallita: %{errors}"
 
   activerecord:
     errors:
@@ -227,8 +229,6 @@ it:
         body: "Per favore ricontrolla i seguenti campi:"
 
       messages:
-        taken: "è già in uso"
-        record_invalid: "Validazione fallita: %{errors}"
         <<: *errors_messages
 
       full_messages:


### PR DESCRIPTION
Moved taken and record_invalid into errors block. Psyck used in 3.1 does not properly merge things when a block is injected into another. The 2 translations were resulting as not defined.
"translation missing: it.activerecord.errors.messages.taken" 
