### PR TITLE
Use 12-hour clock for :en-US and :en-CA

### DIFF
--- a/rails/locale/en-CA.yml
+++ b/rails/locale/en-CA.yml
@@ -201,9 +201,9 @@ en-CA:
   time:
     am: am
     formats:
-      default: ! '%a, %d %b %Y %H:%M:%S %z'
-      long: ! '%B %d, %Y %H:%M'
-      short: ! '%d %b %H:%M'
+      default: ! '%a, %d %b %Y %I:%M:%S %p %Z'
+      long: ! '%B %d, %Y %I:%M %p'
+      short: ! '%d %b %I:%M %p'
     pm: pm
   # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
   activemodel:

--- a/rails/locale/en-US.yml
+++ b/rails/locale/en-US.yml
@@ -198,9 +198,9 @@ en-US:
   time:
     am: am
     formats:
-      default: ! '%a, %d %b %Y %H:%M:%S %z'
-      long: ! '%B %d, %Y %H:%M'
-      short: ! '%d %b %H:%M'
+      default: ! '%a, %d %b %Y %I:%M:%S %p %Z'
+      long: ! '%B %d, %Y %I:%M %p'
+      short: ! '%d %b %I:%M %p'
     pm: pm
   # remove these aliases after 'activemodel' and 'activerecord' namespaces are removed from Rails repository
   activemodel:


### PR DESCRIPTION
Fixes #335

In addition for time:formats:defaults the time zone as been modified from 'time zone as hour and minute offset from UTC' to 'time zone abbreviation name' to match common US usage as used for example by the US Naval Observatory (http://tycho.usno.navy.mil/timer.html) and the New York Times.
