### PR TITLE
Fix typo

### DIFF
--- a/rails/locale/es-419.yml
+++ b/rails/locale/es-419.yml
@@ -116,7 +116,7 @@ es-419:
       exclusion: está reservado
       greater_than: debe ser mayor que %{count}
       greater_than_or_equal_to: debe ser mayor o igual que %{count}
-      inclusion: no está incluído en la lista
+      inclusion: no está incluido en la lista
       invalid: es inválido
       less_than: debe ser menor que %{count}
       less_than_or_equal_to: debe ser menor o igual que %{count}

--- a/rails/locale/es-AR.yml
+++ b/rails/locale/es-AR.yml
@@ -107,7 +107,7 @@ es-AR:
       exclusion: está reservado
       greater_than: debe ser mayor que %{count}
       greater_than_or_equal_to: debe ser mayor o igual que %{count}
-      inclusion: no está incluído en la lista
+      inclusion: no está incluido en la lista
       invalid: es inválido
       less_than: debe ser menor que %{count}
       less_than_or_equal_to: debe ser menor o igual que %{count}

--- a/rails/locale/es-CO.yml
+++ b/rails/locale/es-CO.yml
@@ -107,7 +107,7 @@ es-CO:
       exclusion: está reservado
       greater_than: debe ser mayor que %{count}
       greater_than_or_equal_to: debe ser mayor o igual que %{count}
-      inclusion: no está incluído en la lista
+      inclusion: no está incluido en la lista
       invalid: es inválido
       less_than: debe ser menor que %{count}
       less_than_or_equal_to: debe ser menor o igual que %{count}

--- a/rails/locale/es-CR.yml
+++ b/rails/locale/es-CR.yml
@@ -107,7 +107,7 @@ es-CR:
       exclusion: está reservado
       greater_than: debe ser mayor que %{count}
       greater_than_or_equal_to: debe ser mayor o igual que %{count}
-      inclusion: no está incluído en la lista
+      inclusion: no está incluido en la lista
       invalid: es inválido
       less_than: debe ser menor que %{count}
       less_than_or_equal_to: debe ser menor o igual que %{count}

--- a/rails/locale/es-MX.yml
+++ b/rails/locale/es-MX.yml
@@ -107,7 +107,7 @@ es-MX:
       exclusion: está reservado
       greater_than: debe ser mayor que %{count}
       greater_than_or_equal_to: debe ser mayor o igual que %{count}
-      inclusion: no está incluído en la lista
+      inclusion: no está incluido en la lista
       invalid: es inválido
       less_than: debe ser menor que %{count}
       less_than_or_equal_to: debe ser menor o igual que %{count}

--- a/rails/locale/es-PA.yml
+++ b/rails/locale/es-PA.yml
@@ -108,7 +108,7 @@ es-PA:
       exclusion: está reservado
       greater_than: debe ser mayor que %{count}
       greater_than_or_equal_to: debe ser mayor que o igual a %{count}
-      inclusion: no está incluído en la lista
+      inclusion: no está incluido en la lista
       invalid: no es válido
       less_than: debe ser menor que %{count}
       less_than_or_equal_to: debe ser menor que o igual a %{count}

--- a/rails/locale/es-PE.yml
+++ b/rails/locale/es-PE.yml
@@ -104,7 +104,7 @@ es-PE:
       exclusion: está reservado
       greater_than: debe ser mayor que %{count}
       greater_than_or_equal_to: debe ser mayor o igual que %{count}
-      inclusion: no está incluído en la lista
+      inclusion: no está incluido en la lista
       invalid: es inválido
       less_than: debe ser menor que %{count}
       less_than_or_equal_to: debe ser menor o igual que %{count}

--- a/rails/locale/es-VE.yml
+++ b/rails/locale/es-VE.yml
@@ -107,7 +107,7 @@ es-VE:
       exclusion: está reservado
       greater_than: debe ser mayor que %{count}
       greater_than_or_equal_to: debe ser mayor o igual que %{count}
-      inclusion: no está incluído en la lista
+      inclusion: no está incluido en la lista
       invalid: no es válido
       less_than: debe ser menor que %{count}
       less_than_or_equal_to: debe ser menor o igual que %{count}


### PR DESCRIPTION
The participle of `incluir` (`include` in Spanish) is `incluido`.
