### PR TITLE
Don't use Swiss German

### DIFF
--- a/rails/locale/de-CH.yml
+++ b/rails/locale/de-CH.yml
@@ -116,8 +116,8 @@ de-CH:
       odd: muss ungerade sein
       record_invalid: ! 'Gültigkeitsprüfung ist fehlgeschlagen: %{errors}'
       restrict_dependent_destroy:
-        one: S lösche hät nöd funktioniert wills no en anhängige %{record} git
-        many: S lösche hät nöd funktioniert wills no anhängigi %{record} git
+        one: ! 'Datensatz kann nicht gelöscht werden, da ein abhängiger %{record}-Datensatz existiert.'
+        many: ! 'Datensatz kann nicht gelöscht werden, da abhängige %{record} existieren.'
       taken: ist bereits vergeben
       too_long: ist zu lang (nicht mehr als %{count} Zeichen)
       too_short: ist zu kurz (nicht weniger als %{count} Zeichen)


### PR DESCRIPTION
All the other translations in this file use standard German, and nobody really uses Swiss German on websites anyway ;-) The new translation was taken from `de.yml`.
Also [see this comment](https://github.com/svenfuchs/rails-i18n/commit/f88496c3692611a188b264f34a9660b8868dca05#commitcomment-6728593).
