### PR TITLE
Fix RTL order of submit lables in he locale

### DIFF
--- a/rails/locale/he.yml
+++ b/rails/locale/he.yml
@@ -130,9 +130,9 @@ he:
     select:
       prompt: נא לבחור
     submit:
-      create: ! '%{model} יצירת'
-      submit: ! '%{model} שמור'
-      update: ! '%{model} עדכון'
+      create: ! 'יצירת %{model}'
+      submit: ! 'שמור %{model}'
+      update: ! 'עדכון %{model}'
   number:
     currency:
       format:


### PR DESCRIPTION
Labels on submit buttons was in the format of "%{model} %{action}", but Hebrew dictates the opposite order, i.e. "%{action} %{model}".

For example, "יצירת חשבון" instead of "חשבון יצירת".
