### PR TITLE
Fix confirmation error message for Italian.

### DIFF
--- a/rails/locale/it-CH.yml
+++ b/rails/locale/it-CH.yml
@@ -101,7 +101,7 @@ it-CH:
     messages:
       accepted: deve essere accettata
       blank: non può essere lasciato in bianco
-      confirmation: non coincide con la conferma
+      confirmation: non coincide con %{attribute}
       empty: non può essere vuoto
       equal_to: deve essere uguale a %{count}
       even: deve essere pari

--- a/rails/locale/it.yml
+++ b/rails/locale/it.yml
@@ -102,7 +102,7 @@ it:
       accepted: deve essere accettata
       blank: non può essere lasciato in bianco
       present: deve essere lasciato in bianco
-      confirmation: non coincide con la conferma
+      confirmation: non coincide con %{attribute}
       empty: non può essere vuoto
       equal_to: deve essere uguale a %{count}
       even: deve essere pari


### PR DESCRIPTION
The errors.messages.confirmation string is still obsolete, without the
%{attribute} parameter.