### PR TITLE
Correct French 24 hour notation.

### DIFF
--- a/rails/locale/fr-CA.yml
+++ b/rails/locale/fr-CA.yml
@@ -194,7 +194,7 @@ fr-CA:
   time:
     am: am
     formats:
-      default: ! '%H:%M:%S'
-      long: ! '%A %d %B %Y %H:%M'
-      short: ! '%H:%M'
+      default: ! '%H h %M min %S s'
+      long: ! '%A %d %B %Y %H h %M'
+      short: ! '%H h %M'
     pm: pm

--- a/rails/locale/fr-CH.yml
+++ b/rails/locale/fr-CH.yml
@@ -194,7 +194,7 @@ fr-CH:
   time:
     am: am
     formats:
-      default: ! '%d. %B %Y %H:%M'
-      long: ! '%A, %d. %B %Y %H:%M:%S %Z'
-      short: ! '%d. %b %H:%M'
+      default: ! '%d. %B %Y %H h %M'
+      long: ! '%A, %d %B %Y %H h %M min %S s %Z'
+      short: ! '%d %b %H h %M'
     pm: pm

--- a/rails/locale/fr.yml
+++ b/rails/locale/fr.yml
@@ -208,7 +208,7 @@ fr:
   time:
     am: 'am'
     formats:
-      default: "%d %B %Y %H:%M:%S"
-      long: "%A %d %B %Y %H:%M"
-      short: "%d %b %H:%M"
+      default: "%d %B %Y %H h %M min %S s"
+      long: "%A %d %B %Y %H h %M"
+      short: "%d %b %H h %M"
     pm: 'pm'


### PR DESCRIPTION
Fixes #437
Added **h**, **min** and **s** separators with spaces on both sides as discussed in #437 comments
