### PR TITLE
default time format

### DIFF
--- a/rails/locale/en.yml
+++ b/rails/locale/en.yml
@@ -198,7 +198,7 @@ en:
   time:
     am: am
     formats:
-      default: ! '%a, %d %b %Y %H:%M:%S %z'
-      long: ! '%B %d, %Y %H:%M'
+      default: ! '%B %d, %Y %H:%M'
+      long: ! '%a, %d %b %Y %H:%M:%S %z'
       short: ! '%d %b %H:%M'
     pm: pm


### PR DESCRIPTION
the long time format should be longer than the default time format. We should switch the two around
