### PR TITLE
README correction: en.yml not en-US.yml should be used as the base for translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ If you are not,
 
 ### Create or edit your locale file
 
-* Have a look in `rails/locale/en-US.yml`, which can be used as the base of your translation.
+* Have a look in `rails/locale/en.yml`, which should be used as the base of your translation.
   Note that we use `&errors_messages` and `<<: *errors_messages` to anchor and merge a part of translation data.
 * Create or edit your locale file.
   Please pay attention to save your files as UTF-8.


### PR DESCRIPTION
This rails commit: https://github.com/rails/rails/commit/12118963acacc9c869bdd41ef8480a1a4e06d358 changed the default rails locale from :en-US to :en . Therefore the :en locale should be used as the base for translations.
