### PR TITLE
Update rails-i18n.gemspec

### DIFF
--- a/rails-i18n.gemspec
+++ b/rails-i18n.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = '>= 1.3.5'
 
   s.add_dependency('i18n', '~> 0.6')
-  s.add_dependency('rails', '~> 4.0')
+  s.add_dependency('rails', '>= 4.0')
   s.add_development_dependency "rails", "= 4.0.2"
   s.add_development_dependency "rspec-rails", "= 2.14.0"
   s.add_development_dependency "i18n-spec", "= 0.4.0"


### PR DESCRIPTION
```
rails-i18n at /home/myuser/.rvm/gems/ruby-2.1.0@rails403/bundler/gems/rails-i18n-6b****39 did not have a valid gemspec.
This prevents bundler from installing bins or native extensions, but that may not affect its functionality.
The validation message from Rubygems was:
  duplicate dependency on rails (= 4.0.2, development), (~> 4.0) use:
    add_runtime_dependency 'rails', '= 4.0.2', '~> 4.0'
```
