### PR TITLE
Fix incomplete NL locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,14 +56,14 @@ Available locales are:
 
 Following locales are complete:
 
-> bs, da, en, hr, is, ja, sr, zh-HK
+> bs, da, en, hr, is, ja, nl, sr, zh-HK
 
 Following locales have some missing translations or pluralizations:
 
 > af, ar, az, bg, bn, ca, cs, cy, de, de-AT, de-CH, el, en-AU, en-CA, en-GB, en-IE, en-IN, en-NZ, eo,
 > es, es-419, es-AR, es-CL, es-CO, es-CR, es-MX, es-PE, es-VE, et, eu, fa, fi, fr, fr-CA, fr-CH,
 > gl, he, hi, hi-IN, hu, id, it, it-CH, kn, ko, lo, lt, lv, mk, mn, ms, nb,
-> ne, nl, nn, or, pl, pt, pt-BR, rm, ro, ru, sk, sl, sv, sw, th,
+> ne, nn, or, pl, pt, pt-BR, rm, ro, ru, sk, sl, sv, sw, th,
 > tl, tr, uk, uz, vi, wo, zh-CN, zh-TW
 
 We always welcome your contributions!

--- a/rails/locale/nl.yml
+++ b/rails/locale/nl.yml
@@ -100,6 +100,7 @@ nl:
     messages:
       accepted: moet worden geaccepteerd
       blank: moet opgegeven zijn
+      present: moet leeg zijn
       confirmation: komt niet met de bevestiging overeen
       empty: moet opgegeven zijn
       equal_to: moet gelijk zijn aan %{count}
@@ -115,10 +116,20 @@ nl:
       not_an_integer: moet een geheel getal zijn
       odd: moet oneven zijn
       record_invalid: ! 'Validatie mislukt: %{errors}'
+      restrict_dependent_destroy:
+        one: "Kan item niet verwijderen omdat %{record} afhankelijk is"
+        many: "Kan item niet verwijderen omdat afhankelijke %{record} bestaan"
       taken: is al in gebruik
-      too_long: is te lang (maximaal %{count} tekens)
-      too_short: is te kort (minimaal %{count} tekens)
-      wrong_length: heeft onjuiste lengte (moet %{count} tekens lang zijn)
+      too_long:
+        one: is te lang (maximaal %{count} teken)
+        other: is te lang (maximaal %{count} tekens)
+      too_short:
+        one: is te kort (minimaal %{count} teken)
+        other: is te kort (minimaal %{count} tekens)
+      wrong_length:
+        one: heeft onjuiste lengte (moet %{count} teken lang zijn)
+        other: heeft onjuiste lengte (moet %{count} tekens lang zijn)
+      other_than: "moet anders zijn dan %{count}"
     template:
       body: ! 'Controleer de volgende velden:'
       header:
@@ -175,6 +186,7 @@ nl:
     percentage:
       format:
         delimiter: ''
+        format: "%n%"
     precision:
       format:
         delimiter: ''


### PR DESCRIPTION
Added missing entries in nl.yml for Dutch locale.

`i18n-spec` is passing on my machine, but please check to see if everything is actually complete.
