### PR TITLE
Fix es-AR delimiter and separator

### DIFF
--- a/rails/locale/es-AR.yml
+++ b/rails/locale/es-AR.yml
@@ -140,10 +140,10 @@ es-AR:
   number:
     currency:
       format:
-        delimiter: ! ','
+        delimiter: .
         format: ! '%u%n'
         precision: 2
-        separator: .
+        separator: ! ','
         significant: false
         strip_insignificant_zeros: false
         unit: $


### PR DESCRIPTION
Fixed as described here: http://publib.boulder.ibm.com/infocenter/forms/v3r5m1/index.jsp?topic=%2Fcom.ibm.form.designer.locales.doc%2Fi_xfdl_r_formats_es_AR.html

The right format for es-AR is "$ 23,99" instead of "$ 23.99".
