### PR TITLE
nb currency: strip_insignificant_zeros should be false

### DIFF
--- a/rails/locale/nb.yml
+++ b/rails/locale/nb.yml
@@ -139,7 +139,7 @@ nb:
         precision: 2
         separator: ! ','
         significant: false
-        strip_insignificant_zeros: true
+        strip_insignificant_zeros: false
         unit: kr
     format:
       delimiter: ! ' '


### PR DESCRIPTION
Norwegian currency should format to "99,50 kr", not "99,5 kr". This
commit fixes that.

Note that the helper for ordinary floating-point numbers still strip
zeros, as expected.
