### PR TITLE
Fixed significant digits to 0 in JA for Yen currency

### DIFF
--- a/rails/locale/ja.yml
+++ b/rails/locale/ja.yml
@@ -136,7 +136,7 @@ ja:
       format:
         delimiter: ! ','
         format: ! '%n%u'
-        precision: 3
+        precision: 0
         separator: .
         significant: false
         strip_insignificant_zeros: false


### PR DESCRIPTION
The significant digits for JA in currency had been set to 3 in this commit:
https://github.com/svenfuchs/rails-i18n/commit/be037c16684b61f56aefd4379ab03ebcd42a32f3
However the only situation I can think of where divisions of less than one Yen would be displayed would be in financial/currency markets, in which case the denomination would not be Yen[円] it would be Sen[銭]. In regular life Sen would never be used or displayed, a 10 yen piece of chocolate for example would be displayed "10円", however with the current 3 digits of significance Rails apps will display "10.000円" which is intensely confusing.

Note also how "significant" is set to "false" - this makes sense. However "strip_insignificant_zeros" is also set to "false". Perhaps if "strip_insignificant_zeros" were set to "true" that would make more sense. But rearguardless digits less than one yen are never shown in regular situations, so the precision should logically be 0.
