### PR TITLE
`self.rule` was being defined inside itself...

### DIFF
--- a/lib/rails_i18n/common_pluralizations/one_two_other.rb
+++ b/lib/rails_i18n/common_pluralizations/one_two_other.rb
@@ -5,15 +5,13 @@ module RailsI18n
   module Pluralization
     module OneTwoOther
       def self.rule
-        def self.rule
-          lambda do |n|
-            if n == 1
-              :one
-            elsif n == 2
-              :two
-            else
-              :other
-            end
+        lambda do |n|
+          if n == 1
+            :one
+          elsif n == 2
+            :two
+          else
+            :other
           end
         end
       end


### PR DESCRIPTION
Was reading through the source when I noticed something strange in `lib/rails_i18n/common_pluralizations/one_two_other.rb`:

``` ruby
def self.rule
  def self.rule
    ...
  end
end
```

None of the other files in `lib/rails_i18n/common_pluralizations/` do this, so I'm pretty sure it's a mistake.
