### PR TITLE
Added not_saved error message to pt-PT

### DIFF
--- a/rails/locale/pt-PT.yml
+++ b/rails/locale/pt-PT.yml
@@ -172,6 +172,7 @@
       less_than_or_equal_to: "tem de ser menor ou igual a %{count}"
       odd: "tem de ser ímpar"
       even: "tem de ser par"
+      not_saved: "Não foi possível gravar"
 
   activerecord:
     errors:


### PR DESCRIPTION
I'm not sure if it's in the right position. It works, but i've noticed that there is a group for action record error messages a bit bellow, but it my edit is in their it's not detected.
