### PR TITLE
Adding defaults to created_at and updated_at

### DIFF
--- a/rails/locale/pt-BR.yml
+++ b/rails/locale/pt-BR.yml
@@ -205,3 +205,6 @@ pt-BR:
   activerecord:
     errors:
       <<: *errors
+  attributes:
+    created_at: Criado em
+    updated_at: Modificado em


### PR DESCRIPTION
Why not use attribute defaults to _created_at_ and _updated_at_, as describerd in http://blog.plataformatec.com.br/2010/02/rails-3-i18n-changes/?
