### PR TITLE
Create es_CR.yml

### DIFF
--- a/rails/locale/es_CR.yml
+++ b/rails/locale/es_CR.yml
@@ -1,4 +1,4 @@
-es-CR:
+es_CR:
   date:
     abbr_day_names:
     - dom


### PR DESCRIPTION
Add spanish as spoken in Costa Rica (es_CR) translations for Rails including number currency symbol ( ¢ ).
