### PR TITLE
Remove spurious 'mis' from Welsh month names.

### DIFF
--- a/rails/locale/cy.yml
+++ b/rails/locale/cy.yml
@@ -36,18 +36,18 @@ cy:
       short: ! '%b %d'
     month_names:
     - 
-    - mis Ionawr
-    - mis Chwefror
-    - mis Mawrth
-    - mis Ebrill
-    - mis Mai
-    - mis Mehefin
-    - mis Gorffennaf
-    - mis Awst
-    - mis Medi
-    - mis Hydref
-    - mis Tachwedd
-    - mis Rhagfyr
+    - Ionawr
+    - Chwefror
+    - Mawrth
+    - Ebrill
+    - Mai
+    - Mehefin
+    - Gorffennaf
+    - Awst
+    - Medi
+    - Hydref
+    - Tachwedd
+    - Rhagfyr
     order:
     - :year
     - :month


### PR DESCRIPTION
The word 'mis' literally translates to 'in', so for example:

'29 mis Tachwedd 2012' literally translates to '29 in November 2012'

In the English locale this would be simply '29 November 2012'
