### PR TITLE
Update rails/locale/ro.yml

### DIFF
--- a/rails/locale/ro.yml
+++ b/rails/locale/ro.yml
@@ -146,10 +146,10 @@ ro:
   number:
     currency:
       format:
-        delimiter: ! ','
+        delimiter: ! '.'
         format: ! '%n %u'
         precision: 2
-        separator: .
+        separator: ! ','
         significant: false
         strip_insignificant_zeros: false
         unit: RON


### PR DESCRIPTION
Romanian language shows currency in the format: 123.300,50 i.e. separator is ',' and delimiter is '.'
