### PR TITLE
created_at and updated_at default attribute names for Polish

### DIFF
--- a/rails/locale/pl.yml
+++ b/rails/locale/pl.yml
@@ -218,6 +218,9 @@ pl:
       even: "musi być parzyste"
 
   activerecord:
+    attributes:
+      created_at: "Stworzony"
+      updated_at: "Zaktualizowany"
     errors:
       template:
         header:


### PR DESCRIPTION
I have seen this field being used in admin panel to show the admins when records were created, and it struck me that created_at and updated_at attributes are translated in each of the model scopes rather than in the generic scope
