### PR TITLE
changed ja.time.formats.long

### DIFF
--- a/rails/locale/ja.yml
+++ b/rails/locale/ja.yml
@@ -66,7 +66,7 @@ ja:
     formats:
       default: "%Y/%m/%d %H:%M:%S"
       short: "%y/%m/%d %H:%M"
-      long: "%Y年%m月%d日(%a) %H時%M分%S秒 %Z"
+      long: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
     am: "午前"
     pm: "午後"
 


### PR DESCRIPTION
%Z embeds Shift JIS characters on Windows.
Use %z insted.

%Z : I18n.l(Time.now, :format => :long)
=> "2011年12月27日(火) 16時24分45秒 \x93\x8C\x8B\x9E (\x95W\x8F\x80\x8E\x9E)"

%z : I18n.l(Time.now, :format => :long)
=> "2011年12月27日(火) 16時27分24秒 +0900"
