### PR TITLE
Support Buddhist calendar year for thai locale.

### DIFF
--- a/lib/rails_i18n/railtie.rb
+++ b/lib/rails_i18n/railtie.rb
@@ -6,7 +6,7 @@ module RailsI18n
       RailsI18n::Railtie.instance_eval do
         pattern = pattern_from app.config.i18n.available_locales
 
-        add("rails/locale/#{pattern}.yml")
+        add("rails/locale/#{pattern}.{rb,yml}")
         add("rails/pluralization/#{pattern}.rb")
         add("rails/transliteration/#{pattern}.{rb,yml}")
 

--- a/rails/locale/th.rb
+++ b/rails/locale/th.rb
@@ -1,0 +1,21 @@
+# encoding: utf-8
+# More at http://en.wikipedia.org/wiki/Buddhist_calendar
+BUDDHIST_CALENDAR_YEAR_OFFSET = 543 unless defined?(BUDDHIST_CALENDAR_YEAR_OFFSET)
+
+{
+  th: {
+    date: {
+      formats: {
+        default: lambda { |date, _| "%d-%m-#{date.year + BUDDHIST_CALENDAR_YEAR_OFFSET}" },
+        long: lambda { |date, _| "%d %B #{date.year + BUDDHIST_CALENDAR_YEAR_OFFSET}" },
+        year: lambda { |date, _| date.year + BUDDHIST_CALENDAR_YEAR_OFFSET },
+      }
+    },
+    time: {
+      formats: {
+        default: lambda { |time, _| "%a %d %b #{time.year + BUDDHIST_CALENDAR_YEAR_OFFSET} %H:%M:%S %z" },
+        long: lambda { |time, _| "%d %B #{time.year + BUDDHIST_CALENDAR_YEAR_OFFSET} %H:%M น." },
+      }
+    }
+  }
+}

--- a/rails/locale/th.yml
+++ b/rails/locale/th.yml
@@ -31,8 +31,6 @@ th:
     - ศุกร์
     - เสาร์
     formats:
-      default: ! '%d-%m-%Y'
-      long: ! '%d %B %Y'
       short: ! '%d %b'
     month_names:
     - 
@@ -160,8 +158,6 @@ th:
   time:
     am: ก่อนเที่ยง
     formats:
-      default: ! '%a %d %b %Y %H:%M:%S %z'
-      long: ! '%d %B %Y %H:%M น.'
       short: ! '%d %b %H:%M น.'
     pm: หลังเที่ยง
   # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository


### PR DESCRIPTION
In :th locale year differs from standard western calendar. Now there is already 2556 year, so offset to default year is needed. Look more at http://en.wikipedia.org/wiki/Buddhist_calendar

To make this offset additional .rb locale file is used.

``` ruby
>> Date.today
=> Fri, 15 Mar 2013
>> I18n.l(Date.today)
=> "15-03-2556"
>> I18n.l(Date.today, format: :long)
=> "15 มีนาคม 2556"
>> I18n.l(Date.today, format: :year)
=> "2556"
>> I18n.l(Time.now)
=> "ศ 15 มี.ค. 2556 18:05:20 +0400"
>> I18n.l(Time.now, format: :long)
=> "15 มีนาคม 2556 18:05 น."
```
