### PR TITLE
fixed zh-CN.yml activerecord translation missing errors

### DIFF
--- a/rails/locale/zh-CN.yml
+++ b/rails/locale/zh-CN.yml
@@ -200,6 +200,8 @@ zh-CN:
       less_than_or_equal_to: "必须小于或等于 %{count}"
       odd: "必须为单数"
       even: "必须为双数"
+      taken: "已经被使用"
+      record_invalid: "验证失败: %{errors}"
     template: &errors_template
       header:
         one: "有 1 个错误发生导致「%{model}」无法被保存。"


### PR DESCRIPTION
fixed zh-CN.activerecord.errors.messages.record_invalid and zh.activerecord.errors.models.xxx.attributes.xxx.taken translation missing errors
