### PR TITLE
Fix two non-dutch formats

### DIFF
--- a/rails/locale/nl.yml
+++ b/rails/locale/nl.yml
@@ -1,13 +1,13 @@
 nl:
   date:
     abbr_day_names:
-    - zon
-    - maa
-    - din
-    - woe
-    - don
-    - vri
-    - zat
+    - zo
+    - ma
+    - di
+    - wo
+    - do
+    - vr
+    - za
     abbr_month_names:
     -
     - jan
@@ -31,7 +31,7 @@ nl:
     - vrijdag
     - zaterdag
     formats:
-      default: ! '%d/%m/%Y'
+      default: ! '%d-%m-%Y'
       long: ! '%e %B %Y'
       short: ! '%e %b'
     month_names:


### PR DESCRIPTION
In the Netherlands we use two letter week day abbriviations and we use dashes in date formats instead of slashes. This commit will fix it for you.
