### PR TITLE
include attribute name in confirmation error message

### DIFF
--- a/rails/locale/ja.yml
+++ b/rails/locale/ja.yml
@@ -100,7 +100,7 @@ ja:
     messages:
       accepted: を受諾してください。
       blank: を入力してください。
-      confirmation: と確認の入力が一致しません。
+      confirmation: と%{attribute}の入力が一致しません。
       empty: を入力してください。
       equal_to: は%{count}にしてください。
       even: は偶数にしてください。


### PR DESCRIPTION
This follows en.yml change in https://github.com/rails/rails/commit/fcc534e.

See https://github.com/rails/rails/pull/5942 for details.
