### PR TITLE
Fix I18n::InvalidPluralizationData for "count: 12" in Polish locale

### DIFF
--- a/rails/locale/pl.yml
+++ b/rails/locale/pl.yml
@@ -58,47 +58,58 @@ pl:
         few: około %{count} godziny
         one: około godziny
         other: około %{count} godzin
+        many: około %{count} godzin
       about_x_months:
         few: około %{count} miesiące
         one: około miesiąca
         other: około %{count} miesięcy
+        many: około %{count} miesięcy
       about_x_years:
         few: około %{count} lata
         one: około rok
         other: około %{count} lat
+        many: około %{count} lat
       almost_x_years:
         few: prawie %{count} lata
         one: prawie rok
         other: prawie %{count} lat
+        many: prawie %{count} lat
       half_a_minute: pół minuty
       less_than_x_minutes:
         few: mniej niż %{count} minuty
         one: mniej niż minutę
         other: mniej niż %{count} minut
+        many: mniej niż %{count} minut
       less_than_x_seconds:
         few: mniej niż %{count} sekundy
         one: mniej niż sekundę
         other: mniej niż %{count} sekund
+        many: mniej niż %{count} sekund
       over_x_years:
         few: ponad %{count} lata
         one: ponad rok
         other: ponad %{count} lat
+        many: ponad %{count} lat
       x_days:
         few: ! '%{count} dni'
         one: 1 dzień
         other: ! '%{count} dni'
+        many: ! '%{count} dni'
       x_minutes:
         few: ! '%{count} minuty'
         one: 1 minuta
         other: ! '%{count} minut'
+        many: ! '%{count} minut'
       x_months:
         few: ! '%{count} miesiące'
         one: 1 miesiąc
         other: ! '%{count} miesięcy'
+        many: ! '%{count} miesięcy'
       x_seconds:
         few: ! '%{count} sekundy'
         one: 1 sekunda
         other: ! '%{count} sekund'
+        many: ! '%{count} sekund'
     prompts:
       day: Dzień
       hour: Godzina


### PR DESCRIPTION
I've encountered a `I18n::InvalidPluralizationData` exception when executing `I18n.t('datetime.distance_in_words.about_x_months', count: 12)` with `I18n.locale = :pl`. I'm not sure if this is a proper fix for that problem, but that worked for me and I wanted to touch as little code as possible.

Polish pluralization rule returns `:many` as pluralization key for 12, but such key is missing from the translations.

I couldn't find any place for tests of actual translations, so there are no tests in my commit, I'd gladly add one with some guidance.
