### PR TITLE
Suggestion: Put "Monday" as first day of the week

### DIFF
--- a/rails/locale/de.yml
+++ b/rails/locale/de.yml
@@ -1,13 +1,13 @@
 de:
   date:
     abbr_day_names:
-    - So
     - Mo
     - Di
     - Mi
     - Do
     - Fr
     - Sa
+    - So
     abbr_month_names:
     -
     - Jan
@@ -23,13 +23,13 @@ de:
     - Nov
     - Dez
     day_names:
-    - Sonntag
     - Montag
     - Dienstag
     - Mittwoch
     - Donnerstag
     - Freitag
     - Samstag
+    - Sonntag
     formats:
       default: ! '%d.%m.%Y'
       long: ! '%e. %B %Y'


### PR DESCRIPTION
Recently used a gem that actually got the order of weekdays from the abbreviations in this file. As (I think?) in most German speaking countries "Montag" (Monday) is considered the first day of the week, I'd suggest putting it first in the file as well.

Unless of course the order is some kind of "standard for all locales"...