### PR TITLE
Remove duplicate month symbol in Korean

### DIFF
--- a/rails/locale/ko.yml
+++ b/rails/locale/ko.yml
@@ -185,6 +185,6 @@ ko:
     am: 오전
     formats:
       default: ! '%Y/%m/%d %H:%M:%S'
-      long: ! '%Y년 %B월 %d일, %H시 %M분 %S초 %Z'
+      long: ! '%Y년 %m월 %d일, %H시 %M분 %S초 %Z'
       short: ! '%y/%m/%d %H:%M'
     pm: 오후


### PR DESCRIPTION
Previous format `'%Y년 %B월 %d일, %H시 %M분 %S초 %Z'` renders:

2014년 **6월월** 12일, 12시 30분 00초 +09:00

In this case, the 월 char is incorrectly printed twice. By changing %B to %m we can avoid this.
