### PR TITLE
Update en-IN.yml

### DIFF
--- a/rails/locale/en-IN.yml
+++ b/rails/locale/en-IN.yml
@@ -31,7 +31,7 @@ en-IN:
     - Friday
     - Saturday
     formats:
-      default: ! '%Y-%m-%d'
+      default: ! '%d-%m-%Y'
       long: ! '%B %d, %Y'
       short: ! '%b %d'
     month_names:


### PR DESCRIPTION
Default format for Expressing dates in Indian (English) or EN-IN is DD-MM-YY.
Updated accordingly.

This is in correction and verification of Issue no. #378
