### PR TITLE
Add translation for restrict_dependent_destroy for :fr locale

### DIFF
--- a/rails/locale/fr.yml
+++ b/rails/locale/fr.yml
@@ -125,6 +125,9 @@ fr:
       not_an_integer: "doit être un nombre entier"
       odd: "doit être impair"
       record_invalid: "La validation a échoué : %{errors}"
+      restrict_dependent_destroy:
+        one: "Suppression impossible: un autre enregistrement est lié"
+        many: "Suppression impossible: d'autres enregistrements sont liés"
       taken: "n'est pas disponible"
       too_long:
         one: "est trop long (pas plus d'un caractère)"


### PR DESCRIPTION
I believe this is a fair general purpose translation into French for _restrict_dependent_destroy_. 

It does not interpolate information about the dependent record like the en.yml - however this gets around problems linked to gender that are evident elsewhere in the :fr locale translation file.
