### PR TITLE
Revert "Capitalize month and day names for fr, fr-CA, fr-CH"

### DIFF
--- a/rails/locale/fr-CA.yml
+++ b/rails/locale/fr-CA.yml
@@ -1,53 +1,53 @@
 fr-CA:
   date:
     abbr_day_names:
-    - Dim
-    - Lun
-    - Mar
-    - Mer
-    - Jeu
-    - Ven
-    - Sam
+    - dim
+    - lun
+    - mar
+    - mer
+    - jeu
+    - ven
+    - sam
     abbr_month_names:
     -
-    - Jan.
-    - Fév.
-    - Mar.
-    - Avr.
-    - Mai
-    - Juin
-    - Juil.
-    - Août
-    - Sept.
-    - Oct.
-    - Nov.
-    - Déc.
+    - jan.
+    - fév.
+    - mar.
+    - avr.
+    - mai
+    - juin
+    - juil.
+    - août
+    - sept.
+    - oct.
+    - nov.
+    - déc.
     day_names:
-    - Dimanche
-    - Lundi
-    - Mardi
-    - Mercredi
-    - Jeudi
-    - Vendredi
-    - Samedi
+    - dimanche
+    - lundi
+    - mardi
+    - mercredi
+    - jeudi
+    - vendredi
+    - samedi
     formats:
       default: ! '%Y-%m-%d'
       long: ! '%d %B %Y'
       short: ! '%y-%m-%d'
     month_names:
     -
-    - Janvier
-    - Février
-    - Mars
-    - Avril
-    - Mai
-    - Juin
-    - Juillet
-    - Août
-    - Septembre
-    - Octobre
-    - Novembre
-    - Décembre
+    - janvier
+    - février
+    - mars
+    - avril
+    - mai
+    - juin
+    - juillet
+    - août
+    - septembre
+    - octobre
+    - novembre
+    - décembre
     order:
     - :year
     - :month

--- a/rails/locale/fr-CH.yml
+++ b/rails/locale/fr-CH.yml
@@ -1,53 +1,53 @@
 fr-CH:
   date:
     abbr_day_names:
-    - Dim
-    - Lun
-    - Mar
-    - Mer
-    - Jeu
-    - Ven
-    - Sam
+    - dim
+    - lun
+    - mar
+    - mer
+    - jeu
+    - ven
+    - sam
     abbr_month_names:
     -
-    - Jan.
-    - Fév.
-    - Mar.
-    - Avr.
-    - Mai
-    - Juin
-    - Juil.
-    - Août
-    - Sept.
-    - Oct.
-    - Nov.
-    - Déc.
+    - jan.
+    - fév.
+    - mar.
+    - avr.
+    - mai
+    - juin
+    - juil.
+    - août
+    - sept.
+    - oct.
+    - nov.
+    - déc.
     day_names:
-    - Dimanche
-    - Lundi
-    - Mardi
-    - Mercredi
-    - Jeudi
-    - Vendredi
-    - Samedi
+    - dimanche
+    - lundi
+    - mardi
+    - mercredi
+    - jeudi
+    - vendredi
+    - samedi
     formats:
       default: ! '%d.%m.%Y'
       long: ! '%e %B %Y'
       short: ! '%e %b'
     month_names:
     -
-    - Janvier
-    - Février
-    - Mars
-    - Avril
-    - Mai
-    - Juin
-    - Juillet
-    - Août
-    - Septembre
-    - Octobre
-    - Novembre
-    - Décembre
+    - janvier
+    - février
+    - mars
+    - avril
+    - mai
+    - juin
+    - juillet
+    - août
+    - septembre
+    - octobre
+    - novembre
+    - décembre
     order:
     - :day
     - :month

--- a/rails/locale/fr.yml
+++ b/rails/locale/fr.yml
@@ -9,53 +9,53 @@
 fr:
   date:
     abbr_day_names:
-      - Dim
-      - Lun
-      - Mar
-      - Mer
-      - Jeu
-      - Ven
-      - Sam
+      - dim
+      - lun
+      - mar
+      - mer
+      - jeu
+      - ven
+      - sam
     abbr_month_names:
       - ~
-      - Jan.
-      - Fév.
-      - Mar.
-      - Avr.
-      - Mai
-      - Juin
-      - Juil.
-      - Août
-      - Sept.
-      - Oct.
-      - Nov.
-      - Déc.
+      - jan.
+      - fév.
+      - mar.
+      - avr.
+      - mai
+      - juin
+      - juil.
+      - août
+      - sept.
+      - oct.
+      - nov.
+      - déc.
     day_names:
-      - Dimanche
-      - Lundi
-      - Mardi
-      - Mercredi
-      - Jeudi
-      - Vendredi
-      - Samedi
+      - dimanche
+      - lundi
+      - mardi
+      - mercredi
+      - jeudi
+      - vendredi
+      - samedi
     formats:
       default: "%d/%m/%Y"
       short: "%e %b"
       long: "%e %B %Y"
     month_names:
       - ~
-      - Janvier
-      - Février
-      - Mars
-      - Avril
-      - Mai
-      - Juin
-      - Juillet
-      - Août
-      - Septembre
-      - Octobre
-      - Novembre
-      - Décembre
+      - janvier
+      - février
+      - mars
+      - avril
+      - mai
+      - juin
+      - juillet
+      - août
+      - septembre
+      - octobre
+      - novembre
+      - décembre
     order:
       - :day
       - :month


### PR DESCRIPTION
French days names and months shouldn't be capitalized. 
For reference (fr) : [Academie Francaise](http://www.academie-francaise.fr/la-langue-francaise/questions-de-langue#42_strong-em-jours-de-la-semaine-pluriel-et-majuscules-em-strong) or [Wikipedia](http://fr.wikipedia.org/wiki/Usage_des_majuscules_en_fran%C3%A7ais#Jours_de_la_semaine_et_mois_de_l.27ann.C3.A9e)

This reverts commit 327b840ae2dff282f94fcf31a2edf0e16d2c0ab8.
