### PR TITLE
Fix indentation in sk.yml

### DIFF
--- a/rails/locale/sk.yml
+++ b/rails/locale/sk.yml
@@ -187,8 +187,8 @@
           submit: 'Uložiť %{model}'
 
     errors:
-       format: "%{attribute} %{message}"
-       messages: &errors_messages
+        format: "%{attribute} %{message}"
+        messages: &errors_messages
             inclusion: "nie je v zozname povolených hodnôt"
             exclusion: "je vyhradené pre iný účel"
             invalid: "nie je platná hodnota"


### PR DESCRIPTION
Psych can't parse it currently. Indentation issue caused by 89f1ecbad01de641f1eff89568cc255df79db5c6
