### PR TITLE
Improve french translations

### DIFF
--- a/rails/locale/fr-CA.yml
+++ b/rails/locale/fr-CA.yml
@@ -98,7 +98,7 @@ fr-CA:
       second: Seconde
       year: Année
   errors: &errors
-    format: Le %{attribute} %{message}
+    format: %{attribute} %{message}
     messages:
       accepted: doit être accepté(e)
       blank: doit être rempli(e)

--- a/rails/locale/fr-CH.yml
+++ b/rails/locale/fr-CH.yml
@@ -98,7 +98,7 @@ fr-CH:
       second: Seconde
       year: Année
   errors: &errors
-    format: Le %{attribute} %{message}
+    format: %{attribute} %{message}
     messages:
       accepted: doit être accepté(e)
       blank: doit être rempli(e)

--- a/rails/locale/fr.yml
+++ b/rails/locale/fr.yml
@@ -178,15 +178,15 @@ fr:
       submit: "Enregistrer ce(tte) %{model}"
 
   errors: &errors
-    format: "Le %{attribute} %{message}"
+    format: "%{attribute} %{message}"
     messages: &errors_messages
       inclusion: "n'est pas inclus(e) dans la liste"
       exclusion: "n'est pas disponible"
       invalid: "n'est pas valide"
       confirmation: "ne concorde pas avec la confirmation"
       accepted: "doit être accepté(e)"
-      empty: "champ obligé"
-      blank: "champ obligé"
+      empty: "doit être rempli(e)"
+      blank: "doit être rempli(e)"
       too_long:
         one: "est trop long (pas plus d'un caractère)"
         other: "est trop long (pas plus de %{count} caractères)"
@@ -213,7 +213,7 @@ fr:
         one:   "Impossible d'enregistrer ce(tte) %{model} : 1 erreur"
         other: "Impossible d'enregistrer ce(tte) %{model} : %{count} erreurs"
       body: "Veuillez vérifier les champs suivants : "
-      
+
   activemodel:
     errors:
       <<: *errors


### PR DESCRIPTION
The current fr locale generated errors like "Le email est obligé" which
is just wrong. Even if we correct into its probable original meaning so
it becomes "est obligatoire", the fr-CA/fr-CH wording is much more correct.

Then there's the gender problem which is also present in the fr-CA/fr-CH
locales, by removing the gender we avoid the pain of writing an error
message like "Le/La/L' %{attribute} %{message}".
