### PR TITLE
ru, uk: Short day number in natural date format

### DIFF
--- a/rails/locale/ru.yml
+++ b/rails/locale/ru.yml
@@ -32,8 +32,8 @@ ru:
     - суббота
     formats:
       default: ! '%d.%m.%Y'
-      long: ! '%d %B %Y'
-      short: ! '%d %b'
+      long: ! '%-d %B %Y'
+      short: ! '%-d %b'
     month_names:
     - 
     - января

--- a/rails/locale/uk.yml
+++ b/rails/locale/uk.yml
@@ -32,8 +32,8 @@ uk:
     - субота
     formats:
       default: ! '%d.%m.%Y'
-      long: ! '%d %B %Y'
-      short: ! '%d %b'
+      long: ! '%-d %B %Y'
+      short: ! '%-d %b'
     month_names:
     - 
     - Січень


### PR DESCRIPTION
Using %-d to build natural long or short human-readable date

`%d` will produce leading zero ("01"), `%e` will produce leading space (" 1") while `%-d` preserves natural number of digits. See #216 for discussion.

I did it only for Russian and Ukrainian as long as I do not have enough knowledge about was is traditional for other languages.
