### PR TITLE
Fix "i18n" gem dependency

### DIFF
--- a/rails-i18n.gemspec
+++ b/rails-i18n.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project = '[none]'
   s.required_rubygems_version = '>= 1.3.5'
 
-  s.add_runtime_dependency "i18n", "~> 0.5"
+  s.add_runtime_dependency "i18n", "~> 0.5", "< 0.7.0.beta1"
   s.add_runtime_dependency "rails", ">= 3.0.0", "< 4.0.0"
   s.add_development_dependency "rspec-rails", "= 2.14.0"
   s.add_development_dependency "i18n-spec", "= 0.3.0"


### PR DESCRIPTION
Hi, 

I have an error when I use `i18n 0.7.0.beta1` gem in my Gemfile with `rails 3.2.21`:
```
cannot load such file -- i18n/core_ext/string/interpolate
.../ruby/2.1.0/gems/activesupport-3.2.21/lib/active_support/core_ext/string/interpolation.rb:2:in `require'
```

To fix it I suggest to lock version dependency below `0.7.0.beta1`.