### PR TITLE
Update and document i18n-tasks 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,12 +46,12 @@ GEM
     i18n (0.6.9)
     i18n-spec (0.4.0)
       iso
-    i18n-tasks (0.2.14)
+    i18n-tasks (0.3.6)
       activesupport
-      easy_translate
+      easy_translate (>= 0.4.0)
       erubis
       highline
-      rake
+      slop (>= 3.4.7)
       term-ansicolor
       terminal-table
     iso (0.2.0)
@@ -92,6 +92,7 @@ GEM
       rspec-core (~> 2.14.0)
       rspec-expectations (~> 2.14.0)
       rspec-mocks (~> 2.14.0)
+    slop (3.4.7)
     spork (1.0.0rc3)
     sprockets (2.10.1)
       hike (~> 1.2)
@@ -102,15 +103,15 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (~> 2.8)
-    term-ansicolor (1.2.2)
-      tins (~> 0.8)
+    term-ansicolor (1.3.0)
+      tins (~> 1.0)
     terminal-table (1.4.5)
     thor (0.18.1)
     thread (0.1.3)
     thread_safe (0.1.3)
       atomic
     tilt (1.4.1)
-    tins (0.13.1)
+    tins (1.0.0)
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
@@ -121,7 +122,7 @@ PLATFORMS
 
 DEPENDENCIES
   i18n-spec (= 0.4.0)
-  i18n-tasks (~> 0.2.9)
+  i18n-tasks (~> 0.3.6)
   rails (= 4.0.2)
   rails-i18n!
   rspec-rails (= 2.14.0)

--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ Also, you can list all available locales:
 
     thor locales:list
 
+You can list all missing keys:
+
+    i18n-tasks missing es
+
 ### Edit README.md
 
 Add your locale name to the list in `README.md` if it isn't there.

--- a/Rakefile
+++ b/Rakefile
@@ -34,6 +34,4 @@ end
 
 require 'i18n-spec/tasks' # needs to be loaded after rspec
 
-load 'tasks/i18n-tasks.rake'
-
 task :default => :spec

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -1,8 +1,7 @@
-base_locale: 'en'
-locales: <%= Dir['rails/locale/*.yml'].map { |f| File.basename(f, '.yml') }.inspect %>
+base_locale: en
 
 data:
-  adapter: yaml
+  adapter: file_system
   read:
     - "rails/locale/%{locale}.yml"
   write:
@@ -12,19 +11,16 @@ search:
   paths: ['lib/']
 
 ignore_missing:
-  - number.precision.format.*
-  - 'number.percentage.format.{format,delimiter}'
-  - number.{human,percentage}.format.delimiter
-  - number.human.decimal_units.units.unit
-  - number.{format, human.format, currency.format}.{strip_insignificant_zeros,significant,delimiter}
+  - 'number.{precision, format, :.format}.{strip_insignificant_zeros, significant, format, delimiter, format.delimiter}'
+  - 'number.human.decimal_units.units.unit'
   - 'time.{pm,am}'
 
 ignore_eq_base:
   all:
     - 'number.*'
-    - '{activerecord,activemodel}.errors.format'
     - 'time.{pm,am,formats.*}'
     - 'date.{order,formats.*}'
+    - '{activerecord, activemodel}.errors.format'
     - errors.format
     - support.array.words_connector
 

--- a/rails-i18n.gemspec
+++ b/rails-i18n.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec-rails", "= 2.14.0"
   s.add_development_dependency "i18n-spec", "= 0.4.0"
   s.add_development_dependency "spork", "= 1.0.0rc3"
-  s.add_development_dependency 'i18n-tasks', '~> 0.2.9'
+  s.add_development_dependency 'i18n-tasks', '~> 0.3.6'
 end


### PR DESCRIPTION
Update [i18n-tasks](https://github.com/glebm/i18n-tasks) to v0.3.6 and document how to get missing keys with it
- Remove `load "tasks/i18n-tasks.rake'` from Rakefile since i18n-tasks is now an executable.
- i18n-tasks.yml.erb -> i18n-tasks.yml. Available locales are now picked up automatically
