### PR TITLE
fix negative values for 'number_to_currency'

### DIFF
--- a/rails/locale/bg.yml
+++ b/rails/locale/bg.yml
@@ -95,6 +95,7 @@ bg:
     currency:
       format:
         format: "%n %u"
+        negative_format: "-%n %u"
         unit: "лв."
         separator: ","
         delimiter: " "


### PR DESCRIPTION
correct form for negative bulgarian currency values is "-%n %u" (example "-20.20 лв.")

Reference: http://download.microsoft.com/download/a/2/9/a29902cc-41c0-4ceb-a6ed-ba16bc511e15/bul-bgr-StyleGuide.pdf
