### PR TITLE
Makes the confirmation message more meaningful in pt-BR

### DIFF
--- a/rails/locale/pt-BR.yml
+++ b/rails/locale/pt-BR.yml
@@ -101,7 +101,7 @@ pt-BR:
       accepted: deve ser aceito
       blank: não pode ficar em branco
       present: deve ficar em branco
-      confirmation: não está de acordo com a confirmação
+      confirmation: não é igual a %{attribute}
       empty: não pode ficar vazio
       equal_to: deve ser igual a %{count}
       even: deve ser par


### PR DESCRIPTION
Includes the %{attribute} in the message, and makes the message more
Brazilian Portuguese meaningful
