### PR TITLE
I18n::InvalidPluralizationData for "almost 3 years"

### DIFF
--- a/rails/locale/ru.yml
+++ b/rails/locale/ru.yml
@@ -71,6 +71,8 @@ ru:
         other: около %{count} лет
       almost_x_years:
         one: почти 1 год
+        few: почти %{count} года
+        many: почти %{count} лет
         other: почти %{count} лет
       half_a_minute: меньше минуты
       less_than_x_minutes:


### PR DESCRIPTION
I have an error when passing 2..4 values for datetime.distance_in_words.almost_x_years in russian locale:

`translation data {:other=>"почти %{count} лет", :one=>"почти 1 год"} can not be used with :count => 3`

Here's a fix for it
