### PR TITLE
Clarify de.errors.messages.too_(long|short)

### DIFF
--- a/rails/locale/de.yml
+++ b/rails/locale/de.yml
@@ -116,8 +116,8 @@ de:
       odd: muss ungerade sein
       record_invalid: ! 'Gültigkeitsprüfung ist fehlgeschlagen: %{errors}'
       taken: ist bereits vergeben
-      too_long: ist zu lang (nicht mehr als %{count} Zeichen)
-      too_short: ist zu kurz (nicht weniger als %{count} Zeichen)
+      too_long: ist zu lang (mehr als %{count} Zeichen)
+      too_short: ist zu kurz (weniger als %{count} Zeichen)
       wrong_length: hat die falsche Länge (muss genau %{count} Zeichen haben)
     template:
       body: ! 'Bitte überprüfen Sie die folgenden Felder:'


### PR DESCRIPTION
Previous messages literally read too_long: "is too long (not more than X characters)", too_short: "is too short (not less than X characters)" which IMO was confusing as it could be read as "is too short (i.e., is not less than…)" whereas the actual meaning is "is too short (it _should_ not be less than…)".

The version I suggest translates to "is too long (more than X characters)" and "is too short (less than X characters)" respectively which is unambiguous. It can now be read as a natural sentence "Attribute IS too short (less than…)" without the user having to assume another verb for the details given in the parentheses.
