### PR TITLE
Make date formatting similar to other locales

### DIFF
--- a/rails/locale/fi.yml
+++ b/rails/locale/fi.yml
@@ -31,9 +31,9 @@ fi:
     - perjantai
     - lauantai
     formats:
-      default: ! '%e. %Bta %Y'
+      default: ! '%-d.%-m.%Y'
       long: ! '%A %e. %Bta %Y'
-      short: ! '%e.%m.%Y'
+      short: ! '%d. %b'
     month_names:
     -
     - tammikuu


### PR DESCRIPTION
Most other locales use plain numeric format as the default format for
dates. Finnish locale used the long format as default format.

Also change the day and month to use non-padded formats by default.
