### PR TITLE
Use accusative case in x_seconds for ru locale

### DIFF
--- a/rails/locale/ru.yml
+++ b/rails/locale/ru.yml
@@ -108,7 +108,7 @@ ru:
       x_seconds:
         few: ! '%{count} секунды'
         many: ! '%{count} секунд'
-        one: ! '%{count} секунда'
+        one: ! '%{count} секундy'
         other: ! '%{count} секунды'
     prompts:
       day: День


### PR DESCRIPTION
I think it is better to use accusative case for _x_seconds.one_ like it is in _x_minutes.one_.
