### PR TITLE
for AT: separator '.' and delimiter ','

### DIFF
--- a/rails/locale/de-AT.yml
+++ b/rails/locale/de-AT.yml
@@ -123,8 +123,8 @@ de-AT:
       format:
         unit: '€'
         format: '%u %n'
-        separator: '.'
-        delimiter: ','
+        separator: ','
+        delimiter: '.'
         precision: 2
         significant: false
         strip_insignificant_zeros: false


### PR DESCRIPTION
The Austrian currency system and its display use the same convention as German one. This should be changed in the translations file.
To be really really correct the separator should be a narrow space character, but for legibility reasons mostly '.' is used.
