### PR TITLE
changed too_long and too_short in he.yml file

### DIFF
--- a/rails/locale/he.yml
+++ b/rails/locale/he.yml
@@ -118,8 +118,8 @@ he:
       odd: חייב להיות אי זוגי
       record_invalid: ! 'האימות נכשל: %{errors}'
       taken: כבר בשימוש
-      too_long: "יותר מדי ארוך (לא יותר מ- %{count} תווים)"
-      too_short: "יותר מדי קצר (לא פחות  מ- %{count} תווים)"
+      too_long: "ארוך מדי (יותר מ- %{count} תווים)"
+      too_short: "קצר מדי (פחות מ- %{count} תווים)"
       wrong_length: "לא באורך הנכון (חייב להיות %{count} תווים)"
     template:
       body: ! 'אנא בדוק את השדות הבאים:'


### PR DESCRIPTION
Changed "too_long" and "too_short" definitions in rails/locales/he.yml, thought there is a better way for writing it in hebrew.
