### PR TITLE
Change en-AU to use en-GB date and time formats instead of en-US

### DIFF
--- a/rails/locale/en-AU.yml
+++ b/rails/locale/en-AU.yml
@@ -32,8 +32,8 @@ en-AU:
     - Saturday
     formats:
       default: ! '%d-%m-%Y'
-      long: ! '%B %d, %Y'
-      short: ! '%b %d'
+      long: ! '%d %B, %Y'
+      short: ! '%d %b'
     month_names:
     - 
     - January
@@ -193,7 +193,7 @@ en-AU:
     am: am
     formats:
       default: ! '%a, %d %b %Y %H:%M:%S %z'
-      long: ! '%B %d, %Y %H:%M'
+      long: ! '%d %B, %Y %H:%M'
       short: ! '%d %b %H:%M'
     pm: pm
   # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository


### PR DESCRIPTION
Updated to match the official Date and Time notation. See http://en.wikipedia.org/wiki/Date_and_time_notation_in_Australia
