### PR TITLE
Change Swedish taken error message.

### DIFF
--- a/rails/locale/sv.yml
+++ b/rails/locale/sv.yml
@@ -115,7 +115,7 @@ sv:
       not_an_integer: måste vara ett heltal
       odd: måste vara udda
       record_invalid: ! 'Ett fel uppstod: %{errors}'
-      taken: har redan tagits
+      taken: används redan
       too_long: är för lång (maximum är %{count} tecken)
       too_short: är för kort (minimum är %{count} tecken)
       wrong_length: har fel längd (ska vara %{count} tecken)


### PR DESCRIPTION
I think "används redan" reads better than "har redan tagits" in Swedish.

Example: "Artikelnummer har redan tagits" / "Artikelnummer används redan"
