### PR TITLE
missing :many plural form in :pl

### DIFF
--- a/rails/locale/pl.yml
+++ b/rails/locale/pl.yml
@@ -147,6 +147,7 @@ pl:
         one: ! '%{model} nie został zachowany z powodu jednego błędu'
         few: ! '%{model} nie został zachowany z powodu %{count} błędów'
         other: ! '%{model} nie został zachowany z powodu %{count} błędów'
+        many: ! '%{model} nie został zachowany z powodu %{count} błędów'
   helpers:
     select:
       prompt: Proszę wybrać


### PR DESCRIPTION
:many for errors.template.header is missing in polish (:pl) translation and raises

```
I18n::InvalidPluralizationData
```

for some count values.
