### PR TITLE
Fill in some missing number and string formats

### DIFF
--- a/rails/locale/bn-IN.yml
+++ b/rails/locale/bn-IN.yml
@@ -12,6 +12,8 @@ bn-IN:
       delimiter: ","
       # Number of decimals, behind the separator (1 with a precision of 2 gives: 1.00)
       precision: 2
+      significant: false
+      strip_insignificant_zeros: false
 
     # Used in number_to_currency()
     currency:
@@ -23,6 +25,8 @@ bn-IN:
         separator: "."
         delimiter: ","
         precision: 2
+        significant: false
+        strip_insignificant_zeros: false
 
     # Used in number_to_percentage()
     percentage:
@@ -47,6 +51,8 @@ bn-IN:
         # separator:
         delimiter: ""
         precision: 1
+        significant: true
+        strip_insignificant_zeros: true
       # Rails <= v2.2.2
       # storage_units: [Bytes, KB, MB, GB, TB]
       # Rails >= v2.3
@@ -60,6 +66,10 @@ bn-IN:
           mb: "MB"
           gb: "GB"
           tb: "TB"
+      decimal_units:
+        format: "%n %u"
+        units:
+          unit: ""
 
   # Used in distance_of_time_in_words(), distance_of_time_in_words_to_now(), time_ago_in_words()
   datetime:
@@ -104,6 +114,7 @@ bn-IN:
       second: "সেকেন্ড"
 
   errors:
+    format: "%{attribute} %{message}"
     messages: &errors_messages
       inclusion: "লিস্টে অন্তর্ভুক্ত নয়"
       exclusion: "রিসার্ভ করা অাছে"
@@ -136,6 +147,8 @@ bn-IN:
         <<: *errors_messages
       template:
         <<: *errors_template
+      full_messages:
+        format: "%{attribute} %{message}"
 
       # The values :model, :attribute and :value are always available for interpolation
       # The value :count is available when applicable. Can be used for pluralization.

--- a/rails/locale/dsb.yml
+++ b/rails/locale/dsb.yml
@@ -80,6 +80,8 @@ dsb:
       precision: 3
       separator: ","
       delimiter: "."
+      significant: false
+      strip_insignificant_zeros: false
     currency:
       format:
         unit: "€"
@@ -87,10 +89,14 @@ dsb:
         format: "%n %u"
         separator: ","
         delimiter: " "
+        significant: false
+        strip_insignificant_zeros: false
     human:
       format:
         precision: 1
         delimiter: ""
+        significant: true
+        strip_insignificant_zeros: true
       storage_units:
         format: "%n %u"
         units:
@@ -103,6 +109,10 @@ dsb:
           mb:   "MB"
           gb:   "GB"
           tb:   "TB"
+      decimal_units:
+        format: "%n %u"
+        units:
+          unit: ""
 
     percentage:
       format:
@@ -169,6 +179,7 @@ dsb:
         few:    "wěcej ako %{count} lětami"
         other:  "wěcej ako %{count} lětami"
   errors:
+    format: "%{attribute} %{message}"
     messages: &errors_messages
       inclusion:           "njejo płaśiwa gódnota"
       exclusion:           "njestoj k dispoziciji"
@@ -216,3 +227,5 @@ dsb:
         <<: *errors_messages
       template:
         <<: *errors_template
+      full_messages:
+        format: "%{attribute} %{message}"

--- a/rails/locale/en-US.yml
+++ b/rails/locale/en-US.yml
@@ -83,7 +83,6 @@
       precision: 3
       significant: false
       strip_insignificant_zeros: false
-
     currency:
       format:
         format: "%u%n"
@@ -93,15 +92,12 @@
         precision: 2
         significant: false
         strip_insignificant_zeros: false
-
     percentage:
       format:
         delimiter: ""
-
     precision:
       format:
         delimiter: ""
-
     human:
       format:
         delimiter: ""
@@ -183,7 +179,6 @@
 
   errors:
     format: "%{attribute} %{message}"
-
     messages: &errors_messages
       inclusion: "is not included in the list"
       exclusion: "is reserved"
@@ -224,6 +219,5 @@
         <<: *errors_messages
       template:
         <<: *errors_template
-
       full_messages:
         format: "%{attribute} %{message}"

--- a/rails/locale/es-PE.yml
+++ b/rails/locale/es-PE.yml
@@ -12,19 +12,37 @@ es-PE:
       format: # Nuevos Soles
         format: "%u%n"
         unit: "S./"
+        separator: "."
+        delimiter: ","
+        precision: 2
+        significant: false
+        strip_insignificant_zeros: false
     format:
       delimiter: ","
       precision: 2
       separator: "."
+      significant: false
+      strip_insignificant_zeros: false
     human:
       format:
         delimiter: ","
-      storage_units: 
-        - Bytes
-        - KB
-        - MB
-        - GB
-        - TB
+        precision: 2
+        significant: true
+        strip_insignificant_zeros: true
+      decimal_units:
+        format: "%n %u"
+        units:
+          unit: ""
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one:   "Byte"
+            other: "Bytes"
+          kb: "KB"
+          mb: "MB"
+          gb: "GB"
+          tb: "TB"
     precision:
       format:
         delimiter: ","
@@ -129,6 +147,7 @@ es-PE:
       second: 'Segundo'
 
   errors:
+    format: "%{attribute} %{message}"
     template: &errors_template
       header:
         one: "%{model} no pudo guardarse debido a 1 error"
@@ -168,3 +187,5 @@ es-PE:
         <<: *errors_messages
       template:
         <<: *errors_template
+      full_messages:
+        format: "%{attribute} %{message}"

--- a/rails/locale/fur.yml
+++ b/rails/locale/fur.yml
@@ -7,6 +7,8 @@ fur:
       separator: ","
       delimiter: "."
       precision: 3
+      significant: false
+      strip_insignificant_zeros: false
 
     currency:
       format:
@@ -15,6 +17,8 @@ fur:
         separator: "."
         delimiter: ","
         precision: 2
+        significant: false
+        strip_insignificant_zeros: false
 
     percentage:
       format:
@@ -32,6 +36,8 @@ fur:
         # separator:
         delimiter: ""
         precision: 1
+        significant: true
+        strip_insignificant_zeros: true
       storage_units:
         format: "%n %u"
         units:
@@ -42,6 +48,10 @@ fur:
           mb: "Mb"
           gb: "Gb"
           tb: "Tb"
+      decimal_units:
+        format: "%n %u"
+        units:
+          unit: ""
 
   date:
     formats:
@@ -156,6 +166,7 @@ fur:
       last_word_connector: ", e "
 
   errors:
+    format: "%{attribute} %{message}"
     template: &errors_template
       header:
         one: "No si pues salvâ chest %{model}: 1 erôr"
@@ -188,3 +199,5 @@ fur:
         <<: *errors_messages
       template:
         <<: *errors_template
+      full_messages:
+        format: "%{attribute} %{message}"

--- a/rails/locale/gl-ES.yml
+++ b/rails/locale/gl-ES.yml
@@ -9,6 +9,8 @@ gl-ES:
       separator: ","
       delimiter: "."
       precision: 2
+      significant: false
+      strip_insignificant_zeros: false
 
     # Usado en number_to_currency()
     currency:
@@ -20,6 +22,8 @@ gl-ES:
         separator: ","
         delimiter: "."
         precision: 2
+        significant: false
+        strip_insignificant_zeros: false
 
     # Usado en number_to_percentage()
     percentage:
@@ -41,6 +45,8 @@ gl-ES:
         # separator:
         delimiter: ""
         precision: 1
+        significant: true
+        strip_insignificant_zeros: true
       # Se estás a usar Rails <= 2.2.2
       # storage_units: [Bytes, KB, MB, GB, TB]
       # Se estás a usar Rails >= 2.3
@@ -57,6 +63,10 @@ gl-ES:
           mb: "MB"
           gb: "GB"
           tb: "TB"
+      decimal_units:
+        format: "%n %u"
+        units:
+          unit: ""
 
   # active_support
   date:
@@ -168,6 +178,7 @@ gl-ES:
       last_word_connector: " e "
 
   errors:
+    format: "%{attribute} %{message}"
     template: &errors_template
       header:
         one: "1 erro evitou que se poidese gardar o %{model}"
@@ -200,3 +211,5 @@ gl-ES:
         <<: *errors_messages
       template:
         <<: *errors_template
+      full_messages:
+        format: "%{attribute} %{message}"

--- a/rails/locale/hr.yml
+++ b/rails/locale/hr.yml
@@ -110,13 +110,38 @@
       precision: 3
       separator: ','
       delimiter: '.'
+      significant: false
+      strip_insignificant_zeros: false
     currency:
       format:
         unit: 'Kn'
         precision: 2
         format: '%n %u'
+        separator: "."
+        delimiter: ","
+        significant: false
+        strip_insignificant_zeros: false
+    percentage:
+      format:
+        delimiter: ""
+    precision:
+      format:
+        delimiter: ""
+    human:
+      format:
+        delimiter: ""
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+      decimal_units:
+        format: "%n %u"
+        units:
+          unit: ""
 
   errors:
+    format: "%{attribute} %{message}"
     template: &errors_template
       header:
         one: 'Nisam uspio spremiti %{model}: 1 greška'
@@ -150,3 +175,5 @@
         <<: *errors_messages
       template:
         <<: *errors_template
+      full_messages:
+        format: "%{attribute} %{message}"

--- a/rails/locale/hsb.yml
+++ b/rails/locale/hsb.yml
@@ -83,6 +83,8 @@ hsb:
       precision: 3
       separator: ","
       delimiter: "."
+      significant: false
+      strip_insignificant_zeros: false
 
     currency:
       format:
@@ -91,12 +93,15 @@ hsb:
         format: "%n %u"
         separator: ","
         delimiter: " "
+        significant: false
+        strip_insignificant_zeros: false
 
     human:
       format:
         precision: 1
         delimiter: ""
-
+        significant: true
+        strip_insignificant_zeros: true
       storage_units:
         format: "%n %u"
         units:
@@ -109,6 +114,10 @@ hsb:
           mb:   "MB"
           gb:   "GB"
           tb:   "TB"
+      decimal_units:
+        format: "%n %u"
+        units:
+          unit: ""
 
     percentage:
       format:
@@ -175,6 +184,7 @@ hsb:
         few:    "přez %{count} lětami"
         other:  "přez %{count} lětami"
   errors:
+    format: "%{attribute} %{message}"
     messages: &errors_messages
       inclusion:    "njeje płaćiwa hódnota"
       exclusion:    "njesteji k dispoziciji"
@@ -221,3 +231,5 @@ hsb:
         <<: *errors_messages
       template:
         <<: *errors_template
+      full_messages:
+        format: "%{attribute} %{message}"

--- a/rails/locale/lo.yml
+++ b/rails/locale/lo.yml
@@ -13,6 +13,8 @@ lo:
       delimiter: ","
       # Number of decimals, behind the separator (the number 1 with a precision of 2 gives: 1.00)
       precision: 3
+      significant: false
+      strip_insignificant_zeros: false
 
     # Used in number_to_currency()
     currency:
@@ -24,6 +26,8 @@ lo:
         separator: "."
         delimiter: ","
         precision: 2
+        significant: false
+        strip_insignificant_zeros: false
 
     # Used in number_to_percentage()
     percentage:
@@ -48,6 +52,8 @@ lo:
         # separator:
         delimiter: ""
         precision: 1
+        significant: true
+        strip_insignificant_zeros: true
       storage_units:
         # Storage units output formatting.
         # %u is the storage unit, %n is the number (default: 2 MB)
@@ -60,6 +66,10 @@ lo:
           mb: "MB"
           gb: "GB"
           tb: "TB"
+      decimal_units:
+        format: "%n %u"
+        units:
+          unit: ""
 
   # Used in distance_of_time_in_words(), distance_of_time_in_words_to_now(), time_ago_in_words()
   datetime:
@@ -104,6 +114,7 @@ lo:
       second: "ວິນາທີ"
 
   errors:
+    format: "%{attribute} %{message}"
     template: &errors_template
       header:
         one:    "ບໍ່ສາມາດບັນທຶກ %{model} ໄດ້ເນື່ອງຈາກເກີດຂໍ້ຜິດພາດ"
@@ -136,6 +147,8 @@ lo:
         <<: *errors_messages
       template:
         <<: *errors_template
+      full_messages:
+        format: "%{attribute} %{message}"
 
   date:
     formats:

--- a/rails/locale/lt.yml
+++ b/rails/locale/lt.yml
@@ -7,7 +7,8 @@ lt:
       separator: ","
       delimiter: " "
       precision: 3
-
+      significant: false
+      strip_insignificant_zeros: false
     currency:
       format:
         format: "%n %u"
@@ -15,7 +16,8 @@ lt:
         separator: ","
         delimiter: " "
         precision: 2
-
+        significant: false
+        strip_insignificant_zeros: false
     percentage:
       format:
         delimiter: ""
@@ -28,6 +30,8 @@ lt:
       format:
         delimiter: ""
         precision: 1
+        significant: true
+        strip_insignificant_zeros: true
       storage_units:
         # Storage units output formatting.
         # %u is the storage unit, %n is the number (default: 2 MB)
@@ -40,6 +44,10 @@ lt:
           mb: "MB"
           gb: "GB"
           tb: "TB"
+      decimal_units:
+        format: "%n %u"
+        units:
+          unit: ""
 
   datetime:
     distance_in_words:
@@ -83,6 +91,7 @@ lt:
       second: "Sekundės"
 
   errors:
+    format: "%{attribute} %{message}"
     template: &errors_template
       header:
         one:    "Išsaugant objektą %{model} rasta klaida"
@@ -115,6 +124,8 @@ lt:
         <<: *errors_messages
       template:
         <<: *errors_template
+      full_messages:
+        format: "%{attribute} %{message}"
 
   date:
     formats:

--- a/rails/locale/mk.yml
+++ b/rails/locale/mk.yml
@@ -110,13 +110,38 @@
       precision: 3
       separator: ','
       delimiter: '.'
+      significant: false
+      strip_insignificant_zeros: false
     currency:
       format:
         unit: 'MKD'
         precision: 2
         format: '%n %u'
+        separator: "."
+        delimiter: ","
+        significant: false
+        strip_insignificant_zeros: false
+    percentage:
+      format:
+        delimiter: ""
+    precision:
+      format:
+        delimiter: ""
+    human:
+      format:
+        delimiter: ""
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+      decimal_units:
+        format: "%n %u"
+        units:
+          unit: ""
 
   errors:
+    format: "%{attribute} %{message}"
     template: &errors_template
       header:
         one: 'Не успеав да го зачувам %{model}: 1 грешка.'
@@ -150,3 +175,5 @@
         <<: *errors_messages
       template:
         <<: *errors_template
+      full_messages:
+        format: "%{attribute} %{message}"

--- a/rails/locale/mn.yml
+++ b/rails/locale/mn.yml
@@ -73,7 +73,8 @@ mn:
       separator: "."
       delimiter: " "
       precision: 3
-
+      significant: false
+      strip_insignificant_zeros: false
     currency:
       format:
         format: "%n %u"
@@ -81,6 +82,8 @@ mn:
         separator: "."
         delimiter: " "
         precision: 2
+        significant: false
+        strip_insignificant_zeros: false
 
     percentage:
       format:
@@ -93,7 +96,9 @@ mn:
     human:
       format:
         delimiter: ""
-        precision: 1
+        precision: 
+        significant: true
+        strip_insignificant_zeros: true
       # Rails 2.2
       # storage_units: [байт, КБ, МБ, ГБ, ТБ]
 
@@ -110,6 +115,10 @@ mn:
           mb: "МБ"
           gb: "ГБ"
           tb: "ТБ"
+      decimal_units:
+        format: "%n %u"
+        units:
+          unit: ""
 
   datetime:
     distance_in_words:
@@ -156,6 +165,7 @@ mn:
       second: "Секунд"
 
   errors:
+    format: "%{attribute} %{message}"
     messages: &errors_messages
       inclusion: "жагсаалтад алга байна"
       exclusion: "бол ашиглахад хориотой"
@@ -191,6 +201,8 @@ mn:
         <<: *errors_messages
       template:
         <<: *errors_template
+      full_messages:
+        format: "%{attribute} %{message}"
 
   support:
     array:

--- a/rails/locale/nn.yml
+++ b/rails/locale/nn.yml
@@ -98,14 +98,37 @@ nn:
       precision: 2
       separator: "."
       delimiter: ","
+      significant: false
+      strip_insignificant_zeros: false
     currency:
       format:
         unit: "kr"
         format: "%n %u"
+        separator: "."
+        delimiter: ","
+        precision: 2
+        significant: false
+        strip_insignificant_zeros: false
+    percentage:
+      format:
+        delimiter: ""
     precision:
       format:
         delimiter: ""
+    human:
+      format:
+        delimiter: ""
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+      decimal_units:
+        format: "%n %u"
+        units:
+          unit: ""
   errors:
+    format: "%{attribute} %{message}"
     template: &errors_template
       header: "kunne ikkje lagra %{model} grunna %{count} feil."
       body: "det oppstod problem i følgjande felt:"
@@ -135,3 +158,5 @@ nn:
         <<: *errors_messages
       template:
         <<: *errors_template
+      full_messages:
+        format: "%{attribute} %{message}"

--- a/rails/locale/rm.yml
+++ b/rails/locale/rm.yml
@@ -111,6 +111,8 @@ rm:
       precision: 2
       separator: "."
       delimiter: "'"
+      significant: false
+      strip_insignificant_zeros: false
     currency:
       format:
         precision: 2
@@ -118,6 +120,8 @@ rm:
         delimiter: "'"
         unit: "CHF"
         format: "%n %u"
+        significant: false
+        strip_insignificant_zeros: false
     percentage:
       format:
         delimiter: ""
@@ -128,6 +132,8 @@ rm:
       format:
         delimiter: ""
         precision: 1
+        significant: true
+        strip_insignificant_zeros: true
       storage_units:
         # Storage units output formatting.
         # %u is the storage unit, %n is the number (default: 2 MB)
@@ -140,6 +146,10 @@ rm:
           mb: "MB"
           gb: "GB"
           tb: "TB"
+      decimal_units:
+        format: "%n %u"
+        units:
+          unit: ""
 
   support:
     array:
@@ -148,6 +158,7 @@ rm:
       last_word_connector: " e "
 
   errors:
+    format: "%{attribute} %{message}"
     messages: &errors_messages
       inclusion: "n'è betg sin la glista"
       exclusion: "na stat betg a disposiziun"
@@ -180,3 +191,5 @@ rm:
         <<: *errors_messages
       template:
         <<: *errors_template
+      full_messages:
+        format: "%{attribute} %{message}"

--- a/rails/locale/sl.yml
+++ b/rails/locale/sl.yml
@@ -74,6 +74,7 @@ sl:
       last_word_connector: " in "
 
   errors:
+    format: "%{attribute} %{message}"
     messages: &errors_messages
       inclusion: "ni vključeno v seznam"
       exclusion: "je rezervirano"
@@ -109,6 +110,8 @@ sl:
         <<: *errors_messages
       template:
         <<: *errors_template
+      full_messages:
+          format: "%{attribute} %{message}"
 
 
   number:
@@ -121,6 +124,8 @@ sl:
        delimiter: "."
        # Number of decimals, behind the separator (the number 1 with a precision of 2 gives: 1.00)
        precision: 2
+       significant: false
+       strip_insignificant_zeros: false
 
      # Used in number_to_currency()
      currency:
@@ -132,6 +137,8 @@ sl:
          separator: ","
          delimiter: "."
          precision: 2
+         significant: false
+         strip_insignificant_zeros: false
 
      # Used in number_to_percentage()
      percentage:
@@ -156,6 +163,8 @@ sl:
          # separator:
          delimiter: ""
          precision: 1
+         significant: true
+         strip_insignificant_zeros: true
        storage_units:
          # Storage units output formatting.
          # %u is the storage unit, %n is the number (default: 2 MB)
@@ -168,6 +177,10 @@ sl:
            mb: "MB"
            gb: "GB"
            tb: "TB"
+       decimal_units:
+         format: "%n %u"
+         units:
+           unit: ""
 
   # Used in distance_of_time_in_words(), distance_of_time_in_words_to_now(), time_ago_in_words()
   datetime:

--- a/rails/locale/sr-Latn.yml
+++ b/rails/locale/sr-Latn.yml
@@ -110,13 +110,38 @@
       precision: 3
       separator: ','
       delimiter: '.'
+      significant: false
+      strip_insignificant_zeros: false
     currency:
       format:
         unit: 'DIN'
         precision: 2
         format: '%n %u'
+        separator: "."
+        delimiter: ","
+        significant: false
+        strip_insignificant_zeros: false
+    percentage:
+      format:
+        delimiter: ""
+    precision:
+      format:
+        delimiter: ""
+    human:
+      format:
+        delimiter: ""
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+      decimal_units:
+        format: "%n %u"
+        units:
+          unit: ""
 
   errors:
+    format: "%{attribute} %{message}"
     messages: &errors_messages
       inclusion: "nije u listi"
       exclusion: "nije dostupno"
@@ -150,3 +175,5 @@
         <<: *errors_messages
       template:
         <<: *errors_template
+      full_messages:
+        format: "%{attribute} %{message}"

--- a/rails/locale/sr.yml
+++ b/rails/locale/sr.yml
@@ -110,13 +110,38 @@
       precision: 3
       separator: ','
       delimiter: '.'
+      significant: false
+      strip_insignificant_zeros: false
     currency:
       format:
         unit: 'ДИН'
         precision: 2
         format: '%n %u'
+        separator: "."
+        delimiter: ","
+        significant: false
+        strip_insignificant_zeros: false
+    percentage:
+      format:
+        delimiter: ""
+    precision:
+      format:
+        delimiter: ""
+    human:
+      format:
+        delimiter: ""
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+      decimal_units:
+        format: "%n %u"
+        units:
+          unit: ""
 
   errors:
+    format: "%{attribute} %{message}"
     messages: &errors_messages
       inclusion: "није у листи"
       exclusion: "није доступно"
@@ -150,3 +175,5 @@
         <<: *errors_messages
       template:
         <<: *errors_template
+      full_messages:
+        format: "%{attribute} %{message}"

--- a/rails/locale/sv-SE.yml
+++ b/rails/locale/sv-SE.yml
@@ -26,21 +26,24 @@
         # Where is the currency sign? %u is the currency unit, %n the number (default: $5.00)
         format: "%n %u"
         unit: "kr"
-
+        separator: "."
+        delimiter: ","
+        precision: 2
+        significant: false
+        strip_insignificant_zeros: false
     percentage:
       format:
          delimiter: ""
-
     precision:
       format:
         delimiter: ""
-
     # Used in number_to_human_size()
     human:
       format:
         delimiter: ""
         precision: 1
-
+        significant: true
+        strip_insignificant_zeros: true
       storage_units:
         # Storage units output formatting.
         # %u is the storage unit, %n is the number (default: 2 MB)

--- a/rails/locale/tr.yml
+++ b/rails/locale/tr.yml
@@ -109,6 +109,8 @@ tr:
       precision: 2
       separator: ','
       delimiter: '.'
+      significant: false
+      strip_insignificant_zeros: false
     currency:
       format:
         unit: 'TL'
@@ -116,6 +118,8 @@ tr:
         separator: ','
         delimiter: '.'
         precision: 2
+        significant: false
+        strip_insignificant_zeros: false
     percentage:
       format:
         delimiter: '.'
@@ -126,6 +130,14 @@ tr:
       format:
         delimiter: '.'
         precision: 2
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+      decimal_units:
+        format: "%n %u"
+        units:
+          unit: ""
 
   support:
     select:
@@ -137,6 +149,7 @@ tr:
       last_word_connector: " ve "
 
   errors:
+    format: "%{attribute} %{message}"
     messages: &errors_messages
       inclusion: "kabul edilen bir kelime değil"
       exclusion: "kullanılamaz"
@@ -170,3 +183,5 @@ tr:
         <<: *errors_messages
       template:
         <<: *errors_template
+      full_messages:
+        format: "%{attribute} %{message}"

--- a/rails/locale/vi.yml
+++ b/rails/locale/vi.yml
@@ -14,6 +14,8 @@ vi:
       delimiter: "."
       # Number of decimals, behind the separator (1 with a precision of 2 gives: 1.00)
       precision: 3
+      significant: false
+      strip_insignificant_zeros: false
 
     # Used in number_to_currency()
     currency:
@@ -25,6 +27,8 @@ vi:
         separator: ","
         delimiter: "."
         precision: 2
+        significant: false
+        strip_insignificant_zeros: false
 
     # Used in number_to_percentage()
     percentage:
@@ -49,6 +53,8 @@ vi:
         # separator:
         delimiter: ""
         precision: 1
+        significant: true
+        strip_insignificant_zeros: true
       storage_units:
           # Storage units output formatting.
           # %u is the storage unit, %n is the number (default: 2 MB)
@@ -61,6 +67,10 @@ vi:
             mb: "MB"
             gb: "GB"
             tb: "TB"
+      decimal_units:
+        format: "%n %u"
+        units:
+          unit: ""
 
   # Used in distance_of_time_in_words(), distance_of_time_in_words_to_now(), time_ago_in_words()
   datetime:
@@ -105,6 +115,7 @@ vi:
       second: "Giây"
 
   errors:
+    format: "%{attribute} %{message}"
     messages: &errors_messages
       inclusion: "không có trong danh sách"
       exclusion: "đã được giành trước"
@@ -137,6 +148,8 @@ vi:
         <<: *errors_messages
       template:
         <<: *errors_template
+      full_messages:
+          format: "%{attribute} %{message}"
 
   date:
     formats:


### PR DESCRIPTION
Filled in some of the missing number formatting and string formatting translations with the en-US version.

Since these translations would fallback to en-US anyway, the changes are non-destructive. It does however increase the completeness of the modified locales.

Mk, sr and sr-Latn are 75% complete, all others are over 80% complete. Notably, sv-SE is now 100% complete :)
