### PR TITLE
Update i18n-spec

### DIFF
--- a/rails-i18n.gemspec
+++ b/rails-i18n.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |s|
   s.add_dependency('i18n', '~> 0.5')
   s.add_development_dependency "rails", ">= 3.0.0"
   s.add_development_dependency "rspec-rails", ">= 2.7.0"
-  s.add_development_dependency "i18n-spec", ">= 0.1.1"
+  s.add_development_dependency "i18n-spec", ">= 0.2"
   s.add_development_dependency "spork", "~> 1.0rc"
 end


### PR DESCRIPTION
`i18n-spec` now supports MRI 1.8 as well (fixes #210)
