### PR TITLE
Change confirmation error message  for es-* locales

### DIFF
--- a/rails/locale/es-419.yml
+++ b/rails/locale/es-419.yml
@@ -109,7 +109,7 @@ es-419:
     messages:
       accepted: debe ser aceptado
       blank: no puede estar en blanco
-      confirmation: no coincide con la confirmación
+      confirmation: no coincide
       empty: no puede estar vacío
       equal_to: debe ser igual a %{count}
       even: debe ser un número par

--- a/rails/locale/es-AR.yml
+++ b/rails/locale/es-AR.yml
@@ -100,7 +100,7 @@ es-AR:
     messages:
       accepted: debe ser aceptado
       blank: no puede estar en blanco
-      confirmation: no coincide con la confirmación
+      confirmation: no coincide
       empty: no puede estar vacío
       equal_to: debe ser igual a %{count}
       even: debe ser un número par

--- a/rails/locale/es-CL.yml
+++ b/rails/locale/es-CL.yml
@@ -100,7 +100,7 @@ es-CL:
     messages:
       accepted: debe ser aceptado
       blank: no puede estar en blanco
-      confirmation: no coincide con la confirmación
+      confirmation: no coincide
       empty: no puede estar vacío
       equal_to: debe ser igual a %{count}
       even: debe ser par

--- a/rails/locale/es-CO.yml
+++ b/rails/locale/es-CO.yml
@@ -100,7 +100,7 @@ es-CO:
     messages:
       accepted: debe ser aceptado
       blank: no puede estar en blanco
-      confirmation: no coincide con la confirmación
+      confirmation: no coincide
       empty: no puede estar vacío
       equal_to: debe ser igual a %{count}
       even: debe ser un número par

--- a/rails/locale/es-CR.yml
+++ b/rails/locale/es-CR.yml
@@ -100,7 +100,7 @@ es-CR:
     messages:
       accepted: debe ser aceptado
       blank: no puede estar en blanco
-      confirmation: no coincide con la confirmación
+      confirmation: no coincide
       empty: no puede estar vacío
       equal_to: debe ser igual a %{count}
       even: debe ser un número par

--- a/rails/locale/es-EC.yml
+++ b/rails/locale/es-EC.yml
@@ -101,7 +101,7 @@ es-EC:
       accepted: debe ser aceptado
       blank: no puede estar en blanco
       present: debe estar en blanco
-      confirmation: no coincide con la confirmación
+      confirmation: no coincide
       empty: no puede estar vacío
       equal_to: debe ser igual a %{count}
       even: debe ser un número par

--- a/rails/locale/es-MX.yml
+++ b/rails/locale/es-MX.yml
@@ -101,7 +101,7 @@ es-MX:
       accepted: debe ser aceptado
       blank: no puede estar en blanco
       present: debe estar en blanco
-      confirmation: no coincide con la confirmación
+      confirmation: no coincide
       empty: no puede estar vacío
       equal_to: debe ser igual a %{count}
       even: debe ser un número par

--- a/rails/locale/es-PA.yml
+++ b/rails/locale/es-PA.yml
@@ -101,7 +101,7 @@ es-PA:
       accepted: debe ser aceptado
       blank: no puede estar en blanco
       present: debe estar en blanco
-      confirmation: no coincide con la confirmación
+      confirmation: no coincide
       empty: no puede estar vacío
       equal_to: debe ser igual a %{count}
       even: debe ser un número par

--- a/rails/locale/es-PE.yml
+++ b/rails/locale/es-PE.yml
@@ -97,7 +97,7 @@ es-PE:
     messages:
       accepted: debe ser aceptado
       blank: no puede estar en blanco
-      confirmation: no coincide con la confirmación
+      confirmation: no coincide
       empty: no puede estar vacío
       equal_to: debe ser igual a %{count}
       even: debe ser un número par

--- a/rails/locale/es-US.yml
+++ b/rails/locale/es-US.yml
@@ -100,7 +100,7 @@ es-US:
     messages:
       accepted: debe ser aceptado
       blank: no puede estar en blanco
-      confirmation: no coincide con la confirmación
+      confirmation: no coincide
       empty: no puede estar vacío
       equal_to: debe ser igual a %{count}
       even: debe ser un número par

--- a/rails/locale/es-VE.yml
+++ b/rails/locale/es-VE.yml
@@ -100,7 +100,7 @@ es-VE:
     messages:
       accepted: debe ser aceptado
       blank: no puede estar en blanco
-      confirmation: no coincide con la confirmación
+      confirmation: no coincide
       empty: no puede estar vacío
       equal_to: debe ser igual a %{count}
       even: debe ser un número par

--- a/rails/locale/es.yml
+++ b/rails/locale/es.yml
@@ -100,7 +100,7 @@ es:
     messages:
       accepted: debe ser aceptado
       blank: no puede estar en blanco
-      confirmation: no coincide con la confirmación
+      confirmation: no coincide
       empty: no puede estar vacío
       equal_to: debe ser igual a %{count}
       even: debe ser par


### PR DESCRIPTION
This follows the changes introduced in rails/rails#5942, but does not include the attribute name in the message because it reads weird and it would require adding an article, which in turn would require knowing the grammatical gender of the attribute. E.g., "no coincide con _la_ contraseña" or "no coincide con _el_ número de cuenta". I think simply saying "no coincide" (lit. "does not match") in the context of a confirmation field is enough to figure out what is wrong.
