### PR TITLE
Prefer "できる" over "出来る"

### DIFF
--- a/rails/locale/ja.yml
+++ b/rails/locale/ja.yml
@@ -116,7 +116,7 @@ ja:
       not_an_integer: は整数で入力してください。
       odd: は奇数にしてください。
       record_invalid: バリデーションに失敗しました。 %{errors}
-      restrict_dependent_destroy: ! '%{record}が存在しているので削除出来ません。'
+      restrict_dependent_destroy: ! '%{record}が存在しているので削除できません。'
       taken: はすでに存在します。
       too_long: は%{count}文字以内で入力してください。
       too_short: は%{count}文字以上で入力してください。


### PR DESCRIPTION
In this case, "できる" is considered as a "standard" Japanese according to ["公用文における漢字使用等について"](http://www.bunka.go.jp/kokugo_nihongo/joho/kijun/sanko/koyobun/pdf/kunrei.pdf) (page 3) by the government.
