### PR TITLE
The Japanese language is plural-unaware in most cases

### DIFF
--- a/rails/locale/ja.yml
+++ b/rails/locale/ja.yml
@@ -116,9 +116,7 @@ ja:
       not_an_integer: は整数で入力してください。
       odd: は奇数にしてください。
       record_invalid: バリデーションに失敗しました。 %{errors}
-      restrict_dependent_destroy:
-        one: "%{record}が存在しているので削除出来ません。"
-        many: "%{record}が存在しているので削除出来ません。"
+      restrict_dependent_destroy: %{record}が存在しているので削除出来ません。
       taken: はすでに存在します。
       too_long: は%{count}文字以内で入力してください。
       too_short: は%{count}文字以上で入力してください。


### PR DESCRIPTION
Need not to repeat the same Strings for `one:` and `many:` where these are the same ones.
