### PR TITLE
Fill in missing datetime/helpers/translations/template/number/prompts with their en-US

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ For more information, visit [Rails Internationalization (I18n) API](http://guide
 
 ## Usage on Rails 2.3
 
-Locale data whose structure is compatible with Rails 2.3 are available on the separate branch [rails-2-3](https://github.com/svenfuchs/rails-i18n/tree/rails-2-3). 
+Locale data whose structure is compatible with Rails 2.3 are available on the separate branch [rails-2-3](https://github.com/svenfuchs/rails-i18n/tree/rails-2-3).
 
 ## Available Locales
 
@@ -55,12 +55,12 @@ Available locales are:
 Following locales are complete:
 
 > ar, az, bg, bs, ca, cs, csb, cy, da, de, de-AT, de-CH, el, en-AU, en-GB, en-US, eo, es, es-AR, es-CL, es-CO, es-MX, et,
-> eu, fa, fi, fr, fr-CA, fr-CH, fur, gsw-CH, he, hi, hi-IN, hr, hu, is, it, ja, kn, ko, lv, nb,
+> eu, fa, fi, fr, fr-CA, fr-CH, fur, gsw-CH, he, hi, hi-IN, hr, hu, is, it, ja, kn, ko, lv, mn, nb,
 > nl, pl, pt-BR, pt-PT, ro, ru, sk, sv-SE, sw, th, uk, zh-CN, zh-TW
 
 Following locales have some missing translations:
 
-> bn-IN, dsb, en-IN, es-PE, gl-ES, hsb, id, lo, lt, mk, mn, nn, rm, sl, sr, sr-Latn, tr, vi
+> bn-IN, dsb, en-IN, es-PE, gl-ES, hsb, id, lo, lt, mk, nn, rm, sl, sr, sr-Latn, tr, vi
 
 We always welcome your contributions!
 
@@ -92,7 +92,7 @@ If you are not,
 Before committing and pushing your changes, test the integrity of your locale file.
 
     rake spec
-	
+
 Make sure you have included all translations with:
 
     rake i18n-spec:completeness rails/locale/en-US.yml rails/locale/YOUR_NEW_LOCALE.yml

--- a/rails/locale/mn.yml
+++ b/rails/locale/mn.yml
@@ -9,7 +9,7 @@ mn:
     - Ба
     - Бя
     abbr_month_names:
-    - 
+    -
     - 1 сар
     - 2 сар
     - 3 сар
@@ -35,7 +35,7 @@ mn:
       long: ! '%Y %B %d'
       short: ! '%y-%m-%d'
     month_names:
-    - 
+    -
     - 1 сар
     - 2 сар
     - 3 сар
@@ -55,38 +55,38 @@ mn:
   datetime:
     distance_in_words:
       about_x_hours:
-        one: ! '%{count} цаг орчим'
+        one: ! '1 цаг орчим'
         other: ! '%{count} цаг орчим'
       about_x_months:
-        one: ! '%{count} сар орчим'
+        one: ! '1 сар орчим'
         other: ! '%{count} сар орчим'
       about_x_years:
-        one: ! '%{count} жил орчим'
+        one: ! '1 жил орчим'
         other: ! '%{count} жил орчим'
       almost_x_years:
-        one: бараг %{count} жил
+        one: бараг 1 жил
         other: бараг %{count} жил
       half_a_minute: хагас минут
       less_than_x_minutes:
-        one: ! '%{count} минутаас бага'
+        one: ! '1 минутаас бага'
         other: ! '%{count} минутаас бага'
       less_than_x_seconds:
-        one: ! '%{count} секундээс бага'
+        one: ! '1 секундээс бага'
         other: ! '%{count} секундээс бага'
       over_x_years:
-        one: ! '%{count} жилээс илүү'
+        one: ! '1 жилээс илүү'
         other: ! '%{count} жилээс илүү'
       x_days:
-        one: ! '%{count} өдөр'
+        one: ! '1 өдөр'
         other: ! '%{count} өдөр'
       x_minutes:
-        one: ! '%{count} минут'
+        one: ! '1 минут'
         other: ! '%{count} минут'
       x_months:
-        one: ! '%{count} сар'
+        one: ! '1 сар'
         other: ! '%{count} сар'
       x_seconds:
-        one: ! '%{count} секунд'
+        one: ! '1 секунд'
         other: ! '%{count} секунд'
     prompts:
       day: Өдөр
@@ -106,26 +106,37 @@ mn:
       even: тэгш байх ёстой
       exclusion: бол ашиглахад хориотой
       greater_than: ! '%{count}-с их байх ёстой'
-      greater_than_or_equal_to: ! '%{count}-с их юмуу тэнцүү байх ёстой'
-      inclusion: жагсаалтад алга байна
+      greater_than_or_equal_to: ! '%{count}-с их юмуу эсвэл тэнцүү байх ёстой'
+      inclusion: жагсаалтанд алга байна
       invalid: буруу байна
       less_than: ! '%{count}-с бага байх ёстой'
-      less_than_or_equal_to: ! '%{count}-с бага юмуу тэнцүү байх ёстой'
+      less_than_or_equal_to: ! '%{count}-с бага юмуу эсвэл тэнцүү байх ёстой'
       not_a_number: тоо биш байна
       not_an_integer: бүхэл тоо байх ёстой
       odd: сонгой байх ёстой
       record_invalid: ! 'Шалгалт амжилтгүй: %{errors}'
       taken: аль хэдийн авчихсан байна
-      too_long: хэт урт байна (хамгийн уртдаа %{count} тэмдэгт)
-      too_short: хэт богино байна (хамгийн багадаа %{count} тэмдэгт)
+      too_long:
+        one: хэт урт байна (хамгийн уртдаа 1 тэмдэгт)
+        other: хэт урт байна (хамгийн уртдаа %{count} тэмдэгт)
+      too_short:
+        one: хэт богино байна (хамгийн багадаа 1 тэмдэгт)
+        other: хэт богино байна (хамгийн багадаа %{count} тэмдэгт)
       wrong_length: урт нь буруу байна (%{count} тэмдэгт байх ёстой)
+        one: урт нь буруу байна (1 тэмдэгт байх ёстой)
+        other: урт нь буруу байна (%{count} тэмдэгт байх ёстой)
     template:
+      body: ! 'Дараах талбарууд дээр алдаа гарлаа:'
       header:
         one: 1 алдаа гарсан тул %{model} хадгалагдахгүй байна
         other: ! '%{count} алдаа гарсан тул %{model} хадгалагдахгүй байна'
   helpers:
     select:
       prompt: Сонгоно уу
+    submit:
+      create: %{model}-г үүсгэх
+      submit: %{model}-г хадгалах
+      update: %{model}-г шинэчлэх
   number:
     currency:
       format:
@@ -146,9 +157,15 @@ mn:
       decimal_units:
         format: ! '%n %u'
         units:
+          billion: Тэрбум
+          million: Сая
+          quadrillion: Тунамал
+          thousand: Мянга
+          trillion: Их наяд
           unit: ''
       format:
         delimiter: ''
+        precision: 3
         significant: true
         strip_insignificant_zeros: true
       storage_units:


### PR DESCRIPTION
Filled in some of the missing datetime, helpers, prompts and template translations with the en-US version.
