### PR TITLE
Comma is used as a decimal mark in Russia

### DIFF
--- a/rails/locale/ru.yml
+++ b/rails/locale/ru.yml
@@ -173,14 +173,14 @@ ru:
         delimiter: ! ' '
         format: ! '%n %u'
         precision: 2
-        separator: .
+        separator: ','
         significant: false
         strip_insignificant_zeros: false
         unit: руб.
     format:
       delimiter: ! ' '
       precision: 3
-      separator: .
+      separator: ','
       significant: false
       strip_insignificant_zeros: false
     human:


### PR DESCRIPTION
http://www.unicode.org/cldr/charts/by_type/patterns.numbers.html#4ec3d1b99830ad07
