### PR TITLE
Include attribute name in confirmation error message

### DIFF
--- a/rails/locale/en-AU.yml
+++ b/rails/locale/en-AU.yml
@@ -100,7 +100,7 @@ en-AU:
     messages:
       accepted: must be accepted
       blank: can't be blank
-      confirmation: doesn't match confirmation
+      confirmation: ! "doesn't match %{attribute}"
       empty: can't be empty
       equal_to: must be equal to %{count}
       even: must be even

--- a/rails/locale/en-CA.yml
+++ b/rails/locale/en-CA.yml
@@ -109,7 +109,7 @@ en-CA:
     messages:
       accepted: must be accepted
       blank: can't be blank
-      confirmation: doesn't match confirmation
+      confirmation: ! "doesn't match %{attribute}"
       empty: can't be empty
       equal_to: must be equal to %{count}
       even: must be even

--- a/rails/locale/en-GB.yml
+++ b/rails/locale/en-GB.yml
@@ -100,7 +100,7 @@ en-GB:
     messages:
       accepted: must be accepted
       blank: can't be blank
-      confirmation: doesn't match confirmation
+      confirmation: ! "doesn't match %{attribute}"
       empty: can't be empty
       equal_to: must be equal to %{count}
       even: must be even

--- a/rails/locale/en-IE.yml
+++ b/rails/locale/en-IE.yml
@@ -100,7 +100,7 @@ en-IE:
     messages:
       accepted: must be accepted
       blank: can't be blank
-      confirmation: doesn't match confirmation
+      confirmation: ! "doesn't match %{attribute}"
       empty: can't be empty
       equal_to: must be equal to %{count}
       even: must be even

--- a/rails/locale/en-IN.yml
+++ b/rails/locale/en-IN.yml
@@ -100,7 +100,7 @@ en-IN:
     messages:
       accepted: must be accepted
       blank: can't be blank
-      confirmation: doesn't match confirmation
+      confirmation: ! "doesn't match %{attribute}"
       empty: can't be empty
       equal_to: must be equal to %{count}
       even: must be even

--- a/rails/locale/en-NZ.yml
+++ b/rails/locale/en-NZ.yml
@@ -100,7 +100,7 @@ en-NZ:
     messages:
       accepted: must be accepted
       blank: can't be blank
-      confirmation: doesn't match confirmation
+      confirmation: ! "doesn't match %{attribute}"
       empty: can't be empty
       equal_to: must be equal to %{count}
       even: must be even

--- a/rails/locale/id.yml
+++ b/rails/locale/id.yml
@@ -102,7 +102,7 @@ id:
     messages:
       accepted: harus diterima
       blank: tidak bisa kosong
-      confirmation: tidak sesuai dengan konfirmasi
+      confirmation: ! 'tidak sesuai dengan %{attribute}'
       empty: tidak bisa kosong
       equal_to: harus sama dengan %{count}
       even: harus genap

--- a/rails/locale/wo.yml
+++ b/rails/locale/wo.yml
@@ -100,7 +100,7 @@ wo:
     messages:
       accepted: must be accepted
       blank: can't be blank
-      confirmation: doesn't match confirmation
+      confirmation: ! "doesn't match %{attribute}"
       empty: can't be empty
       equal_to: must be equal to %{count}
       even: must be even


### PR DESCRIPTION
For locales `en-*` and `id`.

Follows en.yml change in rails/rails@fcc534e

See: rails/rails#5942

Totally not copypasting off d3dac51.
