### PR TITLE
Making Hungarian datetime.distance_in_words nicer

### DIFF
--- a/rails/locale/hu.yml
+++ b/rails/locale/hu.yml
@@ -55,39 +55,39 @@ hu:
   datetime:
     distance_in_words:
       about_x_hours:
-        one: kb 1 óra
-        other: kb %{count} óra
+        one: kb 1 órája
+        other: kb %{count} órája
       about_x_months:
-        one: kb 1 hónap
-        other: kb %{count} hónap
+        one: kb 1 hónapja
+        other: kb %{count} hónapja
       about_x_years:
-        one: kb 1 év
-        other: kb %{count} év
+        one: kb 1 éve
+        other: kb %{count} éve
       almost_x_years:
-        one: majdnem 1 év
-        other: majdnem %{count} év
-      half_a_minute: fél perc
+        one: majdnem 1 éve
+        other: majdnem %{count} éve
+      half_a_minute: fél perce
       less_than_x_minutes:
-        one: kevesebb, mint 1 perc
-        other: kevesebb, mint %{count} perc
+        one: kevesebb, mint 1 perce
+        other: kevesebb, mint %{count} perce
       less_than_x_seconds:
-        one: kevesebb, mint 1 másodperc
-        other: kevesebb, mint %{count} másodperc
+        one: kevesebb, mint 1 másodperce
+        other: kevesebb, mint %{count} másodperce
       over_x_years:
-        one: több, mint 1 év
-        other: több, mint %{count} év
+        one: több, mint 1 éve
+        other: több, mint %{count} éve
       x_days:
-        one: 1 nap
-        other: ! '%{count} nap'
+        one: 1 napja
+        other: ! '%{count} napja'
       x_minutes:
-        one: 1 perc
-        other: ! '%{count} perc'
+        one: 1 perce
+        other: ! '%{count} perce'
       x_months:
-        one: 1 hónap
-        other: ! '%{count} hónap'
+        one: 1 hónapja
+        other: ! '%{count} hónapja'
       x_seconds:
-        one: 1 másodperc
-        other: ! '%{count} másodperc'
+        one: 1 másodperce
+        other: ! '%{count} másodperce'
     prompts:
       day: Nap
       hour: Óra


### PR DESCRIPTION
Making Hungarian datetime.distance_in_words translations much nicer with proper endings. In Hungarian you need these endings to actually mean that the time is x "ago". I believe this should be used as many I18N libs for other languages do the same translation.
