### PR TITLE
bring activemodel and activerecord namespaces back which was removed in 21c8006

### DIFF
--- a/rails/locale/ar.yml
+++ b/rails/locale/ar.yml
@@ -95,7 +95,7 @@ ar:
       month: الشهر
       second: ثانية
       year: السنة
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: يجب أن تقبل
@@ -190,3 +190,10 @@ ar:
       long: ! '%B %d, %Y %H:%M'
       short: ! '%d %b %H:%M'
     pm: مساءا
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/az.yml
+++ b/rails/locale/az.yml
@@ -95,7 +95,7 @@ az:
       month: Ay
       second: Saniyə
       year: İl
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: qəbul olunmalıdır
@@ -190,3 +190,10 @@ az:
       long: ! '%d %B %Y, %H:%M'
       short: ! '%d %b, %H:%M'
     pm: günortadan sonra
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/bg.yml
+++ b/rails/locale/bg.yml
@@ -95,7 +95,7 @@ bg:
       month: Месец
       second: Секунда
       year: Година
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: трябва да се потвърди
@@ -190,3 +190,10 @@ bg:
       long: ! '%d %B %Y, %H:%M'
       short: ! '%d %b, %H:%M'
     pm: следобед
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/bn-IN.yml
+++ b/rails/locale/bn-IN.yml
@@ -92,7 +92,7 @@ bn-IN:
       month: মাস
       second: সেকেন্ড
       year: বছর
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: গ্রাহ্য করতে হবে
@@ -173,3 +173,10 @@ bn-IN:
       long: ! '%e de %B de %Y %H:%M'
       short: ! '%e de %b %H:%M'
     pm: pm
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/bs.yml
+++ b/rails/locale/bs.yml
@@ -113,7 +113,7 @@ bs:
       month: mjesec
       second: sekundi
       year: godina
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: mora biti prihvaćeno
@@ -232,3 +232,10 @@ bs:
       long: ! '%d. %B %Y. - %H:%M:%S'
       short: ! '%d. %b %Y. %H:%M'
     pm: ''
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/ca.yml
+++ b/rails/locale/ca.yml
@@ -95,7 +95,7 @@ ca:
       month: Mes
       second: Segun
       year: Any
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: ha de ser acceptat
@@ -190,3 +190,10 @@ ca:
       long: ! '%d de %B de %Y %H:%M'
       short: ! '%d de %b %H:%M'
     pm: pm
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/cs.yml
+++ b/rails/locale/cs.yml
@@ -95,7 +95,7 @@ cs:
       month: Měsíc
       second: Sekunda
       year: Rok
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: musí být potvrzeno
@@ -189,3 +189,10 @@ cs:
       long: ! '%A %d. %B %Y %H:%M'
       short: ! '%d. %m. %H:%M'
     pm: pm
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/csb.yml
+++ b/rails/locale/csb.yml
@@ -106,7 +106,7 @@ csb:
       month: Miesiąc
       second: Sekunda
       year: Rok
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: mùszi bëc zaakceptowóné
@@ -201,3 +201,10 @@ csb:
       long: ! '%B %d, %Y %H:%M'
       short: ! '%d %b %H:%M'
     pm: pò pôłnim
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/cy.yml
+++ b/rails/locale/cy.yml
@@ -95,7 +95,7 @@ cy:
       month: Mis
       second: Eiliad
       year: Blwyddyn
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: angen ei dderbyn
@@ -190,3 +190,10 @@ cy:
       long: ! '%B %d, %Y %H:%M'
       short: ! '%d %b %H:%M'
     pm: yh
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/da.yml
+++ b/rails/locale/da.yml
@@ -95,7 +95,7 @@ da:
       month: Måned
       second: Sekund
       year: År
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: skal accepteres
@@ -190,3 +190,10 @@ da:
       long: ! '%A d. %e. %B %Y, %H.%M'
       short: ! '%e. %b %Y, %H.%M'
     pm: ''
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/de-AT.yml
+++ b/rails/locale/de-AT.yml
@@ -95,7 +95,7 @@ de-AT:
       month: Monat
       second: Sekunden
       year: Jahr
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: muss akzeptiert werden
@@ -194,3 +194,10 @@ de-AT:
       long: ! '%A, %d. %B %Y, %H:%M Uhr'
       short: ! '%d. %B, %H:%M Uhr'
     pm: nachmittags
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/de-CH.yml
+++ b/rails/locale/de-CH.yml
@@ -95,7 +95,7 @@ de-CH:
       month: Monat
       second: Sekunden
       year: Jahr
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: muss akzeptiert werden
@@ -194,3 +194,10 @@ de-CH:
       long: ! '%A, %d. %B %Y, %H:%M Uhr'
       short: ! '%d. %B, %H:%M Uhr'
     pm: nachmittags
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/de.yml
+++ b/rails/locale/de.yml
@@ -95,7 +95,7 @@ de:
       month: Monat
       second: Sekunden
       year: Jahr
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: muss akzeptiert werden
@@ -194,3 +194,10 @@ de:
       long: ! '%A, %d. %B %Y, %H:%M Uhr'
       short: ! '%d. %B, %H:%M Uhr'
     pm: nachmittags
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/dsb.yml
+++ b/rails/locale/dsb.yml
@@ -105,7 +105,7 @@ dsb:
         one: 1 sekundu
         other: ! '%{count} sekundami'
         two: ! '%{count} sekundoma'
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: musy se wobkšuśiś
@@ -206,3 +206,10 @@ dsb:
       long: ! '%A, %d. %B %Y, %H:%M hodź.'
       short: ! '%d. %B, %H:%M hodź.'
     pm: wótpołdnja
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/el.yml
+++ b/rails/locale/el.yml
@@ -95,7 +95,7 @@ el:
       month: Μήνας
       second: Δευτερόλεπτο
       year: Έτος
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: πρέπει να είναι αποδεκτό
@@ -190,3 +190,10 @@ el:
       long: ! '%A %d %B %Y %H:%M:%S %Z'
       short: ! '%d %b %H:%M'
     pm: μμ
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/en-AU.yml
+++ b/rails/locale/en-AU.yml
@@ -95,7 +95,7 @@ en-AU:
       month: Month
       second: Seconds
       year: Year
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: must be accepted
@@ -196,3 +196,10 @@ en-AU:
       long: ! '%B %d, %Y %H:%M'
       short: ! '%d %b %H:%M'
     pm: pm
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/en-GB.yml
+++ b/rails/locale/en-GB.yml
@@ -95,7 +95,7 @@ en-GB:
       month: Month
       second: Seconds
       year: Year
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: must be accepted
@@ -196,3 +196,10 @@ en-GB:
       long: ! '%d %B, %Y %H:%M'
       short: ! '%d %b %H:%M'
     pm: pm
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/en-IN.yml
+++ b/rails/locale/en-IN.yml
@@ -97,7 +97,7 @@ en-IN:
       month: Bulan
       second: Detik
       year: Tahun
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: harus diterima
@@ -192,3 +192,10 @@ en-IN:
       long: ! '%d %B %Y %H.%M'
       short: ! '%d %b %H.%M'
     pm: pm
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/en-US.yml
+++ b/rails/locale/en-US.yml
@@ -95,7 +95,7 @@ en-US:
       month: Month
       second: Seconds
       year: Year
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: must be accepted
@@ -196,3 +196,10 @@ en-US:
       long: ! '%B %d, %Y %H:%M'
       short: ! '%d %b %H:%M'
     pm: pm
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/eo.yml
+++ b/rails/locale/eo.yml
@@ -97,7 +97,7 @@ eo:
       month: Monato
       second: Sekundo
       year: Jaro
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: devas esti akceptita
@@ -192,3 +192,10 @@ eo:
       long: ! '%A %d %B %Y %H:%M'
       short: ! '%d %b %H:%M'
     pm: pm
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/es-AR.yml
+++ b/rails/locale/es-AR.yml
@@ -95,7 +95,7 @@ es-AR:
       month: Mes
       second: Segundos
       year: Año
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: debe ser aceptado
@@ -196,3 +196,10 @@ es-AR:
       long: ! '%A, %d de %B de %Y a las %I:%M %p'
       short: ! '%d de %b a las %H:%M hrs'
     pm: pm
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/es-CL.yml
+++ b/rails/locale/es-CL.yml
@@ -95,7 +95,7 @@ es-CL:
       month: Mes
       second: Segundos
       year: Año
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: debe ser aceptado
@@ -190,3 +190,10 @@ es-CL:
       long: ! '%A %d de %B de %Y %H:%M'
       short: ! '%d de %b %H:%M'
     pm: pm
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/es-CO.yml
+++ b/rails/locale/es-CO.yml
@@ -95,7 +95,7 @@ es-CO:
       month: Mes
       second: Segundos
       year: Año
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: debe ser aceptado
@@ -196,3 +196,10 @@ es-CO:
       long: ! '%A, %d de %B de %Y a las %I:%M %p'
       short: ! '%d de %b a las %H:%M hrs'
     pm: pm
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/es-MX.yml
+++ b/rails/locale/es-MX.yml
@@ -95,7 +95,7 @@ es-MX:
       month: Mes
       second: Segundos
       year: Año
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: debe ser aceptado
@@ -196,3 +196,10 @@ es-MX:
       long: ! '%A, %d de %B de %Y a las %I:%M %p'
       short: ! '%d de %b a las %H:%M hrs'
     pm: pm
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/es-PE.yml
+++ b/rails/locale/es-PE.yml
@@ -89,7 +89,7 @@ es-PE:
       hour: Hora
       minute: Minuto
       second: Segundo
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: debe ser aceptado
@@ -172,3 +172,10 @@ es-PE:
       long: ! '%A, %d de %B del %Y a las %I:%M %p'
       short: ! '%d de %b a las %H:%M hrs'
     pm: pm
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/es.yml
+++ b/rails/locale/es.yml
@@ -95,7 +95,7 @@ es:
       month: Mes
       second: Segundos
       year: Año
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: debe ser aceptado
@@ -190,3 +190,10 @@ es:
       long: ! '%d de %B de %Y %H:%M'
       short: ! '%d de %b %H:%M'
     pm: pm
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/et.yml
+++ b/rails/locale/et.yml
@@ -95,7 +95,7 @@ et:
       month: Kuu
       second: Sekundit
       year: Aasta
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: peab olema heaks kiidetud
@@ -190,3 +190,10 @@ et:
       long: ! '%a, %d. %b %Y, %H:%M:%S %z'
       short: ! '%d.%m.%y, %H:%M'
     pm: pärast lõunat
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/eu.yml
+++ b/rails/locale/eu.yml
@@ -95,7 +95,7 @@ eu:
       month: Hilabete
       second: Segundu
       year: Urte
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: onartuta izan behar da
@@ -190,3 +190,10 @@ eu:
       long: ! '%Y(e)ko %Bren %e,  %H:%M'
       short: ! '%b %e, %H:%M'
     pm: pm
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/fa.yml
+++ b/rails/locale/fa.yml
@@ -95,7 +95,7 @@ fa:
       month: ماه
       second: ثانیه
       year: سال
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: باید پذیرفته شود
@@ -190,3 +190,10 @@ fa:
       long: ! '%e %B %Y، ساعت %H:%M'
       short: ! '%e %B، ساعت %H:%M'
     pm: بعد از ظهر
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/fi.yml
+++ b/rails/locale/fi.yml
@@ -95,7 +95,7 @@ fi:
       month: Kuukausi
       second: Sekunti
       year: Vuosi
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: täytyy olla hyväksytty
@@ -190,3 +190,10 @@ fi:
       long: ! '%e. %Bta %Y %H.%M'
       short: ! '%e.%m. %H.%M'
     pm: iltapäivä
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/fr-CA.yml
+++ b/rails/locale/fr-CA.yml
@@ -97,7 +97,7 @@ fr-CA:
       month: Mois
       second: Seconde
       year: Année
-  errors:
+  errors: &errors
     format: Le %{attribute} %{message}
     messages:
       accepted: doit être accepté(e)
@@ -198,3 +198,10 @@ fr-CA:
       long: ! '%A %d %B %Y %H:%M'
       short: ! '%H:%M'
     pm: pm
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/fr-CH.yml
+++ b/rails/locale/fr-CH.yml
@@ -97,7 +97,7 @@ fr-CH:
       month: Mois
       second: Seconde
       year: Année
-  errors:
+  errors: &errors
     format: Le %{attribute} %{message}
     messages:
       accepted: doit être accepté(e)
@@ -198,3 +198,10 @@ fr-CH:
       long: ! '%A, %d. %B %Y %H:%M:%S %Z'
       short: ! '%d. %b %H:%M'
     pm: pm
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/fr.yml
+++ b/rails/locale/fr.yml
@@ -97,7 +97,7 @@ fr:
       month: Mois
       second: Seconde
       year: Année
-  errors:
+  errors: &errors
     format: Le %{attribute} %{message}
     messages:
       accepted: doit être accepté(e)
@@ -198,3 +198,10 @@ fr:
       long: ! '%A %d %B %Y %H:%M'
       short: ! '%d %b %H:%M'
     pm: pm
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/fur.yml
+++ b/rails/locale/fur.yml
@@ -95,7 +95,7 @@ fur:
       month: Mês
       second: Secont
       year: An
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: al à di jessi acetât
@@ -190,3 +190,10 @@ fur:
       long: ! '%d di %B dal %Y %H:%M'
       short: ! '%d di %b %H:%M'
     pm: pm
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/gl-ES.yml
+++ b/rails/locale/gl-ES.yml
@@ -88,7 +88,7 @@ gl-ES:
       x_seconds:
         one: 1 segundo
         other: ! '%{count} segundos'
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: debe ser aceptado
@@ -169,3 +169,10 @@ gl-ES:
       long: ! '%A %e de %B de %Y ás %H:%M'
       short: ! '%e/%m, %H:%M'
     pm: ''
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/gsw-CH.yml
+++ b/rails/locale/gsw-CH.yml
@@ -95,7 +95,7 @@ gsw-CH:
       month: Monät
       second: Sekundä
       year: Jaar
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: mues akzeptiert werdä
@@ -190,3 +190,10 @@ gsw-CH:
       long: ! '%A, %d. %B %Y, %H:%M'
       short: ! '%d. %B, %H:%M'
     pm: am Namitaag
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/he.yml
+++ b/rails/locale/he.yml
@@ -97,7 +97,7 @@ he:
       month: חודש
       second: שניות
       year: שנה
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: חייב באישור
@@ -192,3 +192,10 @@ he:
       long: ! '%d ב%B, %Y %H:%M'
       short: ! '%d %b %H:%M'
     pm: pm
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/hi-IN.yml
+++ b/rails/locale/hi-IN.yml
@@ -95,7 +95,7 @@ hi-IN:
       month: माह
       second: सेकंड
       year: वर्ष
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: होना स्वीकार किया जाना आवश्यक
@@ -190,3 +190,10 @@ hi-IN:
       long: ! '%B %d, %Y %H:%M'
       short: ! '%d %b %H:%M'
     pm: pm
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/hi.yml
+++ b/rails/locale/hi.yml
@@ -95,7 +95,7 @@ hi:
       month: माह
       second: सेकेंड
       year: वर्ष
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: स्वीकार किया जाना जरूरी
@@ -190,3 +190,10 @@ hi:
       long: ! '%B %d, %Y %H:%M'
       short: ! '%d %b %H:%M'
     pm: अपराह्न
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/hr.yml
+++ b/rails/locale/hr.yml
@@ -92,7 +92,7 @@ hr:
         few: ! '%{count} sekunde'
         one: 1 sekunda
         other: ! '%{count} sekundi'
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: mora biti prihvaćen
@@ -161,3 +161,10 @@ hr:
       long: ! '%B %d, %Y %H:%M'
       short: ! '%d %b %H:%M'
     pm: PM
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/hsb.yml
+++ b/rails/locale/hsb.yml
@@ -105,7 +105,7 @@ hsb:
         one: 1 sekundu
         other: ! '%{count} sekundami'
         two: ! '%{count} sekundomaj'
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: dyrbi so wobkrućić
@@ -205,3 +205,10 @@ hsb:
       long: ! '%A, %d. %B %Y, %H:%M hodź.'
       short: ! '%d. %B, %H:%M hodź.'
     pm: popołdnju
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/hu.yml
+++ b/rails/locale/hu.yml
@@ -95,7 +95,7 @@ hu:
       month: Hónap
       second: Másodperc
       year: Év
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: nincs elfogadva
@@ -190,3 +190,10 @@ hu:
       long: ! '%Y. %B %e., %A, %H:%M'
       short: ! '%b %e., %H:%M'
     pm: du.
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/id.yml
+++ b/rails/locale/id.yml
@@ -97,7 +97,7 @@ id:
       month: Bulan
       second: Detik
       year: Tahun
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: harus diterima
@@ -191,3 +191,10 @@ id:
       long: ! '%d %B %Y %H.%M'
       short: ! '%d %b %H.%M'
     pm: pm
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/is.yml
+++ b/rails/locale/is.yml
@@ -95,7 +95,7 @@ is:
       month: Mánuður
       second: Sekúnda
       year: Ár
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: þarf að vera tekið gilt
@@ -198,3 +198,10 @@ is:
       long: ! '%A %e. %B %Y kl. %H:%M'
       short: ! '%e. %B kl. %H:%M'
     pm: ''
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/it.yml
+++ b/rails/locale/it.yml
@@ -95,7 +95,7 @@ it:
       month: Mese
       second: Secondi
       year: Anno
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: deve essere accettata
@@ -196,3 +196,10 @@ it:
       long: ! '%d %B %Y %H:%M'
       short: ! '%d %b %H:%M'
     pm: pm
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/ja.yml
+++ b/rails/locale/ja.yml
@@ -95,7 +95,7 @@ ja:
       month: 月
       second: 秒
       year: 年
-  errors:
+  errors: &errors
     format: ! '%{attribute}%{message}'
     messages:
       accepted: を受諾してください。
@@ -188,3 +188,10 @@ ja:
       long: ! '%Y年%m月%d日(%a) %H時%M分%S秒 %z'
       short: ! '%y/%m/%d %H:%M'
     pm: 午後
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/kn.yml
+++ b/rails/locale/kn.yml
@@ -95,7 +95,7 @@ kn:
       month: ತಿಂಗಳು
       second: ಸೆಕೆಂಡು
       year: ವರುಷ
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: ಒಪ್ಪಿಕೊಳ್ಳಬೇಕು
@@ -190,3 +190,10 @@ kn:
       long: ! '%B %d, %Y %H:%M'
       short: ! '%d %b %H:%M'
     pm: ಅಪರನ್ನಃ
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/ko.yml
+++ b/rails/locale/ko.yml
@@ -95,7 +95,7 @@ ko:
       month: 월
       second: 초
       year: 년
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: 을(를) 반드시 확인해야 합니다
@@ -188,3 +188,10 @@ ko:
       long: ! '%Y년 %B월 %d일, %H시 %M분 %S초 %Z'
       short: ! '%y/%m/%d %H:%M'
     pm: 오후
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/lo.yml
+++ b/rails/locale/lo.yml
@@ -92,7 +92,7 @@ lo:
       month: ເດືອນ
       second: ວິນາທີ
       year: ປີ
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: ຕ້ອງຍອມຮັບ
@@ -177,3 +177,10 @@ lo:
       long: ! '%d %B %Y %H:%M น.'
       short: ! '%d %b %H:%M น.'
     pm: ''
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/lt.yml
+++ b/rails/locale/lt.yml
@@ -92,7 +92,7 @@ lt:
       month: Mėnuo
       second: Sekundės
       year: Metai
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: turi būti patvirtintas
@@ -173,3 +173,10 @@ lt:
       long: ! '%B %d, %Y %H:%M'
       short: ! '%d %b %H:%M'
     pm: pm
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/lv.yml
+++ b/rails/locale/lv.yml
@@ -95,7 +95,7 @@ lv:
       month: mēnesis
       second: sekunde
       year: gads
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: ir jāpiekrīt
@@ -190,3 +190,10 @@ lv:
       long: ! '%Y. gada %e. %B, %H:%M:%S'
       short: ! '%d.%m.%Y., %H:%M'
     pm: pēcpusdiena
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/mk.yml
+++ b/rails/locale/mk.yml
@@ -92,7 +92,7 @@ mk:
         few: ! '%{count} секунди'
         one: 1 секунда
         other: ! '%{count} секунди'
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: мора да биде прифатен
@@ -161,3 +161,10 @@ mk:
       long: ! '%B %d, %Y %H:%M'
       short: ! '%d %b %H:%M'
     pm: ПМ
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/mn.yml
+++ b/rails/locale/mn.yml
@@ -95,7 +95,7 @@ mn:
       month: Сар
       second: Секунд
       year: Жил
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: хүлээн зөвшөөрөгдсөн байх ёстой
@@ -180,3 +180,10 @@ mn:
       long: ! '%Y %B %d, %H:%M:%S'
       short: ! '%y-%m-%d'
     pm: орой
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/nb.yml
+++ b/rails/locale/nb.yml
@@ -95,7 +95,7 @@ nb:
       month: Måned
       second: Sekund
       year: År
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: må være akseptert
@@ -198,3 +198,10 @@ nb:
       long: ! '%A, %e. %B %Y, %H:%M'
       short: ! '%e. %B, %H:%M'
     pm: ''
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/nl.yml
+++ b/rails/locale/nl.yml
@@ -95,7 +95,7 @@ nl:
       month: maand
       second: seconde
       year: jaar
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: moet worden geaccepteerd
@@ -190,3 +190,10 @@ nl:
       long: ! '%d %B %Y %H:%M'
       short: ! '%d %b %H:%M'
     pm: ! '''s middags'
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/nn.yml
+++ b/rails/locale/nn.yml
@@ -85,7 +85,7 @@ nn:
       x_seconds:
         one: 1 sekund
         other: ! '%{count} sekund'
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: må vera akseptert
@@ -151,3 +151,10 @@ nn:
       long: ! '%A, %e. %B %Y, %H:%M'
       short: ! '%e. %B, %H:%M'
     pm: ''
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/pl.yml
+++ b/rails/locale/pl.yml
@@ -106,7 +106,7 @@ pl:
       month: Miesiąc
       second: Sekundy
       year: Rok
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: musi zostać zaakceptowane
@@ -201,3 +201,10 @@ pl:
       long: ! '%B %d, %Y %H:%M'
       short: ! '%d %b %H:%M'
     pm: po południu
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/pt-BR.yml
+++ b/rails/locale/pt-BR.yml
@@ -95,7 +95,7 @@ pt-BR:
       month: Mês
       second: Segundo
       year: Ano
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: deve ser aceito
@@ -198,3 +198,10 @@ pt-BR:
       long: ! '%A, %d de %B de %Y, %H:%M h'
       short: ! '%d/%m, %H:%M h'
     pm: ''
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/pt-PT.yml
+++ b/rails/locale/pt-PT.yml
@@ -95,7 +95,7 @@ pt-PT:
       month: Mês
       second: Segundo
       year: Ano
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: tem de ser aceite
@@ -198,3 +198,10 @@ pt-PT:
       long: ! '%A, %d de %B de %Y, %H:%Mh'
       short: ! '%d/%m, %H:%M hs'
     pm: pm
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/rm.yml
+++ b/rails/locale/rm.yml
@@ -92,7 +92,7 @@ rm:
       month: mais
       second: secundas
       year: onns
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: sto vegnir acceptà
@@ -173,3 +173,10 @@ rm:
       long: ! '%A, %d. %B %Y, %H:%M Uhr'
       short: ! '%d. %B, %H:%M Uhr'
     pm: suentermezdi
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/ro.yml
+++ b/rails/locale/ro.yml
@@ -95,7 +95,7 @@ ro:
       month: Luna
       second: Secunda
       year: Anul
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: trebuie dat acceptul
@@ -190,3 +190,10 @@ ro:
       long: ! '%d %B %Y %H:%M'
       short: ! '%d %b %H:%M'
     pm: ''
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/ru.yml
+++ b/rails/locale/ru.yml
@@ -117,7 +117,7 @@ ru:
       month: Месяц
       second: Секунд
       year: Год
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: нужно подтвердить
@@ -248,3 +248,10 @@ ru:
       long: ! '%d %B %Y, %H:%M'
       short: ! '%d %b, %H:%M'
     pm: вечера
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/sk.yml
+++ b/rails/locale/sk.yml
@@ -95,7 +95,7 @@ sk:
       month: Mesiac
       second: Sekunda
       year: Rok
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: musí byť potvrdené
@@ -191,3 +191,10 @@ sk:
       long: ! '%A %d. %B %Y %H:%M'
       short: ! '%d.%m. %H:%M'
     pm: popoludní
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/sl.yml
+++ b/rails/locale/sl.yml
@@ -117,7 +117,7 @@ sl:
       month: Mesec
       second: Sekunde
       year: Leto
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: mora biti sprejeto
@@ -201,3 +201,10 @@ sl:
       long: ! '%d. %B, %Y ob %H:%M'
       short: ! '%d. %b ob %H:%M'
     pm: popoldan
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/sr-Latn.yml
+++ b/rails/locale/sr-Latn.yml
@@ -92,7 +92,7 @@ sr-Latn:
         few: ! '%{count} sekunde'
         one: 1 sekunda
         other: ! '%{count} sekundi'
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: mora biti prihvaćen
@@ -161,3 +161,10 @@ sr-Latn:
       long: ! '%B %d, %Y %H:%M'
       short: ! '%d %b %H:%M'
     pm: PM
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/sr.yml
+++ b/rails/locale/sr.yml
@@ -92,7 +92,7 @@ sr:
         few: ! '%{count} секунде'
         one: 1 секунда
         other: ! '%{count} секунди'
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: мора бити прихваћено
@@ -161,3 +161,10 @@ sr:
       long: ! '%B %d, %Y %H:%M'
       short: ! '%d %b %H:%M'
     pm: ПМ
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/sv-SE.yml
+++ b/rails/locale/sv-SE.yml
@@ -95,7 +95,7 @@ sv-SE:
       month: Månad
       second: Sekund
       year: År
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: måste vara accepterad
@@ -190,3 +190,10 @@ sv-SE:
       long: ! '%e %B %Y %H:%M'
       short: ! '%e %b %H:%M'
     pm: ''
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/sw.yml
+++ b/rails/locale/sw.yml
@@ -95,7 +95,7 @@ sw:
       month: Mwezi
       second: Sekunde
       year: Mwaka
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: lazima ikubaliwe
@@ -188,3 +188,10 @@ sw:
       long: ! '%A, %e. %B %Y, %H:%M:%S'
       short: ! '%e %b %Y %H:%M'
     pm: pm
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/th.yml
+++ b/rails/locale/th.yml
@@ -73,7 +73,7 @@ th:
       month: เดือน
       second: วินาที
       year: ปี
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: ต้องถูกยอมรับ
@@ -164,3 +164,10 @@ th:
       long: ! '%d %B %Y %H:%M น.'
       short: ! '%d %b %H:%M น.'
     pm: หลังเที่ยง
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/tr.yml
+++ b/rails/locale/tr.yml
@@ -90,7 +90,7 @@ tr:
       x_seconds:
         one: 1 saniye
         other: ! '%{count} saniye'
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: kabul edilmeli
@@ -167,3 +167,10 @@ tr:
       long: ! '%e %B %Y, %A, %H:%M'
       short: ! '%e %B, %H:%M'
     pm: öğleden sonra
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/uk.yml
+++ b/rails/locale/uk.yml
@@ -117,7 +117,7 @@ uk:
       month: Місяць
       second: Секунда
       year: Рік
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: має бути прийнятий
@@ -248,3 +248,10 @@ uk:
       long: ! '%d %B %Y, %H:%M'
       short: ! '%d %b, %H:%M'
     pm: по полудні
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/vi.yml
+++ b/rails/locale/vi.yml
@@ -92,7 +92,7 @@ vi:
       month: Tháng
       second: Giây
       year: Năm
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: phải được đồng ý
@@ -173,3 +173,10 @@ vi:
       long: ! '%d %B, %Y %H:%M'
       short: ! '%d %b %H:%M'
     pm: chiều
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/zh-CN.yml
+++ b/rails/locale/zh-CN.yml
@@ -95,7 +95,7 @@ zh-CN:
       month: 月
       second: 秒
       year: 年
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: 必须是可被接受的
@@ -190,3 +190,10 @@ zh-CN:
       long: ! '%Y年%b%d日 %H:%M'
       short: ! '%b%d日 %H:%M'
     pm: 下午
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors

--- a/rails/locale/zh-TW.yml
+++ b/rails/locale/zh-TW.yml
@@ -95,7 +95,7 @@ zh-TW:
       month: 月
       second: 秒
       year: 年
-  errors:
+  errors: &errors
     format: ! '%{attribute} %{message}'
     messages:
       accepted: 必須是可被接受的
@@ -190,3 +190,10 @@ zh-TW:
       long: ! '%Y年%b%d日 %H:%M'
       short: ! '%b%d日 %H:%M'
     pm: 下午
+  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
+  activemodel:
+    errors:
+      <<: *errors
+  activerecord:
+    errors:
+      <<: *errors


### PR DESCRIPTION
As I described in the #151 comment https://github.com/svenfuchs/rails-i18n/issues/151#issuecomment-4270185
current master doesn't work with edge Rails nor any stable version of Rails.
This patch fixes the situation simply by temporarily aliasing `errors` to `activemodel.errors` and `activerecord.errors`.
IMO These aliases could be removed only when @tigrish's refactoring on ActiveRecord finishes.

FYI this change was created by the following zsh script on OSX.

``` zsh
#!/bin/zsh
sed -i "" "s/errors:/errors: \&errors/" *.yml
cat << EOF >> *.yml
  # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
  activemodel:
    errors:
      <<: *errors
  activerecord:
    errors:
      <<: *errors
EOF
```
