### PR TITLE
:ja message for AbsenceValidator

### DIFF
--- a/rails/locale/ja.yml
+++ b/rails/locale/ja.yml
@@ -100,6 +100,7 @@ ja:
     messages:
       accepted: を受諾してください。
       blank: を入力してください。
+      present: は入力しないでください。
       confirmation: と確認の入力が一致しません。
       empty: を入力してください。
       equal_to: は%{count}にしてください。


### PR DESCRIPTION
A new validator in Rails 4, AbsenceValidator, requires `errors.messages.present`.
See rails/rails@d72a07f and rails/rails@ac6941f for details.
