### PR TITLE
Revert commits that broke the usage of 'distance_of_time_in_words' in Colombian Spanish

### DIFF
--- a/rails/locale/es-CO.yml
+++ b/rails/locale/es-CO.yml
@@ -55,14 +55,14 @@ es-CO:
   datetime:
     distance_in_words:
       about_x_hours:
-        one: hace 1 hora
-        other: hace %{count} horas
+        one: cerca de 1 hora
+        other: cerca de %{count} horas
       about_x_months:
-        one: hace 1 mes
-        other: hace %{count} meses
+        one: cerca de 1 mes
+        other: cerca de %{count} meses
       about_x_years:
-        one: hace 1 año
-        other: hace %{count} años
+        one: cerca de 1 año
+        other: cerca de %{count} años
       almost_x_years:
         one: casi 1 año
         other: casi %{count} años


### PR DESCRIPTION
This reverts commit e6a1c4f1b081b193f45a7f011039f7e55779127e.

This commit broke the meaning of "distance_of_time_in_words". That
method is supposed to return the description of a time interval
without specifying if it's in the future or in the past. That is,
it should return "about 1 hour" instead of "about 1 hour ago" or
"in about 1 hour from now".

Well, this commit replaced "about 1 hour" with "1 hour ago", which is
wrong. You can't now use the "distance_of_time_in_words" method to
describe dates in the future, because the final result would be
something like "in about 2 hours ago from now".
