### PR TITLE
Update ja locale

### DIFF
--- a/rails/locale/ja.yml
+++ b/rails/locale/ja.yml
@@ -123,7 +123,7 @@ ja:
       body: 次の項目を確認してください。
       header:
         one: ! '%{model}にエラーが発生しました。'
-        other: ! '%{model}に%{count}つのエラーが発生しました。'
+        other: ! '%{model}に%{count}個のエラーが発生しました。'
   helpers:
     select:
       prompt: 選択してください。


### PR DESCRIPTION
N-tu is used with 1..9 only. N-ko is more generic.
