### PR TITLE
Fixed currency separator and delimiters for es-AR, fi, ro and sv

### DIFF
--- a/rails/locale/es-AR.yml
+++ b/rails/locale/es-AR.yml
@@ -148,9 +148,9 @@ es-AR:
         strip_insignificant_zeros: false
         unit: $
     format:
-      delimiter: ! ','
+      delimiter: .
       precision: 2
-      separator: .
+      separator: ! ','
       significant: false
       strip_insignificant_zeros: false
     human:

--- a/rails/locale/fi.yml
+++ b/rails/locale/fi.yml
@@ -142,9 +142,9 @@ fi:
         strip_insignificant_zeros: false
         unit: €
     format:
-      delimiter: ! ','
+      delimiter: .
       precision: 3
-      separator: .
+      separator: ! ','
       significant: false
       strip_insignificant_zeros: false
     human:

--- a/rails/locale/ro.yml
+++ b/rails/locale/ro.yml
@@ -146,17 +146,17 @@ ro:
   number:
     currency:
       format:
-        delimiter: ! '.'
+        delimiter: .
         format: ! '%n %u'
         precision: 2
-        separator: ! ','
+        separator: ','
         significant: false
         strip_insignificant_zeros: false
         unit: RON
     format:
-      delimiter: ! ','
+      delimiter: .
       precision: 3
-      separator: .
+      separator: ','
       significant: false
       strip_insignificant_zeros: false
     human:

--- a/rails/locale/sv.yml
+++ b/rails/locale/sv.yml
@@ -134,10 +134,10 @@ sv:
   number:
     currency:
       format:
-        delimiter: ! ','
+        delimiter:
         format: ! '%n %u'
         precision: 2
-        separator: .
+        separator: ! ','
         significant: false
         strip_insignificant_zeros: false
         unit: kr


### PR DESCRIPTION
In es-AR, fi, ro and sv locales the keys _number.currency.format.delimiter_ and _number.currency.format.separator_ have different values with respective keys in _number.format_.  

According to [wikipedia](http://en.wikipedia.org/wiki/Decimal_mark#Countries_using_Arabic_numerals_with_decimal_comma) all these contries use comma as decimal separator, so existing _number.format_ values should be correct and _number.currency.format_ values look erroneous.

This pull request fixes _number.currency.format_ values to their respective equivalents from _number.format_
