### PR TITLE
grammar case fix for ru.yml activerecord confirmation error

### DIFF
--- a/rails/locale/ru.yml
+++ b/rails/locale/ru.yml
@@ -122,7 +122,7 @@ ru:
     messages:
       accepted: нужно подтвердить
       blank: не может быть пустым
-      confirmation: 'не совпадает с  %{attribute}'
+      confirmation: 'не совпадает со значением поля %{attribute}'
       empty: не может быть пустым
       equal_to: может иметь лишь значение, равное %{count}
       even: может иметь лишь нечетное значение


### PR DESCRIPTION
In this case(in russian) attribute name should be presented in genitive grammar case. Usually locales for AR attributes are presented in nominative case. To resolve this problem additional field description could be used ("со значением поля %{attribute}" that means "with %{attribute} field's value").
