### PR TITLE
Days and months must be lower case.

### DIFF
--- a/rails/locale/it.yml
+++ b/rails/locale/it.yml
@@ -1,53 +1,53 @@
 it:
   date:
     abbr_day_names:
-    - Dom
-    - Lun
-    - Mar
-    - Mer
-    - Gio
-    - Ven
-    - Sab
+    - dom
+    - lun
+    - mar
+    - mer
+    - gio
+    - ven
+    - sab
     abbr_month_names:
     - 
-    - Gen
-    - Feb
-    - Mar
-    - Apr
-    - Mag
-    - Giu
-    - Lug
-    - Ago
-    - Set
-    - Ott
-    - Nov
-    - Dic
+    - gen
+    - feb
+    - mar
+    - apr
+    - mag
+    - giu
+    - lug
+    - ago
+    - set
+    - ott
+    - nov
+    - dic
     day_names:
-    - Domenica
-    - Lunedì
-    - Martedì
-    - Mercoledì
-    - Giovedì
-    - Venerdì
-    - Sabato
+    - domenica
+    - lunedì
+    - martedì
+    - mercoledì
+    - giovedì
+    - venerdì
+    - sabato
     formats:
       default: ! '%d-%m-%Y'
       long: ! '%d %B %Y'
       short: ! '%d %b'
     month_names:
     - 
-    - Gennaio
-    - Febbraio
-    - Marzo
-    - Aprile
-    - Maggio
-    - Giugno
-    - Luglio
-    - Agosto
-    - Settembre
-    - Ottobre
-    - Novembre
-    - Dicembre
+    - gennaio
+    - febbraio
+    - marzo
+    - aprile
+    - maggio
+    - giugno
+    - luglio
+    - agosto
+    - settembre
+    - ottobre
+    - novembre
+    - dicembre
     order:
     - :day
     - :month


### PR DESCRIPTION
The names of days and months are common names and must NOT be capitalized.

[cit. from http://www.accademiadellacrusca.it]
I nomi dei giorni della settimana e dei mesi dell'anno non richiedono la maiuscola, eccetto nei casi in cui vengano attribuiti come nomi propri (ad esempio Domenica come nome proprio femminile).
