### PR TITLE
remove white space between attribute and message in Chinese language

### DIFF
--- a/rails/locale/zh-CN.yml
+++ b/rails/locale/zh-CN.yml
@@ -96,7 +96,7 @@ zh-CN:
       second: 秒
       year: 年
   errors: &errors
-    format: ! '%{attribute} %{message}'
+    format: ! '%{attribute}%{message}'
     messages:
       accepted: 必须是可被接受的
       blank: 不能为空字符


### PR DESCRIPTION
remove white space between attribute and message in Chinese language error message, fixes #385
