### PR TITLE
Update nl.errors.messages.confirmation

### DIFF
--- a/rails/locale/nl.yml
+++ b/rails/locale/nl.yml
@@ -101,7 +101,7 @@ nl:
       accepted: moet worden geaccepteerd
       blank: moet opgegeven zijn
       present: moet leeg zijn
-      confirmation: komt niet met de bevestiging overeen
+      confirmation: ! "komt niet overeen met %{attribute}"
       empty: moet opgegeven zijn
       equal_to: moet gelijk zijn aan %{count}
       even: moet even zijn


### PR DESCRIPTION
Now matches `en.errors.messages.confirmation`, show attribute name of confirmation in message.
Previously it stated "doesn't match confirmation", but this is incorrect as the message is shown at the confirmation field.
