### PR TITLE
fix east slavic pluralization for float numbers

### DIFF
--- a/lib/rails_i18n/common_pluralizations/east_slavic.rb
+++ b/lib/rails_i18n/common_pluralizations/east_slavic.rb
@@ -7,10 +7,10 @@ module RailsI18n
   module Pluralization
     module EastSlavic
 
-      FROM_2_TO_4   = (2..4).to_set
-      FROM_5_TO_9   = (5..9).to_set
-      FROM_11_TO_14 = (11..14).to_set
-      FROM_12_TO_14 = (12..14).to_set
+      FROM_2_TO_4   = (2..4).to_a.freeze
+      FROM_5_TO_9   = (5..9).to_a.freeze
+      FROM_11_TO_14 = (11..14).to_a.freeze
+      FROM_12_TO_14 = (12..14).to_a.freeze
 
       def self.rule
         lambda do |n|


### PR DESCRIPTION
``` ruby
(2..4).to_set.include?(3.0) => false
(2..4).to_a.include?(3.0) => true
```
