### PR TITLE
Fixed wrong measure units for storage.

### DIFF
--- a/rails/locale/it.yml
+++ b/rails/locale/it.yml
@@ -48,10 +48,10 @@ it:
           byte:
             one:   "Byte"
             other: "Byte"
-          kb: "Kb"
-          mb: "Mb"
-          gb: "Gb"
-          tb: "Tb"
+          kb: "KB"
+          mb: "MB"
+          gb: "GB"
+          tb: "TB"
       decimal_units:
         format: "%n %u"
         units:


### PR DESCRIPTION
The capital B must be used to indicate Bytes. Small b indicates bit, also according to Italian rules.

Citing from http://it.wikipedia.org/wiki/Byte.

<cite>Il simbolo utilizzato per il byte come unità di misura della quantità di informazione è B (identico al simbolo del bel); la lettera maiuscola sarebbe riservata alle sole unità di misura tratte dai cognomi degli ideatori, ma la Commissione Elettrotecnica Internazionale (IEC) ha deciso di fare un'eccezione dato che b è generalmente usato per indicare il bit (il cui simbolo standard sarebbe bit per esteso).</cite>
