### PR TITLE
Support rails 4.1.0.beta1

### DIFF
--- a/rails-i18n.gemspec
+++ b/rails-i18n.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = '>= 1.3.5'
 
   s.add_dependency('i18n', '~> 0.6')
-  s.add_dependency('rails', '~> 4.0.0')
+  s.add_dependency('rails', '~> 4.0')
   s.add_development_dependency "rails", "= 4.0.0"
   s.add_development_dependency "rspec-rails", "= 2.14.0"
   s.add_development_dependency "i18n-spec", "= 0.4.0"


### PR DESCRIPTION
Without this, bundler can't satisfy rails dependency.

```
Bundler could not find compatible versions for gem "rails":
  In Gemfile:
    rails-i18n (>= 0) ruby depends on
      rails (~> 4.0.0) ruby

    rails (4.1.0.beta1)
```
