### PR TITLE
Correction from Lioness8257 on half_a_minute in Tagalog

### DIFF
--- a/rails/locale/tl.yml
+++ b/rails/locale/tl.yml
@@ -4,6 +4,7 @@
 #  - Patrick CHEW - https://github.com/pchew-change (pchew@change.org)
 #  - Jose BUSTAMANTE - (josebust@cisco.com)
 # Corrected by Christine Roque : christine@change.org
+# Additional correction by: https://github.com/Lioness8257
 
 "tl":
   date:
@@ -133,7 +134,7 @@
 
   datetime:
     distance_in_words:
-      half_a_minute: "kalahating isang minuto"
+      half_a_minute: "kalahating minuto"
       less_than_x_seconds:
         one: mas mababa sa isang segundo
         other: "mas mababa sa %{count} segundo"


### PR DESCRIPTION
Removed "a/one" from half "a" minute. The update reads as proper spoken Tagalog.
