### PR TITLE
Update el according to CLDR

### DIFF
--- a/rails/locale/el.yml
+++ b/rails/locale/el.yml
@@ -140,10 +140,10 @@ el:
   number:
     currency:
       format:
-        delimiter: ! ','
+        delimiter: .
         format: ! '%n %u'
         precision: 2
-        separator: .
+        separator: ! ','
         significant: false
         strip_insignificant_zeros: false
         unit: €


### PR DESCRIPTION
Various fixes in the el.yml, all of them according to the CLDR.

The most important things to note are:
1. Fixed [currency and number format delimiter / separator](http://www.unicode.org/cldr/charts/by_type/patterns.numbers.html#Western_Digits_%28latn%29)
2. Removed accents from [abbreviated day names](http://www.unicode.org/cldr/charts/by_type/calendars.gregorian.html#Days:_format-abbreviated)
3. Removed trailing dots from [abbreviated month names](http://www.unicode.org/cldr/charts/by_type/calendars.gregorian.html#Months:_format-abbreviated)
4. Fixed a small grammar mistake missed from #259

**Shall I create a separate PR to merge these changes into `rails-3-x`?**

We really want to see these fixes into the next stable release of I18n gem for Rails 3.x.
