### PR TITLE
Remove exclamation marks

### DIFF
--- a/rails/locale/af.yml
+++ b/rails/locale/af.yml
@@ -1,6 +1,4 @@
-# Sample localization file for English. Add more files in this directory for other locales.
-# See https://github.com/svenfuchs/rails-i18n/tree/master/rails%2Flocale for starting points.
-
+---
 af:
   date:
     abbr_day_names:
@@ -12,7 +10,7 @@ af:
     - Vry
     - Sat
     abbr_month_names:
-    -
+    - 
     - Jan
     - Feb
     - Mar
@@ -34,11 +32,11 @@ af:
     - Vrydag
     - Saterdag
     formats:
-      default: ! '%Y-%m-%d'
-      long: ! '%B %d, %Y'
-      short: ! '%b %d'
+      default: "%Y-%m-%d"
+      long: "%B %d, %Y"
+      short: "%b %d"
     month_names:
-    -
+    - 
     - Januarie
     - Februarie
     - Maart
@@ -81,16 +79,16 @@ af:
         other: meer as %{count} jaar
       x_days:
         one: 1 dag
-        other: ! '%{count} days'
+        other: "%{count} days"
       x_minutes:
         one: 1 minuut
-        other: ! '%{count} minute'
+        other: "%{count} minute"
       x_months:
         one: 1 maand
-        other: ! '%{count} maande'
+        other: "%{count} maande"
       x_seconds:
         one: 1 sekonde
-        other: ! '%{count} sekondes'
+        other: "%{count} sekondes"
     prompts:
       day: Dag
       hour: Uur
@@ -99,7 +97,7 @@ af:
       second: Sekondes
       year: Jaar
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: moet aanvaar word
       blank: mag nie leeg wees nie
@@ -117,7 +115,7 @@ af:
       not_a_number: is nie n getal nie
       not_an_integer: moet n integer wees
       odd: moet onewe wees
-      record_invalid: ! 'Validation failed: %{errors}'
+      record_invalid: 'Validation failed: %{errors}'
       taken: is reeds geneem
       too_long:
         one: is te lank (maksimum is 1 karakter)
@@ -129,10 +127,10 @@ af:
         one: is die verkeerde lengte (moet 1 karakter wees)
         other: is die verkeerde lengte (moet %{count} karakters wees)
     template:
-      body: ! 'There were problems with the following fields:'
+      body: 'There were problems with the following fields:'
       header:
         one: 1 fout het verhoed dat hierdie %{model} gestoor kon word
-        other: ! '%{count} foute het verhoed dat hierdie %{model} gestoor kon word'
+        other: "%{count} foute het verhoed dat hierdie %{model} gestoor kon word"
   helpers:
     select:
       prompt: Kies asseblief
@@ -143,22 +141,22 @@ af:
   number:
     currency:
       format:
-        delimiter: ! ','
-        format: ! '%u%n'
+        delimiter: ","
+        format: "%u%n"
         precision: 2
-        separator: .
+        separator: "."
         significant: vals
         strip_insignificant_zeros: vals
         unit: R
     format:
-      delimiter: ! ','
+      delimiter: ","
       precision: 3
-      separator: .
+      separator: "."
       significant: vals
       strip_insignificant_zeros: vals
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: miljard
           million: miljoen
@@ -172,7 +170,7 @@ af:
         significant: waar
         strip_insignificant_zeros: waar
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Byte
@@ -189,13 +187,13 @@ af:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ', en '
-      two_words_connector: ! ' en '
-      words_connector: ! ', '
+      last_word_connector: ", en "
+      two_words_connector: " en "
+      words_connector: ", "
   time:
     am: vm
     formats:
-      default: ! '%a, %d %b %Y %H:%M:%S %z'
-      long: ! '%B %d, %Y %H:%M'
-      short: ! '%d %b %H:%M'
+      default: "%a, %d %b %Y %H:%M:%S %z"
+      long: "%B %d, %Y %H:%M"
+      short: "%d %b %H:%M"
     pm: nm

--- a/rails/locale/ar.yml
+++ b/rails/locale/ar.yml
@@ -1,3 +1,4 @@
+---
 ar:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ ar:
     - الجمعة
     - السبت
     abbr_month_names:
-    -
+    - 
     - يناير
     - فبراير
     - مارس
@@ -31,11 +32,11 @@ ar:
     - الجمعة
     - السبت
     formats:
-      default: ! '%Y-%m-%d'
-      long: ! '%B %e, %Y'
-      short: ! '%e %b'
+      default: "%Y-%m-%d"
+      long: "%B %e, %Y"
+      short: "%e %b"
     month_names:
-    -
+    - 
     - يناير
     - فبراير
     - مارس
@@ -55,28 +56,28 @@ ar:
   datetime:
     distance_in_words:
       about_x_hours:
-        zero: ! 'حوالي صفر ساعات'
+        zero: حوالي صفر ساعات
         one: حوالي ساعة واحدة
-        two: ! 'حوالي ساعتان'
-        few: ! 'حوالي %{count} ساعات'
-        many: ! 'حوالي %{count} ساعة'
-        other: ! 'حوالي %{count} ساعة'
+        two: حوالي ساعتان
+        few: حوالي %{count} ساعات
+        many: حوالي %{count} ساعة
+        other: حوالي %{count} ساعة
       about_x_months:
-        zero: ! 'حوالي صفر أشهر'
+        zero: حوالي صفر أشهر
         one: حوالي شهر واحد
-        two: ! 'حوالي شهران'
-        few: ! 'حوالي %{count} أشهر'
-        many: ! 'حوالي %{count} شهر'
-        other: ! 'حوالي %{count} شهر'
+        two: حوالي شهران
+        few: حوالي %{count} أشهر
+        many: حوالي %{count} شهر
+        other: حوالي %{count} شهر
       about_x_years:
-        zero: ! 'حوالي صفر سنوات'
+        zero: حوالي صفر سنوات
         one: حوالي سنة
-        two: ! 'حوالي سنتان'
-        few: ! 'حوالي %{count} سنوات'
-        many: ! 'حوالي %{count} سنة'
-        other: ! 'حوالي %{count} سنة'
+        two: حوالي سنتان
+        few: حوالي %{count} سنوات
+        many: حوالي %{count} سنة
+        other: حوالي %{count} سنة
       almost_x_years:
-        zero: ! 'ما يقرب من صفر سنوات'
+        zero: ما يقرب من صفر سنوات
         one: تقريبا سنة واحدة
         two: ما يقرب من سنتين
         few: ما يقرب من %{count} سنوات
@@ -84,54 +85,54 @@ ar:
         other: ما يقرب من %{count} سنة
       half_a_minute: نصف دقيقة
       less_than_x_minutes:
-        zero: ! 'أقل من صفر دقائق'
+        zero: أقل من صفر دقائق
         one: أقل من دقيقة
-        two: ! 'أقل من دقيقتان'
-        few: ! 'أقل من %{count} دقائق'
-        many: ! 'أقل من %{count} دقيقة'
-        other: ! 'أقل من %{count} دقيقة'
+        two: أقل من دقيقتان
+        few: أقل من %{count} دقائق
+        many: أقل من %{count} دقيقة
+        other: أقل من %{count} دقيقة
       less_than_x_seconds:
-        zero: ! 'أقل من صفر ثواني'
+        zero: أقل من صفر ثواني
         one: أقل من ثانية
-        two: ! 'أقل من ثانيتان'
-        few: ! 'أقل من %{count} ثوان'
-        many: ! 'أقل من %{count} ثانية'
-        other: ! 'أقل من %{count} ثانية'
+        two: أقل من ثانيتان
+        few: أقل من %{count} ثوان
+        many: أقل من %{count} ثانية
+        other: أقل من %{count} ثانية
       over_x_years:
-        zero: ! 'أكثر من صفر سنوات'
+        zero: أكثر من صفر سنوات
         one: أكثر من سنة
-        two: ! 'أكثر من سنتين'
-        few: ! 'أكثر من %{count} سنوات'
-        many: ! 'أكثر من %{count} سنة'
-        other: ! 'أكثر من %{count} سنة'
+        two: أكثر من سنتين
+        few: أكثر من %{count} سنوات
+        many: أكثر من %{count} سنة
+        other: أكثر من %{count} سنة
       x_days:
-        zero: ! 'صفر أيام'
+        zero: صفر أيام
         one: يوم واحد
-        two: ! 'يومان'
-        few: ! '%{count} أيام'
-        many: ! '%{count} يوم'
-        other: ! '%{count} يوم'
+        two: يومان
+        few: "%{count} أيام"
+        many: "%{count} يوم"
+        other: "%{count} يوم"
       x_minutes:
-        zero: ! 'صفر دقائق'
+        zero: صفر دقائق
         one: دقيقة واحدة
-        two: ! 'دقيقتان'
-        few: ! '%{count} دقائق'
-        many: ! '%{count} دقيقة'
-        other: ! '%{count} دقيقة'
+        two: دقيقتان
+        few: "%{count} دقائق"
+        many: "%{count} دقيقة"
+        other: "%{count} دقيقة"
       x_months:
-        zero: ! 'صفر أشهر'
+        zero: صفر أشهر
         one: شهر واحد
-        two: ! 'شهران'
-        few: ! '%{count} أشهر'
-        many: ! '%{count} شهر'
-        other: ! '%{count} شهر'
+        two: شهران
+        few: "%{count} أشهر"
+        many: "%{count} شهر"
+        other: "%{count} شهر"
       x_seconds:
-        zero: ! 'صفر ثواني'
+        zero: صفر ثواني
         one: ثانية واحدة
-        two: ! 'ثانيتان'
-        few: ! '%{count} ثوان'
-        many: ! '%{count} ثانية'
-        other: ! '%{count} ثانية'
+        two: ثانيتان
+        few: "%{count} ثوان"
+        many: "%{count} ثانية"
+        other: "%{count} ثانية"
     prompts:
       day: اليوم
       hour: ساعة
@@ -140,12 +141,12 @@ ar:
       second: ثانية
       year: السنة
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: يجب أن تقبل
       blank: فارغ، يرجى ملء الحقل
       present: يجب ترك الحقل فارغاً
-      confirmation: ! "لا يتوافق مع %{attribute}"
+      confirmation: لا يتوافق مع %{attribute}
       empty: فارغ، يرجى ملء الحقل
       equal_to: يجب أن يساوي %{count}
       even: يجب أن يكون زوجي
@@ -159,10 +160,10 @@ ar:
       not_a_number: ليس رقما
       not_an_integer: يجب أن يكون عدداً صحيحاً
       odd: يجب أن يكون فردي
-      record_invalid: ! 'فشل التحقق من: %{errors}'
+      record_invalid: 'فشل التحقق من: %{errors}'
       restrict_dependent_destroy:
-        one: "لا يمكن حذف السجل لوجود سجل يعتمد عليه %{record}"
-        many: "لا يمكن حذف السجل لوجود سجلات تعتمد عليه %{record}"
+        one: لا يمكن حذف السجل لوجود سجل يعتمد عليه %{record}
+        many: لا يمكن حذف السجل لوجود سجلات تعتمد عليه %{record}
       taken: محجوز مسبقاً
       too_long:
         zero: أطول من اللازم (الحد الأقصى هو ولا حرف)
@@ -186,47 +187,47 @@ ar:
         many: الطول غير مطابق للحد المطلوب (يجب أن يكون %{count} حرف)
         other: الطول غير مطابق للحد المطلوب (يجب أن يكون %{count} حرف)
       other_than:
-        zero: "الطول يجب ألاّ يكون صفر أحرف"
-        one: "الطول يجب ألاّ يكون حرفاً وحداً"
-        two: "الطول يجب ألاّ يكون حرفان"
-        few: "الطول يجب ألاّ يكون %{count} أحرف"
-        many: "الطول يجب ألاّ يكون %{count} حرفاً"
-        other: "الطول يجب ألاّ يكون %{count} حرفاً"
+        zero: الطول يجب ألاّ يكون صفر أحرف
+        one: الطول يجب ألاّ يكون حرفاً وحداً
+        two: الطول يجب ألاّ يكون حرفان
+        few: الطول يجب ألاّ يكون %{count} أحرف
+        many: الطول يجب ألاّ يكون %{count} حرفاً
+        other: الطول يجب ألاّ يكون %{count} حرفاً
     template:
-      body: ! 'يرجى التحقق من الحقول التالية:'
+      body: 'يرجى التحقق من الحقول التالية:'
       header:
-        zero: ! 'ليس بالامكان حفظ %{model}: لايوجد أخطاء.'
-        one: ! 'ليس بالامكان حفظ %{model}: خطأ واحد.'
-        two: ! 'ليس بالامكان حفظ %{model}:  خطئان.'
-        few: ! 'ليس بالامكان حفظ %{model}: %{count} أخطاء.'
-        many: ! 'ليس بالامكان حفظ %{model}: %{count} أخطاء.'
-        other: ! 'ليس بالامكان حفظ %{model}: %{count} خطأ.'
+        zero: 'ليس بالامكان حفظ %{model}: لايوجد أخطاء.'
+        one: 'ليس بالامكان حفظ %{model}: خطأ واحد.'
+        two: 'ليس بالامكان حفظ %{model}:  خطئان.'
+        few: 'ليس بالامكان حفظ %{model}: %{count} أخطاء.'
+        many: 'ليس بالامكان حفظ %{model}: %{count} أخطاء.'
+        other: 'ليس بالامكان حفظ %{model}: %{count} خطأ.'
   helpers:
     select:
       prompt: الرجاء اختيار
     submit:
-      create: ! '%{model} إنشاء'
-      submit: ! '%{model} حفظ'
-      update: ! '%{model} نموذج'
+      create: "%{model} إنشاء"
+      submit: "%{model} حفظ"
+      update: "%{model} نموذج"
   number:
     currency:
       format:
-        delimiter: ! ','
-        format: ! '%u%n'
+        delimiter: ","
+        format: "%u%n"
         precision: 2
-        separator: .
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
-        unit: $
+        unit: "$"
     format:
-      delimiter: ! ','
+      delimiter: ","
       precision: 3
-      separator: .
+      separator: "."
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: مليار
           million: مليون
@@ -240,7 +241,7 @@ ar:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             zero: Bytes
@@ -262,13 +263,13 @@ ar:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ' و '
-      two_words_connector: ! ' و '
-      words_connector: ! ' و '
+      last_word_connector: " و "
+      two_words_connector: " و "
+      words_connector: " و "
   time:
     am: صباحاً
     formats:
-      default: ! '%a %b %d %H:%M:%S %Z %Y'
-      long: ! '%B %d, %Y %H:%M'
-      short: ! '%d %b %H:%M'
+      default: "%a %b %d %H:%M:%S %Z %Y"
+      long: "%B %d, %Y %H:%M"
+      short: "%d %b %H:%M"
     pm: مساءً

--- a/rails/locale/az.yml
+++ b/rails/locale/az.yml
@@ -1,3 +1,4 @@
+---
 az:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ az:
     - C.
     - Ş.
     abbr_month_names:
-    -
+    - 
     - Yan
     - Fev
     - Mar
@@ -31,11 +32,11 @@ az:
     - Cümə
     - Şənbə
     formats:
-      default: ! '%d.%m.%Y'
-      long: ! '%d %B %Y'
-      short: ! '%d %b'
+      default: "%d.%m.%Y"
+      long: "%d %B %Y"
+      short: "%d %b"
     month_names:
-    -
+    - 
     - Yanvar
     - Fevral
     - Mart
@@ -69,25 +70,25 @@ az:
       half_a_minute: yarım dəqiqə
       less_than_x_minutes:
         one: 1 dəqiqədən az
-        other: ! '%{count} dəqiqədən az'
+        other: "%{count} dəqiqədən az"
       less_than_x_seconds:
         one: 1 saniyədən az
-        other: ! '%{count} saniyədən az'
+        other: "%{count} saniyədən az"
       over_x_years:
         one: 1 ildən çox
-        other: ! '%{count} ildən çox'
+        other: "%{count} ildən çox"
       x_days:
         one: 1 gün
-        other: ! '%{count} gün'
+        other: "%{count} gün"
       x_minutes:
         one: 1 dəqiqə
-        other: ! '%{count} dəqiqə'
+        other: "%{count} dəqiqə"
       x_months:
         one: 1 ay
-        other: ! '%{count} ay'
+        other: "%{count} ay"
       x_seconds:
         one: 1 saniyə
-        other: ! '%{count} saniyə'
+        other: "%{count} saniyə"
     prompts:
       day: Gün
       hour: Saat
@@ -96,60 +97,60 @@ az:
       second: Saniyə
       year: İl
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: qəbul olunmalıdır
       blank: boş ola bilməz
       confirmation: təsdiqə uygun deyil
       empty: boş ola bilməz
-      equal_to: ! '%{count}-ə bərabər olmalıdır'
+      equal_to: "%{count}-ə bərabər olmalıdır"
       even: cüt olmalıdır
       exclusion: qorunur
-      greater_than: ! '%{count}-dən böyük olmalıdır'
+      greater_than: "%{count}-dən böyük olmalıdır"
       greater_than_or_equal_to: böyük və ya %{count}-ə bərabər olmalıdır
       inclusion: siyahiyə daxil deyil
       invalid: yalnışdır
-      less_than: ! '%{count}-dən kiçik olmalıdır'
+      less_than: "%{count}-dən kiçik olmalıdır"
       less_than_or_equal_to: kiçik və ya %{count}-ə bərabər olmalıdır
       not_a_number: rəqəm deyil
       not_an_integer: tam rəqəm olmalıdır
       odd: tək olmalıdır
-      record_invalid: ! 'Yoxlama uğursuz oldu: %{errors}'
+      record_invalid: 'Yoxlama uğursuz oldu: %{errors}'
       taken: artıq mövcuddur
       too_long: çox uzundur (%{count} simvoldan çox olmalı deyil)
       too_short: çox qısadır (%{count} simvoldan az olmalı deyil)
       wrong_length: uzunluqu səhvdir (%{count} simvol olmalıdır)
     template:
-      body: ! 'Aşağıdaki səhvlər üzə çıxdı:'
+      body: 'Aşağıdaki səhvlər üzə çıxdı:'
       header:
-        one: ! '%{model} saxlanmadı: 1 səhv'
-        other: ! '%{model} saxlanmadı: %{count} səhv'
+        one: "%{model} saxlanmadı: 1 səhv"
+        other: "%{model} saxlanmadı: %{count} səhv"
   helpers:
     select:
       prompt: Seçin
     submit:
-      create: ! '%{model} yarat'
-      submit: ! '%{model} saxla'
-      update: ! '%{model} yenilə'
+      create: "%{model} yarat"
+      submit: "%{model} saxla"
+      update: "%{model} yenilə"
   number:
     currency:
       format:
-        delimiter: ! ' '
-        format: ! '%n %u'
+        delimiter: " "
+        format: "%n %u"
         precision: 2
-        separator: .
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
         unit: AZN
     format:
-      delimiter: ! ' '
+      delimiter: " "
       precision: 3
-      separator: .
+      separator: "."
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: Milyard
           million: Milyon
@@ -163,7 +164,7 @@ az:
         significant: false
         strip_insignificant_zeros: false
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Bayt
@@ -180,13 +181,13 @@ az:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ' və '
-      two_words_connector: ! ' və '
-      words_connector: ! ', '
+      last_word_connector: " və "
+      two_words_connector: " və "
+      words_connector: ", "
   time:
     am: günortaya qədər
     formats:
-      default: ! '%a, %d %b %Y, %H:%M:%S %z'
-      long: ! '%d %B %Y, %H:%M'
-      short: ! '%d %b, %H:%M'
+      default: "%a, %d %b %Y, %H:%M:%S %z"
+      long: "%d %B %Y, %H:%M"
+      short: "%d %b, %H:%M"
     pm: günortadan sonra

--- a/rails/locale/be.yml
+++ b/rails/locale/be.yml
@@ -1,3 +1,4 @@
+---
 be:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ be:
     - Суб
     - Ндз
     abbr_month_names:
-    -
+    - 
     - Сту
     - Лют
     - Сак
@@ -31,11 +32,11 @@ be:
     - Пятніца
     - Субота
     formats:
-      default: ! '%d-%m-%Y'
-      long: ! '%B %d, %Y'
-      short: ! '%b %d'
+      default: "%d-%m-%Y"
+      long: "%B %d, %Y"
+      short: "%b %d"
     month_names:
-    -
+    - 
     - Студзень
     - Люты
     - Сакавік
@@ -78,16 +79,16 @@ be:
         other: болей за %{count} гадоў
       x_days:
         one: 1 дзень
-        other: ! '%{count} дзён'
+        other: "%{count} дзён"
       x_minutes:
         one: 1 хвіліна
-        other: ! '%{count} хвілін'
+        other: "%{count} хвілін"
       x_months:
         one: 1 месяц
-        other: ! '%{count} месяцаў'
+        other: "%{count} месяцаў"
       x_seconds:
         one: 1 секунда
-        other: ! '%{count} секундаў'
+        other: "%{count} секундаў"
     prompts:
       day: Дзень
       hour: Гадзіна
@@ -96,12 +97,12 @@ be:
       second: Секунда
       year: Год
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: трэба прыняць
       blank: не можа быць пустым
       present: павінна быць пустым
-      confirmation: ! "не супадае з %{attribute}"
+      confirmation: не супадае з %{attribute}
       empty: не можа быць пустым
       equal_to: павінна быць роўным %{count}
       even: павінна быць цотным
@@ -115,10 +116,10 @@ be:
       not_a_number: гэта не лічба
       not_an_integer: павінна быць цэлай лічбай
       odd: павінна быць няцотным
-      record_invalid: ! 'Памылкі валідацыі: %{errors}'
+      record_invalid: 'Памылкі валідацыі: %{errors}'
       restrict_dependent_destroy:
-        one: "Нельга выдаліць запіс, таму што існуе залежнасць %{record}"
-        many: "Нельга выдаліць запіс, таму што існуюць залежнасці %{record}"
+        one: Нельга выдаліць запіс, таму што існуе залежнасць %{record}
+        many: Нельга выдаліць запіс, таму што існуюць залежнасці %{record}
       taken: ўжо занята
       too_long:
         one: занадта доўгі (максімум 1 сімвал)
@@ -129,12 +130,12 @@ be:
       wrong_length:
         one: няправільная даўжыня (павінен быць 1 сімвал)
         other: няправільная даўжыня (павінны быць %{count} сімвалаў)
-      other_than: "павінна адрознівацца ад %{count}"
+      other_than: павінна адрознівацца ад %{count}
     template:
-      body: ! 'Узніклі праблемы з наступнымі палямі:'
+      body: 'Узніклі праблемы з наступнымі палямі:'
       header:
         one: не атрымалася захаваць %{model} з-за 1 памылкі
-        other: ! 'не атрымалася захаваць %{model} з-за %{count} памылак'
+        other: не атрымалася захаваць %{model} з-за %{count} памылак
   helpers:
     select:
       prompt: Калі ласка, абярыце
@@ -145,22 +146,22 @@ be:
   number:
     currency:
       format:
-        delimiter: ! ','
-        format: ! '%u%n'
+        delimiter: ","
+        format: "%u%n"
         precision: 2
-        separator: .
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
-        unit: $
+        unit: "$"
     format:
-      delimiter: ! ','
+      delimiter: ","
       precision: 3
-      separator: .
+      separator: "."
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: мільярд
           million: мільён
@@ -174,7 +175,7 @@ be:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Байт
@@ -192,13 +193,13 @@ be:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ' і '
-      two_words_connector: ! ' і '
-      words_connector: ! ', '
+      last_word_connector: " і "
+      two_words_connector: " і "
+      words_connector: ", "
   time:
     am: раніцы
     formats:
-      default: ! '%a, %d %b %Y %H:%M:%S %z'
-      long: ! '%B %d, %Y %H:%M'
-      short: ! '%d %b %H:%M'
+      default: "%a, %d %b %Y %H:%M:%S %z"
+      long: "%B %d, %Y %H:%M"
+      short: "%d %b %H:%M"
     pm: вечара

--- a/rails/locale/bg.yml
+++ b/rails/locale/bg.yml
@@ -1,3 +1,4 @@
+---
 bg:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ bg:
     - пет
     - съб
     abbr_month_names:
-    -
+    - 
     - ян.
     - фев.
     - март
@@ -31,11 +32,11 @@ bg:
     - петък
     - събота
     formats:
-      default: ! '%d.%m.%Y'
-      long: ! '%d %B %Y'
-      short: ! '%d %b'
+      default: "%d.%m.%Y"
+      long: "%d %B %Y"
+      short: "%d %b"
     month_names:
-    -
+    - 
     - януари
     - февруари
     - март
@@ -78,16 +79,16 @@ bg:
         other: над %{count} години
       x_days:
         one: 1 ден
-        other: ! '%{count} дни'
+        other: "%{count} дни"
       x_minutes:
         one: 1 минута
-        other: ! '%{count} минути'
+        other: "%{count} минути"
       x_months:
         one: 1 месец
-        other: ! '%{count} месеца'
+        other: "%{count} месеца"
       x_seconds:
         one: 1 секунда
-        other: ! '%{count} секунди'
+        other: "%{count} секунди"
     prompts:
       day: Ден
       hour: Час
@@ -96,7 +97,7 @@ bg:
       second: Секунда
       year: Година
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: трябва да се потвърди
       blank: не може да е без стойност
@@ -114,16 +115,16 @@ bg:
       not_a_number: не е число
       not_an_integer: не е цяло число
       odd: трябва да е четно
-      record_invalid: ! 'имаше грешки: %{errors}'
+      record_invalid: 'имаше грешки: %{errors}'
       taken: вече съществува
       too_long: е прекаленo дълго (не може да е повече от %{count} символа)
       too_short: е прекалено късо (не може да бъде по-малко от %{count} символа)
       wrong_length: е с грешна дължина (трябва да е с дължина, равна на %{count} символа)
     template:
-      body: ! 'Възникнаха проблеми със следните полета:'
+      body: 'Възникнаха проблеми със следните полета:'
       header:
-        one: ! '%{model}: записът е неуспешен заради 1 грешка'
-        other: ! '%{model}: записът е неуспешен заради %{count} грешки'
+        one: "%{model}: записът е неуспешен заради 1 грешка"
+        other: "%{model}: записът е неуспешен заради %{count} грешки"
   helpers:
     select:
       prompt: Моля отбележете
@@ -134,22 +135,22 @@ bg:
   number:
     currency:
       format:
-        delimiter: ! ' '
-        format: ! '%n %u'
+        delimiter: " "
+        format: "%n %u"
         precision: 2
-        separator: ! ','
+        separator: ","
         significant: false
         strip_insignificant_zeros: false
         unit: лв.
     format:
-      delimiter: ! ' '
+      delimiter: " "
       precision: 3
-      separator: ! ','
+      separator: ","
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: милиарда
           million: милиона
@@ -163,7 +164,7 @@ bg:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Байт
@@ -180,13 +181,13 @@ bg:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ' и '
-      two_words_connector: ! ' и '
-      words_connector: ! ', '
+      last_word_connector: " и "
+      two_words_connector: " и "
+      words_connector: ", "
   time:
     am: преди обяд
     formats:
-      default: ! '%a, %d %b %Y, %H:%M:%S %z'
-      long: ! '%d %B %Y, %H:%M'
-      short: ! '%d %b, %H:%M'
+      default: "%a, %d %b %Y, %H:%M:%S %z"
+      long: "%d %B %Y, %H:%M"
+      short: "%d %b, %H:%M"
     pm: следобед

--- a/rails/locale/bn.yml
+++ b/rails/locale/bn.yml
@@ -1,3 +1,4 @@
+---
 bn:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ bn:
     - শুক্রবার
     - শনিবার
     abbr_month_names:
-    -
+    - 
     - জানুয়ারি
     - ফেব্রুয়ারি
     - মার্চ
@@ -31,11 +32,11 @@ bn:
     - শুক্রবার
     - শনিবার
     formats:
-      default: ! '%e/%m/%Y'
-      long: ! '%e de %B de %Y'
-      short: ! '%e de %b'
+      default: "%e/%m/%Y"
+      long: "%e de %B de %Y"
+      short: "%e de %b"
     month_names:
-    -
+    - 
     - জানুয়ারি
     - ফেব্রুয়ারি
     - মার্চ
@@ -66,25 +67,25 @@ bn:
       half_a_minute: অার্ধেক মিনিট
       less_than_x_minutes:
         one: ১ মিনিটের কম
-        other: ! '%{count} মিনিটের কম'
+        other: "%{count} মিনিটের কম"
       less_than_x_seconds:
-        one: ! '১ সেকেন্ডর কম '
-        other: ! '%{count} সেকেন্ডের কম'
+        one: '১ সেকেন্ডর কম '
+        other: "%{count} সেকেন্ডের কম"
       over_x_years:
         one: ১ বছরের বেশি
-        other: ! '%{count} বছরের বেশি'
+        other: "%{count} বছরের বেশি"
       x_days:
         one: ১ দিন
-        other: ! '%{count} দিন'
+        other: "%{count} দিন"
       x_minutes:
         one: ১ মিনিট
-        other: ! '%{count} মিনিট'
+        other: "%{count} মিনিট"
       x_months:
         one: ১ মাস
-        other: ! '%{count} মাস'
+        other: "%{count} মাস"
       x_seconds:
         one: ১ সেকেন্ড
-        other: ! '%{count} সেকেন্ড'
+        other: "%{count} সেকেন্ড"
     prompts:
       day: দিন
       hour: ঘন্টা
@@ -93,21 +94,21 @@ bn:
       second: সেকেন্ড
       year: বছর
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: গ্রাহ্য করতে হবে
       blank: ফাঁকা রাখা যাবে না
       confirmation: অনুমোদনের সঙ্গে মিলছে না
       empty: খালি রাখা যাবে না
-      equal_to: ! '%{count} এর সঙ্গে সমান হতে হবে'
+      equal_to: "%{count} এর সঙ্গে সমান হতে হবে"
       even: জোড় হতে হবে
       exclusion: রিসার্ভ করা অাছে
-      greater_than: ! '%{count} থেকে বড়ো হতে হবে'
-      greater_than_or_equal_to: ! '%{count} থেকে বড়ো অথবা তার সমান হতে হবে'
+      greater_than: "%{count} থেকে বড়ো হতে হবে"
+      greater_than_or_equal_to: "%{count} থেকে বড়ো অথবা তার সমান হতে হবে"
       inclusion: লিস্টে অন্তর্ভুক্ত নয়
       invalid: সঠিক নয়
-      less_than: ! '%{count} থেকে ছোটো হতে হবে'
-      less_than_or_equal_to: ! '%{count} থেকে ছোটো অথবা তার সমান হতে হবে'
+      less_than: "%{count} থেকে ছোটো হতে হবে"
+      less_than_or_equal_to: "%{count} থেকে ছোটো অথবা তার সমান হতে হবে"
       not_a_number: নম্বর নয়
       odd: বেজোড় হতে হবে
       taken: অাগেই নিয়ে নেওয়া হয়েছে
@@ -115,29 +116,29 @@ bn:
       too_short: খুব ছোটো (সর্বনিম্ন %{count} অক্ষর)
       wrong_length: দৈর্ঘ্যটি সঠিক নয় (%{count} অক্ষর হতে হবে)
     template:
-      body: ! 'এই ফিল্ডগুলোতে কিছু সমস্যা দেখা দিয়েছে:'
+      body: 'এই ফিল্ডগুলোতে কিছু সমস্যা দেখা দিয়েছে:'
       header:
         one: ১ টি ত্রুটির কারনে %{model} সংরক্ষন করা সম্ভব হয়নি
-        other: ! '%{count} টি ত্রুটির কারনে %{model} সংরক্ষন করা সম্ভব হয়নি'
+        other: "%{count} টি ত্রুটির কারনে %{model} সংরক্ষন করা সম্ভব হয়নি"
   number:
     currency:
       format:
-        delimiter: ! ','
-        format: ! '%u %n'
+        delimiter: ","
+        format: "%u %n"
         precision: 2
-        separator: .
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
-        unit: ₹
+        unit: "₹"
     format:
-      delimiter: ! ','
+      delimiter: ","
       precision: 2
-      separator: .
+      separator: "."
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           unit: ''
       format:
@@ -146,7 +147,7 @@ bn:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Byte
@@ -163,13 +164,13 @@ bn:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ', এবং '
-      two_words_connector: ! ' এবং '
-      words_connector: ! ', '
+      last_word_connector: ", এবং "
+      two_words_connector: " এবং "
+      words_connector: ", "
   time:
     am: am
     formats:
-      default: ! '%A, %e de %B de %Y %H:%M:%S %z'
-      long: ! '%e de %B de %Y %H:%M'
-      short: ! '%e de %b %H:%M'
+      default: "%A, %e de %B de %Y %H:%M:%S %z"
+      long: "%e de %B de %Y %H:%M"
+      short: "%e de %b %H:%M"
     pm: pm

--- a/rails/locale/bs.yml
+++ b/rails/locale/bs.yml
@@ -1,3 +1,4 @@
+---
 bs:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ bs:
     - pet
     - sub
     abbr_month_names:
-    -
+    - 
     - jan
     - feb
     - mar
@@ -30,11 +31,11 @@ bs:
     - četvrtak
     - petak
     formats:
-      default: ! '%d.%m.%Y.'
-      long: ! '%e. %B %Y.'
-      short: ! '%e. %b. %Y.'
+      default: "%d.%m.%Y."
+      long: "%e. %B %Y."
+      short: "%e. %b. %Y."
     month_names:
-    -
+    - 
     - januar
     - februar
     - mart
@@ -90,25 +91,25 @@ bs:
         one: preko godine
         other: preko %{count} godina
       x_days:
-        few: ! '%{count} dana'
-        many: ! '%{count} dana'
+        few: "%{count} dana"
+        many: "%{count} dana"
         one: 1 dan
-        other: ! '%{count} dana'
+        other: "%{count} dana"
       x_minutes:
-        few: ! '%{count} minute'
-        many: ! '%{count} minuta'
+        few: "%{count} minute"
+        many: "%{count} minuta"
         one: 1 minut
-        other: ! '%{count} minuta'
+        other: "%{count} minuta"
       x_months:
-        few: ! '%{count} mjeseca'
-        many: ! '%{count} mjeseci'
+        few: "%{count} mjeseca"
+        many: "%{count} mjeseci"
         one: 1 mjesec
-        other: ! '%{count} mjeseci'
+        other: "%{count} mjeseci"
       x_seconds:
-        few: ! '%{count} sekunde'
-        many: ! '%{count} sekundi'
+        few: "%{count} sekunde"
+        many: "%{count} sekundi"
         one: 1 sekund
-        other: ! '%{count} sekundi'
+        other: "%{count} sekundi"
     prompts:
       day: dan
       hour: sat
@@ -117,7 +118,7 @@ bs:
       second: sekundi
       year: godina
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: mora biti prihvaćeno
       blank: ne smije biti prazno
@@ -136,22 +137,22 @@ bs:
       not_a_number: nije broj
       not_an_integer: mora biti cijeli broj
       odd: mora biti neparno
-      record_invalid: ! 'Validacija nije uspjela: %{errors}'
+      record_invalid: 'Validacija nije uspjela: %{errors}'
       restrict_dependent_destroy:
-        one: "Nije moguće izbrisati zapis jer postoji ovisan %{record}"
-        many: "Nije moguće izbrisati zapis jer postoje ovisni %{record}"
+        one: Nije moguće izbrisati zapis jer postoji ovisan %{record}
+        many: Nije moguće izbrisati zapis jer postoje ovisni %{record}
       taken: je već zauzet
       too_long: je predugo (maksimalno je dozvoljeno %{count} znakova)
       too_short: je prekratko (predviđeno je minimalno %{count} znakova)
       wrong_length: je pogrešne dužine (trebalo bi biti tačno %{count} znakova)
-      other_than: "mora biti različito od %{count}"
+      other_than: mora biti različito od %{count}
     template:
-      body: ! 'Desili su se problemi sa slijedećim poljima:'
+      body: 'Desili su se problemi sa slijedećim poljima:'
       header:
-        few: ! '%{count} greške su spriječile da se ovaj %{model} spremi'
-        many: ! '%{count} grešaka je spriječilo da se ovaj %{model} spremi'
+        few: "%{count} greške su spriječile da se ovaj %{model} spremi"
+        many: "%{count} grešaka je spriječilo da se ovaj %{model} spremi"
         one: 1 greška je spriječila da se ovaj %{model} spremi
-        other: ! '%{count} grešaka je spriječilo da se ovaj %{model} spremi'
+        other: "%{count} grešaka je spriječilo da se ovaj %{model} spremi"
   helpers:
     select:
       prompt: Molimo odaberite
@@ -162,22 +163,22 @@ bs:
   number:
     currency:
       format:
-        delimiter: .
-        format: ! '%n%u'
+        delimiter: "."
+        format: "%n%u"
         precision: 2
-        separator: ! ','
+        separator: ","
         significant: false
         strip_insignificant_zeros: true
         unit: KM
     format:
-      delimiter: .
+      delimiter: "."
       precision: 3
-      separator: ! ','
+      separator: ","
       significant: false
       strip_insignificant_zeros: true
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion:
             few: milijarde
@@ -206,12 +207,12 @@ bs:
             other: biliona
           unit: ''
       format:
-        delimiter: ! ','
+        delimiter: ","
         precision: 0
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             few: bajta
@@ -224,20 +225,20 @@ bs:
           tb: TB
     percentage:
       format:
-        delimiter: ! ','
+        delimiter: ","
         format: "%n%"
     precision:
       format:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ' i '
-      two_words_connector: ! ' i '
-      words_connector: ! ', '
+      last_word_connector: " i "
+      two_words_connector: " i "
+      words_connector: ", "
   time:
     am: ''
     formats:
-      default: ! '%H:%M:%S'
-      long: ! '%d. %B %Y. - %H:%M:%S'
-      short: ! '%d. %b %Y. %H:%M'
+      default: "%H:%M:%S"
+      long: "%d. %B %Y. - %H:%M:%S"
+      short: "%d. %b %Y. %H:%M"
     pm: ''

--- a/rails/locale/ca.yml
+++ b/rails/locale/ca.yml
@@ -1,3 +1,4 @@
+---
 ca:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ ca:
     - Dv
     - Ds
     abbr_month_names:
-    -
+    - 
     - Gen
     - Feb
     - Mar
@@ -31,11 +32,11 @@ ca:
     - Divendres
     - Dissabte
     formats:
-      default: ! '%d-%m-%Y'
-      long: ! '%d de %B de %Y'
-      short: ! '%d de %b'
+      default: "%d-%m-%Y"
+      long: "%d de %B de %Y"
+      short: "%d de %b"
     month_names:
-    -
+    - 
     - Gener
     - Febrer
     - Març
@@ -78,16 +79,16 @@ ca:
         other: més de %{count} anys
       x_days:
         one: 1 dia
-        other: ! '%{count} dies'
+        other: "%{count} dies"
       x_minutes:
         one: 1 minut
-        other: ! '%{count} minuts'
+        other: "%{count} minuts"
       x_months:
         one: 1 mes
-        other: ! '%{count} mesos'
+        other: "%{count} mesos"
       x_seconds:
         one: 1 segon
-        other: ! '%{count} segons'
+        other: "%{count} segons"
     prompts:
       day: dia
       hour: hora
@@ -96,7 +97,7 @@ ca:
       second: segon
       year: any
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: ha de ser acceptat
       blank: no pot estar en blanc
@@ -114,13 +115,13 @@ ca:
       not_a_number: no és un número
       not_an_integer: ha de ser un enter
       odd: ha de ser senar
-      record_invalid: ! 'La validació ha fallat: %{errors}'
+      record_invalid: 'La validació ha fallat: %{errors}'
       taken: no està disponible
       too_long: és massa llarg (%{count} caràcters màxim)
       too_short: és massa curt (%{count} caràcters mínim)
       wrong_length: no té la longitud correcta (%{count} caràcters exactament)
     template:
-      body: ! 'Hi ha hagut problemes amb els següents camps:'
+      body: 'Hi ha hagut problemes amb els següents camps:'
       header:
         one: No s'ha pogut desar aquest/a %{model} perquè hi ha 1 error
         other: No s'ha pogut desar aquest/a %{model} perquè hi ha hagut %{count} errors
@@ -134,22 +135,22 @@ ca:
   number:
     currency:
       format:
-        delimiter: .
-        format: ! '%n %u'
+        delimiter: "."
+        format: "%n %u"
         precision: 2
-        separator: ! ','
+        separator: ","
         significant: false
         strip_insignificant_zeros: false
-        unit: €
+        unit: "€"
     format:
-      delimiter: .
+      delimiter: "."
       precision: 3
-      separator: ! ','
+      separator: ","
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: mil milions
           million: milió
@@ -163,7 +164,7 @@ ca:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Byte
@@ -180,13 +181,13 @@ ca:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ', i '
-      two_words_connector: ! ' i '
-      words_connector: ! ', '
+      last_word_connector: ", i "
+      two_words_connector: " i "
+      words_connector: ", "
   time:
     am: am
     formats:
-      default: ! '%A, %d de %B de %Y %H:%M:%S %z'
-      long: ! '%d de %B de %Y %H:%M'
-      short: ! '%d de %b %H:%M'
+      default: "%A, %d de %B de %Y %H:%M:%S %z"
+      long: "%d de %B de %Y %H:%M"
+      short: "%d de %b %H:%M"
     pm: pm

--- a/rails/locale/cs.yml
+++ b/rails/locale/cs.yml
@@ -1,3 +1,4 @@
+---
 cs:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ cs:
     - Pá
     - So
     abbr_month_names:
-    -
+    - 
     - led
     - úno
     - bře
@@ -31,11 +32,11 @@ cs:
     - pátek
     - sobota
     formats:
-      default: ! '%d. %m. %Y'
-      long: ! '%d. %B %Y'
-      short: ! '%d %b'
+      default: "%d. %m. %Y"
+      long: "%d. %B %Y"
+      short: "%d %b"
     month_names:
-    -
+    - 
     - leden
     - únor
     - březen
@@ -85,20 +86,20 @@ cs:
         other: více než %{count} roky
       x_days:
         one: 24 hodinami
-        few: ! '%{count} dny'
-        other: ! '%{count} dny'
+        few: "%{count} dny"
+        other: "%{count} dny"
       x_minutes:
         one: minutou
-        few: ! '%{count} minutami'
-        other: ! '%{count} minutami'
+        few: "%{count} minutami"
+        other: "%{count} minutami"
       x_months:
         one: měsícem
-        few: ! '%{count} měsíci'
-        other: ! '%{count} měsíci'
+        few: "%{count} měsíci"
+        other: "%{count} měsíci"
       x_seconds:
         one: sekundou
-        few: ! '%{count} sekundami'
-        other: ! '%{count} sekundami'
+        few: "%{count} sekundami"
+        other: "%{count} sekundami"
     prompts:
       day: Den
       hour: Hodina
@@ -107,7 +108,7 @@ cs:
       second: Sekunda
       year: Rok
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: musí být potvrzeno
       blank: je povinná položka
@@ -126,17 +127,17 @@ cs:
       not_a_number: není číslo
       not_an_integer: musí být celé číslo
       odd: musí být liché číslo
-      record_invalid: ! 'Validace je neúspešná: %{errors}'
+      record_invalid: 'Validace je neúspešná: %{errors}'
       restrict_dependent_destroy:
-        one: "Nemůžu smazat položku protože existuje závislá/ý/é %{record}"
-        many: "Nemůžu smazat položku protože existuje závislé/ý %{record}"
+        one: Nemůžu smazat položku protože existuje závislá/ý/é %{record}
+        many: Nemůžu smazat položku protože existuje závislé/ý %{record}
       taken: již databáze obsahuje
       too_long: je příliš dlouhý/á/é (max. %{count} znaků)
       too_short: je příliš krátký/á/é (min. %{count} znaků)
       wrong_length: nemá správnou délku (očekáváno %{count} znaků)
-      other_than: "musí být rozdílný/á/é od %{count}"
+      other_than: musí být rozdílný/á/é od %{count}
     template:
-      body: ! 'Následující pole obsahují chybně vyplněné údaje: '
+      body: 'Následující pole obsahují chybně vyplněné údaje: '
       header:
         one: Při ukládání objektu %{model} došlo k chybám a nebylo jej možné uložit
         few: Při ukládání objektu %{model} došlo ke %{count} chybám a nebylo možné
@@ -153,22 +154,22 @@ cs:
   number:
     currency:
       format:
-        delimiter: ! ' '
-        format: ! '%n %u'
+        delimiter: " "
+        format: "%n %u"
         precision: 2
-        separator: ! ','
+        separator: ","
         significant: false
         strip_insignificant_zeros: false
         unit: Kč
     format:
-      delimiter: ! '.'
+      delimiter: "."
       precision: 3
-      separator: ','
+      separator: ","
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: Miliarda
           million: Milion
@@ -182,7 +183,7 @@ cs:
         significant: false
         strip_insignificant_zeros: false
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte: B
           gb: GB
@@ -198,13 +199,13 @@ cs:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ' a '
-      two_words_connector: ! ' a '
-      words_connector: ! ', '
+      last_word_connector: " a "
+      two_words_connector: " a "
+      words_connector: ", "
   time:
     am: am
     formats:
-      default: ! '%a %d. %B %Y %H:%M %z'
-      long: ! '%A %d. %B %Y %H:%M'
-      short: ! '%d. %m. %H:%M'
+      default: "%a %d. %B %Y %H:%M %z"
+      long: "%A %d. %B %Y %H:%M"
+      short: "%d. %m. %H:%M"
     pm: pm

--- a/rails/locale/cy.yml
+++ b/rails/locale/cy.yml
@@ -1,3 +1,4 @@
+---
 cy:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ cy:
     - Gwe
     - Sad
     abbr_month_names:
-    -
+    - 
     - Ion
     - Chw
     - Maw
@@ -31,11 +32,11 @@ cy:
     - Dydd Gwener
     - Dydd Sadwrn
     formats:
-      default: ! '%d-%m-%Y'
-      long: ! '%B %d, %Y'
-      short: ! '%b %d'
+      default: "%d-%m-%Y"
+      long: "%B %d, %Y"
+      short: "%b %d"
     month_names:
-    -
+    - 
     - Ionawr
     - Chwefror
     - Mawrth
@@ -105,33 +106,33 @@ cy:
         many: dros %{count} blynedd
         other: dros %{count} blynedd
       x_days:
-        zero: ! '%{count} diwrnod'
+        zero: "%{count} diwrnod"
         one: 1 diwrnod
-        two: ! '%{count} diwrnod'
-        few: ! '%{count} diwrnod'
-        many: ! '%{count} diwrnod'
-        other: ! '%{count} diwrnod'
+        two: "%{count} diwrnod"
+        few: "%{count} diwrnod"
+        many: "%{count} diwrnod"
+        other: "%{count} diwrnod"
       x_minutes:
-        zero: ! '%{count} o funudau'
+        zero: "%{count} o funudau"
         one: 1 munud
-        two: ! '%{count} o funudau'
-        few: ! '%{count} o funudau'
-        many: ! '%{count} o funudau'
-        other: ! '%{count} o funudau'
+        two: "%{count} o funudau"
+        few: "%{count} o funudau"
+        many: "%{count} o funudau"
+        other: "%{count} o funudau"
       x_months:
-        zero: ! '%{count} mis'
+        zero: "%{count} mis"
         one: 1 mis
-        two: ! '%{count} mis'
-        few: ! '%{count} mis'
-        many: ! '%{count} mis'
-        other: ! '%{count} mis'
+        two: "%{count} mis"
+        few: "%{count} mis"
+        many: "%{count} mis"
+        other: "%{count} mis"
       x_seconds:
-        zero: ! '%{count} o eiliadau'
+        zero: "%{count} o eiliadau"
         one: 1 eiliad
-        two: ! '%{count} o eiliadau'
-        few: ! '%{count} o eiliadau'
-        many: ! '%{count} o eiliadau'
-        other: ! '%{count} o eiliadau'
+        two: "%{count} o eiliadau"
+        few: "%{count} o eiliadau"
+        many: "%{count} o eiliadau"
+        other: "%{count} o eiliadau"
     prompts:
       day: Diwrnod
       hour: Awr
@@ -140,7 +141,7 @@ cy:
       second: Eiliad
       year: Blwyddyn
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: angen ei dderbyn
       blank: methu bod yn wag
@@ -158,13 +159,13 @@ cy:
       not_a_number: heb fod yn rhif
       not_an_integer: heb fod yn rhif llawn
       odd: rhaid bod yn odrif
-      record_invalid: ! 'Gwirio wedi methu: %{errors}'
+      record_invalid: 'Gwirio wedi methu: %{errors}'
       taken: wedi'i gymryd yn barod
       too_long: yn rhy hir (cewch %{count} llythyren ar y fwyaf)
       too_short: yn rhy fyr (rhaid am o leiaf %{count} llythyren)
       wrong_length: gyda maint anghywir o lythrennau (dylai fod yn %{count} llythyren)
     template:
-      body: ! 'Cafwyd broblemau gyda''r meysydd canlynol:'
+      body: 'Cafwyd broblemau gyda''r meysydd canlynol:'
       header:
         one: Atalwyd y %{model} hwn rhag ei gadw gan 1 nam
         two: Atalwyd y %{model} hwn rhag ei gadw gan %{count} nam
@@ -180,22 +181,22 @@ cy:
   number:
     currency:
       format:
-        delimiter: ! ','
-        format: ! '%u%n'
+        delimiter: ","
+        format: "%u%n"
         precision: 2
-        separator: .
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
-        unit: £
+        unit: "£"
     format:
-      delimiter: ! ','
+      delimiter: ","
       precision: 3
-      separator: .
+      separator: "."
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: Biliwn
           million: Miliwn
@@ -209,7 +210,7 @@ cy:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             zero: Bytes
@@ -230,13 +231,13 @@ cy:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ', a '
-      two_words_connector: ! ' a '
-      words_connector: ! ', '
+      last_word_connector: ", a "
+      two_words_connector: " a "
+      words_connector: ", "
   time:
     am: yb
     formats:
-      default: ! '%a, %d %b %Y %H:%M:%S %z'
-      long: ! '%B %d, %Y %H:%M'
-      short: ! '%d %b %H:%M'
+      default: "%a, %d %b %Y %H:%M:%S %z"
+      long: "%B %d, %Y %H:%M"
+      short: "%d %b %H:%M"
     pm: yh

--- a/rails/locale/da.yml
+++ b/rails/locale/da.yml
@@ -1,3 +1,4 @@
+---
 da:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ da:
     - fre
     - lør
     abbr_month_names:
-    -
+    - 
     - jan
     - feb
     - mar
@@ -31,11 +32,11 @@ da:
     - fredag
     - lørdag
     formats:
-      default: ! '%d.%m.%Y'
-      long: ! '%e. %B %Y'
-      short: ! '%e. %b %Y'
+      default: "%d.%m.%Y"
+      long: "%e. %B %Y"
+      short: "%e. %b %Y"
     month_names:
-    -
+    - 
     - januar
     - februar
     - marts
@@ -78,16 +79,16 @@ da:
         other: mere end %{count} år
       x_days:
         one: en dag
-        other: ! '%{count} dage'
+        other: "%{count} dage"
       x_minutes:
         one: et minut
-        other: ! '%{count} minutter'
+        other: "%{count} minutter"
       x_months:
         one: en måned
-        other: ! '%{count} måneder'
+        other: "%{count} måneder"
       x_seconds:
         one: et sekund
-        other: ! '%{count} sekunder'
+        other: "%{count} sekunder"
     prompts:
       day: Dag
       hour: Time
@@ -96,7 +97,7 @@ da:
       second: Sekund
       year: År
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: skal accepteres
       blank: skal udfyldes
@@ -115,20 +116,20 @@ da:
       not_a_number: er ikke et tal
       not_an_integer: er ikke et heltal
       odd: skal være et ulige tal
-      record_invalid: ! 'Godkendelse gik galt: %{errors}'
+      record_invalid: 'Godkendelse gik galt: %{errors}'
       restrict_dependent_destroy:
-        one: "Kunne ikke slette posten fordi en afhængig %{record} findes"
-        many: "Kunne ikke slette posten fordi afhængige %{record} findes"
+        one: Kunne ikke slette posten fordi en afhængig %{record} findes
+        many: Kunne ikke slette posten fordi afhængige %{record} findes
       taken: er allerede brugt
       too_long: er for lang (højest %{count} tegn)
       too_short: er for kort (mindst %{count} tegn)
       wrong_length: har forkert længde (skulle være %{count} tegn)
-      other_than: "skal være forskellig fra %{count}"
+      other_than: skal være forskellig fra %{count}
     template:
-      body: ! 'Der var problemer med følgende felter:'
+      body: 'Der var problemer med følgende felter:'
       header:
         one: En fejl forhindrede %{model} i at blive gemt
-        other: ! '%{count} fejl forhindrede %{model} i at blive gemt'
+        other: "%{count} fejl forhindrede %{model} i at blive gemt"
   helpers:
     select:
       prompt: Vælg...
@@ -139,22 +140,22 @@ da:
   number:
     currency:
       format:
-        delimiter: .
-        format: ! '%u %n'
+        delimiter: "."
+        format: "%u %n"
         precision: 2
-        separator: ! ','
+        separator: ","
         significant: false
         strip_insignificant_zeros: false
         unit: DKK
     format:
-      delimiter: .
+      delimiter: "."
       precision: 3
-      separator: ! ','
+      separator: ","
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: Milliard
           million: Million
@@ -168,7 +169,7 @@ da:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Byte
@@ -186,13 +187,13 @@ da:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ' og '
-      two_words_connector: ! ' og '
-      words_connector: ! ', '
+      last_word_connector: " og "
+      two_words_connector: " og "
+      words_connector: ", "
   time:
     am: ''
     formats:
-      default: ! '%e. %B %Y, %H.%M'
-      long: ! '%A d. %e. %B %Y, %H.%M'
-      short: ! '%e. %b %Y, %H.%M'
+      default: "%e. %B %Y, %H.%M"
+      long: "%A d. %e. %B %Y, %H.%M"
+      short: "%e. %b %Y, %H.%M"
     pm: ''

--- a/rails/locale/de-AT.yml
+++ b/rails/locale/de-AT.yml
@@ -1,3 +1,4 @@
+---
 de-AT:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ de-AT:
     - Fr
     - Sa
     abbr_month_names:
-    -
+    - 
     - Jän
     - Feb
     - Mär
@@ -31,11 +32,11 @@ de-AT:
     - Freitag
     - Samstag
     formats:
-      default: ! '%d.%m.%Y'
-      long: ! '%e. %B %Y'
-      short: ! '%e. %b'
+      default: "%d.%m.%Y"
+      long: "%e. %B %Y"
+      short: "%e. %b"
     month_names:
-    -
+    - 
     - Jänner
     - Februar
     - März
@@ -78,16 +79,16 @@ de-AT:
         other: mehr als %{count} Jahre
       x_days:
         one: ein Tag
-        other: ! '%{count} Tage'
+        other: "%{count} Tage"
       x_minutes:
         one: eine Minute
-        other: ! '%{count} Minuten'
+        other: "%{count} Minuten"
       x_months:
         one: ein Monat
-        other: ! '%{count} Monate'
+        other: "%{count} Monate"
       x_seconds:
         one: eine Sekunde
-        other: ! '%{count} Sekunden'
+        other: "%{count} Sekunden"
     prompts:
       day: Tag
       hour: Stunden
@@ -96,7 +97,7 @@ de-AT:
       second: Sekunden
       year: Jahr
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: muss akzeptiert werden
       blank: muss ausgefüllt werden
@@ -115,46 +116,47 @@ de-AT:
       not_a_number: ist keine Zahl
       not_an_integer: muss ganzzahlig sein
       odd: muss ungerade sein
-      record_invalid: ! 'Gültigkeitsprüfung ist fehlgeschlagen: %{errors}'
+      record_invalid: 'Gültigkeitsprüfung ist fehlgeschlagen: %{errors}'
       restrict_dependent_destroy:
-        one: ! 'Datensatz kann nicht gelöscht werden, da ein abhängiger %{record}-Datensatz existiert.'
-        many: ! 'Datensatz kann nicht gelöscht werden, da abhängige %{record} existieren.'
+        one: Datensatz kann nicht gelöscht werden, da ein abhängiger %{record}-Datensatz
+          existiert.
+        many: Datensatz kann nicht gelöscht werden, da abhängige %{record} existieren.
       taken: ist bereits vergeben
       too_long: ist zu lang (nicht mehr als %{count} Zeichen)
       too_short: ist zu kurz (nicht weniger als %{count} Zeichen)
       wrong_length: hat die falsche Länge (muss genau %{count} Zeichen haben)
       other_than: darf nicht gleich %{count} sein
     template:
-      body: ! 'Bitte überprüfen Sie die folgenden Felder:'
+      body: 'Bitte überprüfen Sie die folgenden Felder:'
       header:
-        one: ! 'Konnte %{model} nicht speichern: ein Fehler.'
-        other: ! 'Konnte %{model} nicht speichern: %{count} Fehler.'
+        one: 'Konnte %{model} nicht speichern: ein Fehler.'
+        other: 'Konnte %{model} nicht speichern: %{count} Fehler.'
   helpers:
     select:
       prompt: Bitte wählen
     submit:
-      create: ! '%{model} erstellen'
-      submit: ! '%{model} speichern'
-      update: ! '%{model} aktualisieren'
+      create: "%{model} erstellen"
+      submit: "%{model} speichern"
+      update: "%{model} aktualisieren"
   number:
     currency:
       format:
-        delimiter: .
-        format: ! '%u %n'
+        delimiter: "."
+        format: "%u %n"
         precision: 2
-        separator: ! ','
+        separator: ","
         significant: false
         strip_insignificant_zeros: false
-        unit: €
+        unit: "€"
     format:
-      delimiter: .
+      delimiter: "."
       precision: 2
-      separator: ! ','
+      separator: ","
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion:
             one: Milliarde
@@ -172,7 +174,7 @@ de-AT:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Byte
@@ -190,13 +192,13 @@ de-AT:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ' und '
-      two_words_connector: ! ' und '
-      words_connector: ! ', '
+      last_word_connector: " und "
+      two_words_connector: " und "
+      words_connector: ", "
   time:
     am: vormittags
     formats:
-      default: ! '%A, %d. %B %Y, %H:%M Uhr'
-      long: ! '%A, %d. %B %Y, %H:%M Uhr'
-      short: ! '%d. %B, %H:%M Uhr'
+      default: "%A, %d. %B %Y, %H:%M Uhr"
+      long: "%A, %d. %B %Y, %H:%M Uhr"
+      short: "%d. %B, %H:%M Uhr"
     pm: nachmittags

--- a/rails/locale/de-CH.yml
+++ b/rails/locale/de-CH.yml
@@ -1,3 +1,4 @@
+---
 de-CH:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ de-CH:
     - Fr
     - Sa
     abbr_month_names:
-    -
+    - 
     - Jan
     - Feb
     - Mär
@@ -31,11 +32,11 @@ de-CH:
     - Freitag
     - Samstag
     formats:
-      default: ! '%d.%m.%Y'
-      long: ! '%e. %B %Y'
-      short: ! '%e. %b'
+      default: "%d.%m.%Y"
+      long: "%e. %B %Y"
+      short: "%e. %b"
     month_names:
-    -
+    - 
     - Januar
     - Februar
     - März
@@ -78,16 +79,16 @@ de-CH:
         other: mehr als %{count} Jahre
       x_days:
         one: ein Tag
-        other: ! '%{count} Tage'
+        other: "%{count} Tage"
       x_minutes:
         one: eine Minute
-        other: ! '%{count} Minuten'
+        other: "%{count} Minuten"
       x_months:
         one: ein Monat
-        other: ! '%{count} Monate'
+        other: "%{count} Monate"
       x_seconds:
         one: eine Sekunde
-        other: ! '%{count} Sekunden'
+        other: "%{count} Sekunden"
     prompts:
       day: Tag
       hour: Stunden
@@ -96,7 +97,7 @@ de-CH:
       second: Sekunden
       year: Jahr
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: muss akzeptiert werden
       blank: muss ausgefüllt werden
@@ -115,46 +116,47 @@ de-CH:
       not_a_number: ist keine Zahl
       not_an_integer: muss ganzzahlig sein
       odd: muss ungerade sein
-      record_invalid: ! 'Gültigkeitsprüfung ist fehlgeschlagen: %{errors}'
+      record_invalid: 'Gültigkeitsprüfung ist fehlgeschlagen: %{errors}'
       restrict_dependent_destroy:
-        one: ! 'Datensatz kann nicht gelöscht werden, da ein abhängiger %{record}-Datensatz existiert.'
-        many: ! 'Datensatz kann nicht gelöscht werden, da abhängige %{record} existieren.'
+        one: Datensatz kann nicht gelöscht werden, da ein abhängiger %{record}-Datensatz
+          existiert.
+        many: Datensatz kann nicht gelöscht werden, da abhängige %{record} existieren.
       taken: ist bereits vergeben
       too_long: ist zu lang (nicht mehr als %{count} Zeichen)
       too_short: ist zu kurz (nicht weniger als %{count} Zeichen)
       wrong_length: hat die falsche Länge (muss genau %{count} Zeichen haben)
       other_than: darf nicht gleich %{count} sein
     template:
-      body: ! 'Bitte überprüfen Sie die folgenden Felder:'
+      body: 'Bitte überprüfen Sie die folgenden Felder:'
       header:
-        one: ! 'Konnte %{model} nicht speichern: ein Fehler.'
-        other: ! 'Konnte %{model} nicht speichern: %{count} Fehler.'
+        one: 'Konnte %{model} nicht speichern: ein Fehler.'
+        other: 'Konnte %{model} nicht speichern: %{count} Fehler.'
   helpers:
     select:
       prompt: Bitte wählen
     submit:
-      create: ! '%{model} erstellen'
-      submit: ! '%{model} speichern'
-      update: ! '%{model} aktualisieren'
+      create: "%{model} erstellen"
+      submit: "%{model} speichern"
+      update: "%{model} aktualisieren"
   number:
     currency:
       format:
-        delimiter: ! ''''
-        format: ! '%u %n'
+        delimiter: "'"
+        format: "%u %n"
         precision: 2
-        separator: .
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
         unit: CHF
     format:
-      delimiter: ! ''''
+      delimiter: "'"
       precision: 2
-      separator: .
+      separator: "."
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion:
             one: Milliarde
@@ -176,7 +178,7 @@ de-CH:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Byte
@@ -194,13 +196,13 @@ de-CH:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ' und '
-      two_words_connector: ! ' und '
-      words_connector: ! ', '
+      last_word_connector: " und "
+      two_words_connector: " und "
+      words_connector: ", "
   time:
     am: vormittags
     formats:
-      default: ! '%A, %d. %B %Y, %H:%M Uhr'
-      long: ! '%A, %d. %B %Y, %H:%M Uhr'
-      short: ! '%d. %B, %H:%M Uhr'
+      default: "%A, %d. %B %Y, %H:%M Uhr"
+      long: "%A, %d. %B %Y, %H:%M Uhr"
+      short: "%d. %B, %H:%M Uhr"
     pm: nachmittags

--- a/rails/locale/de.yml
+++ b/rails/locale/de.yml
@@ -1,3 +1,4 @@
+---
 de:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ de:
     - Fr
     - Sa
     abbr_month_names:
-    -
+    - 
     - Jan
     - Feb
     - Mär
@@ -31,11 +32,11 @@ de:
     - Freitag
     - Samstag
     formats:
-      default: ! '%d.%m.%Y'
-      long: ! '%e. %B %Y'
-      short: ! '%e. %b'
+      default: "%d.%m.%Y"
+      long: "%e. %B %Y"
+      short: "%e. %b"
     month_names:
-    -
+    - 
     - Januar
     - Februar
     - März
@@ -78,16 +79,16 @@ de:
         other: mehr als %{count} Jahre
       x_days:
         one: ein Tag
-        other: ! '%{count} Tage'
+        other: "%{count} Tage"
       x_minutes:
         one: eine Minute
-        other: ! '%{count} Minuten'
+        other: "%{count} Minuten"
       x_months:
         one: ein Monat
-        other: ! '%{count} Monate'
+        other: "%{count} Monate"
       x_seconds:
         one: eine Sekunde
-        other: ! '%{count} Sekunden'
+        other: "%{count} Sekunden"
     prompts:
       day: Tag
       hour: Stunden
@@ -96,7 +97,7 @@ de:
       second: Sekunden
       year: Jahr
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: muss akzeptiert werden
       blank: muss ausgefüllt werden
@@ -115,46 +116,47 @@ de:
       not_a_number: ist keine Zahl
       not_an_integer: muss ganzzahlig sein
       odd: muss ungerade sein
-      record_invalid: ! 'Gültigkeitsprüfung ist fehlgeschlagen: %{errors}'
+      record_invalid: 'Gültigkeitsprüfung ist fehlgeschlagen: %{errors}'
       restrict_dependent_destroy:
-        one: ! 'Datensatz kann nicht gelöscht werden, da ein abhängiger %{record}-Datensatz existiert.'
-        many: ! 'Datensatz kann nicht gelöscht werden, da abhängige %{record} existieren.'
+        one: Datensatz kann nicht gelöscht werden, da ein abhängiger %{record}-Datensatz
+          existiert.
+        many: Datensatz kann nicht gelöscht werden, da abhängige %{record} existieren.
       taken: ist bereits vergeben
       too_long: ist zu lang (mehr als %{count} Zeichen)
       too_short: ist zu kurz (weniger als %{count} Zeichen)
       wrong_length: hat die falsche Länge (muss genau %{count} Zeichen haben)
       other_than: darf nicht gleich %{count} sein
     template:
-      body: ! 'Bitte überprüfen Sie die folgenden Felder:'
+      body: 'Bitte überprüfen Sie die folgenden Felder:'
       header:
-        one: ! 'Konnte %{model} nicht speichern: ein Fehler.'
-        other: ! 'Konnte %{model} nicht speichern: %{count} Fehler.'
+        one: 'Konnte %{model} nicht speichern: ein Fehler.'
+        other: 'Konnte %{model} nicht speichern: %{count} Fehler.'
   helpers:
     select:
       prompt: Bitte wählen
     submit:
-      create: ! '%{model} erstellen'
-      submit: ! '%{model} speichern'
-      update: ! '%{model} aktualisieren'
+      create: "%{model} erstellen"
+      submit: "%{model} speichern"
+      update: "%{model} aktualisieren"
   number:
     currency:
       format:
-        delimiter: .
-        format: ! '%n %u'
+        delimiter: "."
+        format: "%n %u"
         precision: 2
-        separator: ! ','
+        separator: ","
         significant: false
         strip_insignificant_zeros: false
-        unit: €
+        unit: "€"
     format:
-      delimiter: .
+      delimiter: "."
       precision: 2
-      separator: ! ','
+      separator: ","
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion:
             one: Milliarde
@@ -172,7 +174,7 @@ de:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Byte
@@ -190,13 +192,13 @@ de:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ' und '
-      two_words_connector: ! ' und '
-      words_connector: ! ', '
+      last_word_connector: " und "
+      two_words_connector: " und "
+      words_connector: ", "
   time:
     am: vormittags
     formats:
-      default: ! '%A, %d. %B %Y, %H:%M Uhr'
-      long: ! '%A, %d. %B %Y, %H:%M Uhr'
-      short: ! '%d. %B, %H:%M Uhr'
+      default: "%A, %d. %B %Y, %H:%M Uhr"
+      long: "%A, %d. %B %Y, %H:%M Uhr"
+      short: "%d. %B, %H:%M Uhr"
     pm: nachmittags

--- a/rails/locale/el.yml
+++ b/rails/locale/el.yml
@@ -1,3 +1,4 @@
+---
 el:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ el:
     - Παρ
     - Σάβ
     abbr_month_names:
-    -
+    - 
     - Ιαν
     - Φεβ
     - Μαρ
@@ -31,11 +32,11 @@ el:
     - Παρασκευή
     - Σάββατο
     formats:
-      default: ! '%d/%m/%Y'
-      long: ! '%e %B %Y'
-      short: ! '%d %b'
+      default: "%d/%m/%Y"
+      long: "%e %B %Y"
+      short: "%d %b"
     month_names:
-    -
+    - 
     - Ιανουάριος
     - Φεβρουάριος
     - Μάρτιος
@@ -78,16 +79,16 @@ el:
         other: πάνω από %{count} χρόνια
       x_days:
         one: 1 μέρα
-        other: ! '%{count} μέρες'
+        other: "%{count} μέρες"
       x_minutes:
         one: 1 λεπτό
-        other: ! '%{count} λεπτά'
+        other: "%{count} λεπτά"
       x_months:
         one: 1 μήνα
-        other: ! '%{count} μήνες'
+        other: "%{count} μήνες"
       x_seconds:
         one: 1 δευτερόλεπτο
-        other: ! '%{count} δευτερόλεπτα'
+        other: "%{count} δευτερόλεπτα"
     prompts:
       day: Ημέρα
       hour: Ώρα
@@ -96,7 +97,7 @@ el:
       second: Δευτερόλεπτο
       year: Έτος
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: πρέπει να είναι αποδεκτό
       blank: δεν πρέπει να είναι κενό
@@ -114,7 +115,7 @@ el:
       not_a_number: δεν είναι αριθμός
       not_an_integer: πρέπει να είναι ακέραιος αριθμός
       odd: πρέπει να είναι περιττός
-      record_invalid: ! 'Επικύρωση απέτυχε: %{errors}'
+      record_invalid: 'Επικύρωση απέτυχε: %{errors}'
       taken: το έχουν ήδη χρησιμοποιήσει
       too_long:
         one: είναι πολύ μεγάλο (το μέγιστο μήκος είναι 1 χαρακτήρας)
@@ -126,10 +127,10 @@ el:
         one: έχει λανθασμένο μήκος (πρέπει να είναι 1 χαρακτήρας)
         other: έχει λανθασμένο μήκος (πρέπει να είναι %{count} χαρακτήρες)
     template:
-      body: ! 'Υπήρξαν προβλήματα με τα ακόλουθα πεδία:'
+      body: 'Υπήρξαν προβλήματα με τα ακόλουθα πεδία:'
       header:
         one: 1 λάθος εμπόδισε αυτό το %{model} να αποθηκευτεί.
-        other: ! '%{count} λάθη εμπόδισαν αυτό το %{model} να αποθηκευτεί.'
+        other: "%{count} λάθη εμπόδισαν αυτό το %{model} να αποθηκευτεί."
   helpers:
     select:
       prompt: Παρακαλώ επιλέξτε
@@ -140,22 +141,22 @@ el:
   number:
     currency:
       format:
-        delimiter: .
-        format: ! '%n %u'
+        delimiter: "."
+        format: "%n %u"
         precision: 2
-        separator: ! ','
+        separator: ","
         significant: false
         strip_insignificant_zeros: false
-        unit: €
+        unit: "€"
     format:
-      delimiter: .
+      delimiter: "."
       precision: 3
-      separator: ! ','
+      separator: ","
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: δισεκατομμύριο
           million: εκατομμύριο
@@ -169,7 +170,7 @@ el:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: byte
@@ -186,13 +187,13 @@ el:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ' και '
-      two_words_connector: ! ' και '
-      words_connector: ! ', '
+      last_word_connector: " και "
+      two_words_connector: " και "
+      words_connector: ", "
   time:
     am: π.μ.
     formats:
-      default: ! '%d %B %Y %H:%M'
-      long: ! '%A %d %B %Y %H:%M:%S %Z'
-      short: ! '%d %b %H:%M'
+      default: "%d %B %Y %H:%M"
+      long: "%A %d %B %Y %H:%M:%S %Z"
+      short: "%d %b %H:%M"
     pm: μ.μ.

--- a/rails/locale/en-AU.yml
+++ b/rails/locale/en-AU.yml
@@ -1,3 +1,4 @@
+---
 en-AU:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ en-AU:
     - Fri
     - Sat
     abbr_month_names:
-    -
+    - 
     - Jan
     - Feb
     - Mar
@@ -31,11 +32,11 @@ en-AU:
     - Friday
     - Saturday
     formats:
-      default: ! '%d-%m-%Y'
-      long: ! '%d %B, %Y'
-      short: ! '%d %b'
+      default: "%d-%m-%Y"
+      long: "%d %B, %Y"
+      short: "%d %b"
     month_names:
-    -
+    - 
     - January
     - February
     - March
@@ -78,16 +79,16 @@ en-AU:
         other: over %{count} years
       x_days:
         one: 1 day
-        other: ! '%{count} days'
+        other: "%{count} days"
       x_minutes:
         one: 1 minute
-        other: ! '%{count} minutes'
+        other: "%{count} minutes"
       x_months:
         one: 1 month
-        other: ! '%{count} months'
+        other: "%{count} months"
       x_seconds:
         one: 1 second
-        other: ! '%{count} seconds'
+        other: "%{count} seconds"
     prompts:
       day: Day
       hour: Hour
@@ -96,11 +97,11 @@ en-AU:
       second: Seconds
       year: Year
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: must be accepted
       blank: can't be blank
-      confirmation: ! "doesn't match %{attribute}"
+      confirmation: doesn't match %{attribute}
       empty: can't be empty
       equal_to: must be equal to %{count}
       even: must be even
@@ -114,7 +115,7 @@ en-AU:
       not_a_number: is not a number
       not_an_integer: must be an integer
       odd: must be odd
-      record_invalid: ! 'Validation failed: %{errors}'
+      record_invalid: 'Validation failed: %{errors}'
       taken: has already been taken
       too_long:
         one: is too long (maximum is 1 character)
@@ -126,10 +127,10 @@ en-AU:
         one: is the wrong length (should be 1 character)
         other: is the wrong length (should be %{count} characters)
     template:
-      body: ! 'There were problems with the following fields:'
+      body: 'There were problems with the following fields:'
       header:
         one: 1 error prohibited this %{model} from being saved
-        other: ! '%{count} errors prohibited this %{model} from being saved'
+        other: "%{count} errors prohibited this %{model} from being saved"
   helpers:
     select:
       prompt: Please select
@@ -140,22 +141,22 @@ en-AU:
   number:
     currency:
       format:
-        delimiter: ! ','
-        format: ! '%u%n'
+        delimiter: ","
+        format: "%u%n"
         precision: 2
-        separator: .
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
-        unit: $
+        unit: "$"
     format:
-      delimiter: ! ','
+      delimiter: ","
       precision: 3
-      separator: .
+      separator: "."
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: Billion
           million: Million
@@ -169,7 +170,7 @@ en-AU:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Byte
@@ -186,13 +187,13 @@ en-AU:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ', and '
-      two_words_connector: ! ' and '
-      words_connector: ! ', '
+      last_word_connector: ", and "
+      two_words_connector: " and "
+      words_connector: ", "
   time:
     am: am
     formats:
-      default: ! '%a, %d %b %Y %H:%M:%S %z'
-      long: ! '%d %B, %Y %H:%M'
-      short: ! '%d %b %H:%M'
+      default: "%a, %d %b %Y %H:%M:%S %z"
+      long: "%d %B, %Y %H:%M"
+      short: "%d %b %H:%M"
     pm: pm

--- a/rails/locale/en-CA.yml
+++ b/rails/locale/en-CA.yml
@@ -1,12 +1,4 @@
-# Canadian English for Rails
-# by Patrick CHEW (pchew@change.org)
-# contributors:
-#  - Patrick CHEW - https://github.com/pchew-change (pchew@change.org)
-# date/time notations based primarily on :
-# http://en.wikipedia.org/wiki/Date_and_time_notation_in_Canada
-# basing on the assumption that Anglophone Canada patterns after en-US
-# Corrected by [name] : [references]
-
+---
 en-CA:
   date:
     abbr_day_names:
@@ -18,7 +10,7 @@ en-CA:
     - Fri
     - Sat
     abbr_month_names:
-    -
+    - 
     - Jan
     - Feb
     - Mar
@@ -40,11 +32,11 @@ en-CA:
     - Friday
     - Saturday
     formats:
-      default: ! '%d-%m-%Y'
-      long: ! '%B %d, %Y'
-      short: ! '%d %b'
+      default: "%d-%m-%Y"
+      long: "%B %d, %Y"
+      short: "%d %b"
     month_names:
-    -
+    - 
     - January
     - February
     - March
@@ -87,16 +79,16 @@ en-CA:
         other: over %{count} years
       x_days:
         one: 1 day
-        other: ! '%{count} days'
+        other: "%{count} days"
       x_minutes:
         one: 1 minute
-        other: ! '%{count} minutes'
+        other: "%{count} minutes"
       x_months:
         one: 1 month
-        other: ! '%{count} months'
+        other: "%{count} months"
       x_seconds:
         one: 1 second
-        other: ! '%{count} seconds'
+        other: "%{count} seconds"
     prompts:
       day: Day
       hour: Hour
@@ -105,11 +97,11 @@ en-CA:
       second: Seconds
       year: Year
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: must be accepted
       blank: can't be blank
-      confirmation: ! "doesn't match %{attribute}"
+      confirmation: doesn't match %{attribute}
       empty: can't be empty
       equal_to: must be equal to %{count}
       even: must be even
@@ -123,7 +115,7 @@ en-CA:
       not_a_number: is not a number
       not_an_integer: must be an integer
       odd: must be odd
-      record_invalid: ! 'Validation failed: %{errors}'
+      record_invalid: 'Validation failed: %{errors}'
       taken: has already been taken
       too_long:
         one: is too long (maximum is 1 character)
@@ -135,10 +127,10 @@ en-CA:
         one: is the wrong length (should be 1 character)
         other: is the wrong length (should be %{count} characters)
     template:
-      body: ! 'There were problems with the following fields:'
+      body: 'There were problems with the following fields:'
       header:
         one: 1 error prohibited this %{model} from being saved
-        other: ! '%{count} errors prohibited this %{model} from being saved'
+        other: "%{count} errors prohibited this %{model} from being saved"
   helpers:
     select:
       prompt: Please select
@@ -149,22 +141,22 @@ en-CA:
   number:
     currency:
       format:
-        delimiter: ! ','
-        format: ! '%u%n'
+        delimiter: ","
+        format: "%u%n"
         precision: 2
-        separator: .
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
-        unit: $
+        unit: "$"
     format:
-      delimiter: ! ','
+      delimiter: ","
       precision: 3
-      separator: .
+      separator: "."
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: Billion
           million: Million
@@ -178,7 +170,7 @@ en-CA:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Byte
@@ -195,13 +187,13 @@ en-CA:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ', and '
-      two_words_connector: ! ' and '
-      words_connector: ! ', '
+      last_word_connector: ", and "
+      two_words_connector: " and "
+      words_connector: ", "
   time:
     am: am
     formats:
-      default: ! '%a, %d %b %Y %I:%M:%S %p %Z'
-      long: ! '%B %d, %Y %I:%M %p'
-      short: ! '%d %b %I:%M %p'
+      default: "%a, %d %b %Y %I:%M:%S %p %Z"
+      long: "%B %d, %Y %I:%M %p"
+      short: "%d %b %I:%M %p"
     pm: pm

--- a/rails/locale/en-GB.yml
+++ b/rails/locale/en-GB.yml
@@ -1,3 +1,4 @@
+---
 en-GB:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ en-GB:
     - Fri
     - Sat
     abbr_month_names:
-    -
+    - 
     - Jan
     - Feb
     - Mar
@@ -31,11 +32,11 @@ en-GB:
     - Friday
     - Saturday
     formats:
-      default: ! '%d-%m-%Y'
-      long: ! '%d %B, %Y'
-      short: ! '%d %b'
+      default: "%d-%m-%Y"
+      long: "%d %B, %Y"
+      short: "%d %b"
     month_names:
-    -
+    - 
     - January
     - February
     - March
@@ -78,16 +79,16 @@ en-GB:
         other: over %{count} years
       x_days:
         one: 1 day
-        other: ! '%{count} days'
+        other: "%{count} days"
       x_minutes:
         one: 1 minute
-        other: ! '%{count} minutes'
+        other: "%{count} minutes"
       x_months:
         one: 1 month
-        other: ! '%{count} months'
+        other: "%{count} months"
       x_seconds:
         one: 1 second
-        other: ! '%{count} seconds'
+        other: "%{count} seconds"
     prompts:
       day: Day
       hour: Hour
@@ -96,11 +97,11 @@ en-GB:
       second: Seconds
       year: Year
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: must be accepted
       blank: can't be blank
-      confirmation: ! "doesn't match %{attribute}"
+      confirmation: doesn't match %{attribute}
       empty: can't be empty
       equal_to: must be equal to %{count}
       even: must be even
@@ -114,7 +115,7 @@ en-GB:
       not_a_number: is not a number
       not_an_integer: must be an integer
       odd: must be odd
-      record_invalid: ! 'Validation failed: %{errors}'
+      record_invalid: 'Validation failed: %{errors}'
       taken: has already been taken
       too_long:
         one: is too long (maximum is 1 character)
@@ -126,10 +127,10 @@ en-GB:
         one: is the wrong length (should be 1 character)
         other: is the wrong length (should be %{count} characters)
     template:
-      body: ! 'There were problems with the following fields:'
+      body: 'There were problems with the following fields:'
       header:
         one: 1 error prohibited this %{model} from being saved
-        other: ! '%{count} errors prohibited this %{model} from being saved'
+        other: "%{count} errors prohibited this %{model} from being saved"
   helpers:
     select:
       prompt: Please select
@@ -140,22 +141,22 @@ en-GB:
   number:
     currency:
       format:
-        delimiter: ! ','
-        format: ! '%u%n'
+        delimiter: ","
+        format: "%u%n"
         precision: 2
-        separator: .
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
-        unit: £
+        unit: "£"
     format:
-      delimiter: ! ','
+      delimiter: ","
       precision: 3
-      separator: .
+      separator: "."
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: Billion
           million: Million
@@ -169,7 +170,7 @@ en-GB:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Byte
@@ -186,13 +187,13 @@ en-GB:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ', and '
-      two_words_connector: ! ' and '
-      words_connector: ! ', '
+      last_word_connector: ", and "
+      two_words_connector: " and "
+      words_connector: ", "
   time:
     am: am
     formats:
-      default: ! '%a, %d %b %Y %H:%M:%S %z'
-      long: ! '%d %B, %Y %H:%M'
-      short: ! '%d %b %H:%M'
+      default: "%a, %d %b %Y %H:%M:%S %z"
+      long: "%d %B, %Y %H:%M"
+      short: "%d %b %H:%M"
     pm: pm

--- a/rails/locale/en-IE.yml
+++ b/rails/locale/en-IE.yml
@@ -1,3 +1,4 @@
+---
 en-IE:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ en-IE:
     - Fri
     - Sat
     abbr_month_names:
-    -
+    - 
     - Jan
     - Feb
     - Mar
@@ -31,11 +32,11 @@ en-IE:
     - Friday
     - Saturday
     formats:
-      default: ! '%d-%m-%Y'
-      long: ! '%d %B, %Y'
-      short: ! '%d %b'
+      default: "%d-%m-%Y"
+      long: "%d %B, %Y"
+      short: "%d %b"
     month_names:
-    -
+    - 
     - January
     - February
     - March
@@ -78,16 +79,16 @@ en-IE:
         other: over %{count} years
       x_days:
         one: 1 day
-        other: ! '%{count} days'
+        other: "%{count} days"
       x_minutes:
         one: 1 minute
-        other: ! '%{count} minutes'
+        other: "%{count} minutes"
       x_months:
         one: 1 month
-        other: ! '%{count} months'
+        other: "%{count} months"
       x_seconds:
         one: 1 second
-        other: ! '%{count} seconds'
+        other: "%{count} seconds"
     prompts:
       day: Day
       hour: Hour
@@ -96,11 +97,11 @@ en-IE:
       second: Seconds
       year: Year
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: must be accepted
       blank: can't be blank
-      confirmation: ! "doesn't match %{attribute}"
+      confirmation: doesn't match %{attribute}
       empty: can't be empty
       equal_to: must be equal to %{count}
       even: must be even
@@ -114,7 +115,7 @@ en-IE:
       not_a_number: is not a number
       not_an_integer: must be an integer
       odd: must be odd
-      record_invalid: ! 'Validation failed: %{errors}'
+      record_invalid: 'Validation failed: %{errors}'
       taken: has already been taken
       too_long:
         one: is too long (maximum is 1 character)
@@ -126,10 +127,10 @@ en-IE:
         one: is the wrong length (should be 1 character)
         other: is the wrong length (should be %{count} characters)
     template:
-      body: ! 'There were problems with the following fields:'
+      body: 'There were problems with the following fields:'
       header:
         one: 1 error prohibited this %{model} from being saved
-        other: ! '%{count} errors prohibited this %{model} from being saved'
+        other: "%{count} errors prohibited this %{model} from being saved"
   helpers:
     select:
       prompt: Please select
@@ -140,22 +141,22 @@ en-IE:
   number:
     currency:
       format:
-        delimiter: ! ','
-        format: ! '%u%n'
+        delimiter: ","
+        format: "%u%n"
         precision: 2
-        separator: .
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
-        unit: €
+        unit: "€"
     format:
-      delimiter: ! ','
+      delimiter: ","
       precision: 3
-      separator: .
+      separator: "."
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: Billion
           million: Million
@@ -169,7 +170,7 @@ en-IE:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Byte
@@ -186,13 +187,13 @@ en-IE:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ', and '
-      two_words_connector: ! ' and '
-      words_connector: ! ', '
+      last_word_connector: ", and "
+      two_words_connector: " and "
+      words_connector: ", "
   time:
     am: am
     formats:
-      default: ! '%a, %d %b %Y %H:%M:%S %z'
-      long: ! '%d %B, %Y %H:%M'
-      short: ! '%d %b %H:%M'
+      default: "%a, %d %b %Y %H:%M:%S %z"
+      long: "%d %B, %Y %H:%M"
+      short: "%d %b %H:%M"
     pm: pm

--- a/rails/locale/en-IN.yml
+++ b/rails/locale/en-IN.yml
@@ -1,3 +1,4 @@
+---
 en-IN:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ en-IN:
     - Fri
     - Sat
     abbr_month_names:
-    -
+    - 
     - Jan
     - Feb
     - Mar
@@ -31,11 +32,11 @@ en-IN:
     - Friday
     - Saturday
     formats:
-      default: ! '%d-%m-%Y'
-      long: ! '%B %d, %Y'
-      short: ! '%b %d'
+      default: "%d-%m-%Y"
+      long: "%B %d, %Y"
+      short: "%b %d"
     month_names:
-    -
+    - 
     - January
     - February
     - March
@@ -78,16 +79,16 @@ en-IN:
         other: over %{count} years
       x_days:
         one: 1 day
-        other: ! '%{count} days'
+        other: "%{count} days"
       x_minutes:
         one: 1 minute
-        other: ! '%{count} minutes'
+        other: "%{count} minutes"
       x_months:
         one: 1 month
-        other: ! '%{count} months'
+        other: "%{count} months"
       x_seconds:
         one: 1 second
-        other: ! '%{count} seconds'
+        other: "%{count} seconds"
     prompts:
       day: Day
       hour: Hour
@@ -96,11 +97,11 @@ en-IN:
       second: Seconds
       year: Year
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: must be accepted
       blank: can't be blank
-      confirmation: ! "doesn't match %{attribute}"
+      confirmation: doesn't match %{attribute}
       empty: can't be empty
       equal_to: must be equal to %{count}
       even: must be even
@@ -114,7 +115,7 @@ en-IN:
       not_a_number: is not a number
       not_an_integer: must be an integer
       odd: must be odd
-      record_invalid: ! 'Validation failed: %{errors}'
+      record_invalid: 'Validation failed: %{errors}'
       taken: has already been taken
       too_long:
         one: is too long (maximum is 1 character)
@@ -126,10 +127,10 @@ en-IN:
         one: is the wrong length (should be 1 character)
         other: is the wrong length (should be %{count} characters)
     template:
-      body: ! 'There were problems with the following fields:'
+      body: 'There were problems with the following fields:'
       header:
         one: 1 error prohibited this %{model} from being saved
-        other: ! '%{count} errors prohibited this %{model} from being saved'
+        other: "%{count} errors prohibited this %{model} from being saved"
   helpers:
     select:
       prompt: Please select
@@ -140,22 +141,22 @@ en-IN:
   number:
     currency:
       format:
-        delimiter: ! ','
-        format: ! '%u%n'
+        delimiter: ","
+        format: "%u%n"
         precision: 2
-        separator: .
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
-        unit: ₹
+        unit: "₹"
     format:
-      delimiter: ! ','
+      delimiter: ","
       precision: 3
-      separator: .
+      separator: "."
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: Billion
           million: Million
@@ -169,7 +170,7 @@ en-IN:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Byte
@@ -186,13 +187,13 @@ en-IN:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ', and '
-      two_words_connector: ! ' and '
-      words_connector: ! ', '
+      last_word_connector: ", and "
+      two_words_connector: " and "
+      words_connector: ", "
   time:
     am: am
     formats:
-      default: ! '%a, %d %b %Y %H:%M:%S %z'
-      long: ! '%B %d, %Y %H:%M'
-      short: ! '%d %b %H:%M'
+      default: "%a, %d %b %Y %H:%M:%S %z"
+      long: "%B %d, %Y %H:%M"
+      short: "%d %b %H:%M"
     pm: pm

--- a/rails/locale/en-NZ.yml
+++ b/rails/locale/en-NZ.yml
@@ -1,3 +1,4 @@
+---
 en-NZ:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ en-NZ:
     - Fri
     - Sat
     abbr_month_names:
-    -
+    - 
     - Jan
     - Feb
     - Mar
@@ -31,11 +32,11 @@ en-NZ:
     - Friday
     - Saturday
     formats:
-      default: ! '%d-%m-%Y'
-      long: ! '%d %B, %Y'
-      short: ! '%d %b'
+      default: "%d-%m-%Y"
+      long: "%d %B, %Y"
+      short: "%d %b"
     month_names:
-    -
+    - 
     - January
     - February
     - March
@@ -78,16 +79,16 @@ en-NZ:
         other: over %{count} years
       x_days:
         one: 1 day
-        other: ! '%{count} days'
+        other: "%{count} days"
       x_minutes:
         one: 1 minute
-        other: ! '%{count} minutes'
+        other: "%{count} minutes"
       x_months:
         one: 1 month
-        other: ! '%{count} months'
+        other: "%{count} months"
       x_seconds:
         one: 1 second
-        other: ! '%{count} seconds'
+        other: "%{count} seconds"
     prompts:
       day: Day
       hour: Hour
@@ -96,11 +97,11 @@ en-NZ:
       second: Seconds
       year: Year
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: must be accepted
       blank: can't be blank
-      confirmation: ! "doesn't match %{attribute}"
+      confirmation: doesn't match %{attribute}
       empty: can't be empty
       equal_to: must be equal to %{count}
       even: must be even
@@ -114,7 +115,7 @@ en-NZ:
       not_a_number: is not a number
       not_an_integer: must be an integer
       odd: must be odd
-      record_invalid: ! 'Validation failed: %{errors}'
+      record_invalid: 'Validation failed: %{errors}'
       taken: has already been taken
       too_long:
         one: is too long (maximum is 1 character)
@@ -126,10 +127,10 @@ en-NZ:
         one: is the wrong length (should be 1 character)
         other: is the wrong length (should be %{count} characters)
     template:
-      body: ! 'There were problems with the following fields:'
+      body: 'There were problems with the following fields:'
       header:
         one: 1 error prohibited this %{model} from being saved
-        other: ! '%{count} errors prohibited this %{model} from being saved'
+        other: "%{count} errors prohibited this %{model} from being saved"
   helpers:
     select:
       prompt: Please select
@@ -140,22 +141,22 @@ en-NZ:
   number:
     currency:
       format:
-        delimiter: ! ','
-        format: ! '%u%n'
+        delimiter: ","
+        format: "%u%n"
         precision: 2
-        separator: .
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
-        unit: $
+        unit: "$"
     format:
-      delimiter: ! ','
+      delimiter: ","
       precision: 3
-      separator: .
+      separator: "."
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: Billion
           million: Million
@@ -169,7 +170,7 @@ en-NZ:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Byte
@@ -186,13 +187,13 @@ en-NZ:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ', and '
-      two_words_connector: ! ' and '
-      words_connector: ! ', '
+      last_word_connector: ", and "
+      two_words_connector: " and "
+      words_connector: ", "
   time:
     am: am
     formats:
-      default: ! '%a, %d %b %Y %H:%M:%S %z'
-      long: ! '%d %B, %Y %H:%M'
-      short: ! '%d %b %H:%M'
+      default: "%a, %d %b %Y %H:%M:%S %z"
+      long: "%d %B, %Y %H:%M"
+      short: "%d %b %H:%M"
     pm: pm

--- a/rails/locale/en-US.yml
+++ b/rails/locale/en-US.yml
@@ -1,3 +1,4 @@
+---
 en-US:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ en-US:
     - Fri
     - Sat
     abbr_month_names:
-    -
+    - 
     - Jan
     - Feb
     - Mar
@@ -31,11 +32,11 @@ en-US:
     - Friday
     - Saturday
     formats:
-      default: ! '%m-%d-%Y'
-      long: ! '%B %d, %Y'
-      short: ! '%b %d'
+      default: "%m-%d-%Y"
+      long: "%B %d, %Y"
+      short: "%b %d"
     month_names:
-    -
+    - 
     - January
     - February
     - March
@@ -78,16 +79,16 @@ en-US:
         other: over %{count} years
       x_days:
         one: 1 day
-        other: ! '%{count} days'
+        other: "%{count} days"
       x_minutes:
         one: 1 minute
-        other: ! '%{count} minutes'
+        other: "%{count} minutes"
       x_months:
         one: 1 month
-        other: ! '%{count} months'
+        other: "%{count} months"
       x_seconds:
         one: 1 second
-        other: ! '%{count} seconds'
+        other: "%{count} seconds"
     prompts:
       day: Day
       hour: Hour
@@ -96,12 +97,12 @@ en-US:
       second: Seconds
       year: Year
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: must be accepted
       blank: can't be blank
       present: must be blank
-      confirmation: ! "doesn't match %{attribute}"
+      confirmation: doesn't match %{attribute}
       empty: can't be empty
       equal_to: must be equal to %{count}
       even: must be even
@@ -115,10 +116,10 @@ en-US:
       not_a_number: is not a number
       not_an_integer: must be an integer
       odd: must be odd
-      record_invalid: ! 'Validation failed: %{errors}'
+      record_invalid: 'Validation failed: %{errors}'
       restrict_dependent_destroy:
-        one: "Cannot delete record because a dependent %{record} exists"
-        many: "Cannot delete record because dependent %{record} exist"
+        one: Cannot delete record because a dependent %{record} exists
+        many: Cannot delete record because dependent %{record} exist
       taken: has already been taken
       too_long:
         one: is too long (maximum is 1 character)
@@ -129,12 +130,12 @@ en-US:
       wrong_length:
         one: is the wrong length (should be 1 character)
         other: is the wrong length (should be %{count} characters)
-      other_than: "must be other than %{count}"
+      other_than: must be other than %{count}
     template:
-      body: ! 'There were problems with the following fields:'
+      body: 'There were problems with the following fields:'
       header:
         one: 1 error prohibited this %{model} from being saved
-        other: ! '%{count} errors prohibited this %{model} from being saved'
+        other: "%{count} errors prohibited this %{model} from being saved"
   helpers:
     select:
       prompt: Please select
@@ -145,22 +146,22 @@ en-US:
   number:
     currency:
       format:
-        delimiter: ! ','
-        format: ! '%u%n'
+        delimiter: ","
+        format: "%u%n"
         precision: 2
-        separator: .
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
-        unit: $
+        unit: "$"
     format:
-      delimiter: ! ','
+      delimiter: ","
       precision: 3
-      separator: .
+      separator: "."
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: Billion
           million: Million
@@ -174,7 +175,7 @@ en-US:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Byte
@@ -192,13 +193,13 @@ en-US:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ', and '
-      two_words_connector: ! ' and '
-      words_connector: ! ', '
+      last_word_connector: ", and "
+      two_words_connector: " and "
+      words_connector: ", "
   time:
     am: am
     formats:
-      default: ! '%a, %d %b %Y %I:%M:%S %p %Z'
-      long: ! '%B %d, %Y %I:%M %p'
-      short: ! '%d %b %I:%M %p'
+      default: "%a, %d %b %Y %I:%M:%S %p %Z"
+      long: "%B %d, %Y %I:%M %p"
+      short: "%d %b %I:%M %p"
     pm: pm

--- a/rails/locale/en-ZA.yml
+++ b/rails/locale/en-ZA.yml
@@ -1,3 +1,4 @@
+---
 en-ZA:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ en-ZA:
     - Fri
     - Sat
     abbr_month_names:
-    -
+    - 
     - Jan
     - Feb
     - Mar
@@ -31,11 +32,11 @@ en-ZA:
     - Friday
     - Saturday
     formats:
-      default: ! '%Y-%m-%d'
-      long: ! '%B %d, %Y'
-      short: ! '%b %d'
+      default: "%Y-%m-%d"
+      long: "%B %d, %Y"
+      short: "%b %d"
     month_names:
-    -
+    - 
     - January
     - February
     - March
@@ -78,16 +79,16 @@ en-ZA:
         other: over %{count} years
       x_days:
         one: 1 day
-        other: ! '%{count} days'
+        other: "%{count} days"
       x_minutes:
         one: 1 minute
-        other: ! '%{count} minutes'
+        other: "%{count} minutes"
       x_months:
         one: 1 month
-        other: ! '%{count} months'
+        other: "%{count} months"
       x_seconds:
         one: 1 second
-        other: ! '%{count} seconds'
+        other: "%{count} seconds"
     prompts:
       day: Day
       hour: Hour
@@ -96,12 +97,12 @@ en-ZA:
       second: Seconds
       year: Year
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: must be accepted
       blank: can't be blank
       present: must be blank
-      confirmation: ! "doesn't match %{attribute}"
+      confirmation: doesn't match %{attribute}
       empty: can't be empty
       equal_to: must be equal to %{count}
       even: must be even
@@ -115,10 +116,10 @@ en-ZA:
       not_a_number: is not a number
       not_an_integer: must be an integer
       odd: must be odd
-      record_invalid: ! 'Validation failed: %{errors}'
+      record_invalid: 'Validation failed: %{errors}'
       restrict_dependent_destroy:
-        one: "Cannot delete record because a dependent %{record} exists"
-        many: "Cannot delete record because dependent %{record} exist"
+        one: Cannot delete record because a dependent %{record} exists
+        many: Cannot delete record because dependent %{record} exist
       taken: has already been taken
       too_long:
         one: is too long (maximum is 1 character)
@@ -129,12 +130,12 @@ en-ZA:
       wrong_length:
         one: is the wrong length (should be 1 character)
         other: is the wrong length (should be %{count} characters)
-      other_than: "must be other than %{count}"
+      other_than: must be other than %{count}
     template:
-      body: ! 'There were problems with the following fields:'
+      body: 'There were problems with the following fields:'
       header:
         one: 1 error prohibited this %{model} from being saved
-        other: ! '%{count} errors prohibited this %{model} from being saved'
+        other: "%{count} errors prohibited this %{model} from being saved"
   helpers:
     select:
       prompt: Please select
@@ -145,22 +146,22 @@ en-ZA:
   number:
     currency:
       format:
-        delimiter: ! ','
-        format: ! '%u%n'
+        delimiter: ","
+        format: "%u%n"
         precision: 2
-        separator: .
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
         unit: R
     format:
-      delimiter: ! ','
+      delimiter: ","
       precision: 3
-      separator: .
+      separator: "."
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: Billion
           million: Million
@@ -174,7 +175,7 @@ en-ZA:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Byte
@@ -192,13 +193,13 @@ en-ZA:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ', and '
-      two_words_connector: ! ' and '
-      words_connector: ! ', '
+      last_word_connector: ", and "
+      two_words_connector: " and "
+      words_connector: ", "
   time:
     am: am
     formats:
-      default: ! '%a, %d %b %Y %H:%M:%S %z'
-      long: ! '%B %d, %Y %H:%M'
-      short: ! '%d %b %H:%M'
+      default: "%a, %d %b %Y %H:%M:%S %z"
+      long: "%B %d, %Y %H:%M"
+      short: "%d %b %H:%M"
     pm: pm

--- a/rails/locale/en.yml
+++ b/rails/locale/en.yml
@@ -1,3 +1,4 @@
+---
 en:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ en:
     - Fri
     - Sat
     abbr_month_names:
-    -
+    - 
     - Jan
     - Feb
     - Mar
@@ -31,11 +32,11 @@ en:
     - Friday
     - Saturday
     formats:
-      default: ! '%Y-%m-%d'
-      long: ! '%B %d, %Y'
-      short: ! '%b %d'
+      default: "%Y-%m-%d"
+      long: "%B %d, %Y"
+      short: "%b %d"
     month_names:
-    -
+    - 
     - January
     - February
     - March
@@ -78,16 +79,16 @@ en:
         other: over %{count} years
       x_days:
         one: 1 day
-        other: ! '%{count} days'
+        other: "%{count} days"
       x_minutes:
         one: 1 minute
-        other: ! '%{count} minutes'
+        other: "%{count} minutes"
       x_months:
         one: 1 month
-        other: ! '%{count} months'
+        other: "%{count} months"
       x_seconds:
         one: 1 second
-        other: ! '%{count} seconds'
+        other: "%{count} seconds"
     prompts:
       day: Day
       hour: Hour
@@ -96,12 +97,12 @@ en:
       second: Seconds
       year: Year
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: must be accepted
       blank: can't be blank
       present: must be blank
-      confirmation: ! "doesn't match %{attribute}"
+      confirmation: doesn't match %{attribute}
       empty: can't be empty
       equal_to: must be equal to %{count}
       even: must be even
@@ -115,10 +116,10 @@ en:
       not_a_number: is not a number
       not_an_integer: must be an integer
       odd: must be odd
-      record_invalid: ! 'Validation failed: %{errors}'
+      record_invalid: 'Validation failed: %{errors}'
       restrict_dependent_destroy:
-        one: "Cannot delete record because a dependent %{record} exists"
-        many: "Cannot delete record because dependent %{record} exist"
+        one: Cannot delete record because a dependent %{record} exists
+        many: Cannot delete record because dependent %{record} exist
       taken: has already been taken
       too_long:
         one: is too long (maximum is 1 character)
@@ -129,12 +130,12 @@ en:
       wrong_length:
         one: is the wrong length (should be 1 character)
         other: is the wrong length (should be %{count} characters)
-      other_than: "must be other than %{count}"
+      other_than: must be other than %{count}
     template:
-      body: ! 'There were problems with the following fields:'
+      body: 'There were problems with the following fields:'
       header:
         one: 1 error prohibited this %{model} from being saved
-        other: ! '%{count} errors prohibited this %{model} from being saved'
+        other: "%{count} errors prohibited this %{model} from being saved"
   helpers:
     select:
       prompt: Please select
@@ -145,22 +146,22 @@ en:
   number:
     currency:
       format:
-        delimiter: ! ','
-        format: ! '%u%n'
+        delimiter: ","
+        format: "%u%n"
         precision: 2
-        separator: .
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
-        unit: $
+        unit: "$"
     format:
-      delimiter: ! ','
+      delimiter: ","
       precision: 3
-      separator: .
+      separator: "."
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: Billion
           million: Million
@@ -174,7 +175,7 @@ en:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Byte
@@ -192,13 +193,13 @@ en:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ', and '
-      two_words_connector: ! ' and '
-      words_connector: ! ', '
+      last_word_connector: ", and "
+      two_words_connector: " and "
+      words_connector: ", "
   time:
     am: am
     formats:
-      default: ! '%a, %d %b %Y %H:%M:%S %z'
-      long: ! '%B %d, %Y %H:%M'
-      short: ! '%d %b %H:%M'
+      default: "%a, %d %b %Y %H:%M:%S %z"
+      long: "%B %d, %Y %H:%M"
+      short: "%d %b %H:%M"
     pm: pm

--- a/rails/locale/eo.yml
+++ b/rails/locale/eo.yml
@@ -1,3 +1,4 @@
+---
 eo:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ eo:
     - ven
     - sam
     abbr_month_names:
-    -
+    - 
     - jan.
     - feb.
     - mar.
@@ -31,11 +32,11 @@ eo:
     - vendredo
     - sabato
     formats:
-      default: ! '%Y/%m/%d'
-      long: ! '%e %B %Y'
-      short: ! '%e %b'
+      default: "%Y/%m/%d"
+      long: "%e %B %Y"
+      short: "%e %b"
     month_names:
-    -
+    - 
     - januaro
     - februaro
     - marto
@@ -80,16 +81,16 @@ eo:
         other: pli ol %{count} jaroj
       x_days:
         one: 1 tago
-        other: ! '%{count} tagoj'
+        other: "%{count} tagoj"
       x_minutes:
         one: 1 minuto
-        other: ! '%{count} minutoj'
+        other: "%{count} minutoj"
       x_months:
         one: 1 monato
-        other: ! '%{count} monatoj'
+        other: "%{count} monatoj"
       x_seconds:
         one: 1 sekundo
-        other: ! '%{count} sekundoj'
+        other: "%{count} sekundoj"
     prompts:
       day: Tago
       hour: Horo
@@ -98,7 +99,7 @@ eo:
       second: Sekundo
       year: Jaro
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: devas esti akceptita
       blank: devas esti kompletigita
@@ -116,16 +117,16 @@ eo:
       not_a_number: ne estas nombro
       not_an_integer: devas esti entjero
       odd: devas esti nepara
-      record_invalid: ! 'Validado malsukcesis: %{errors}'
+      record_invalid: 'Validado malsukcesis: %{errors}'
       taken: ne estas disponebla
       too_long: estas tro longa (maksimume %{count} karekteroj)
       too_short: estas tro mallonga (minimume %{count} karakteroj)
       wrong_length: ne estas je ĝusta longo (devas enhavi %{count} karakterojn)
     template:
-      body: ! 'Kontrolu la jenajn kampojn: '
+      body: 'Kontrolu la jenajn kampojn: '
       header:
-        one: ! 'Ne eblas registri tiun %{model}: 1 eraro'
-        other: ! 'Ne eblas registri tiun %{model}: %{count} eraroj'
+        one: 'Ne eblas registri tiun %{model}: 1 eraro'
+        other: 'Ne eblas registri tiun %{model}: %{count} eraroj'
   helpers:
     select:
       prompt: Bonvolu elekti
@@ -136,22 +137,22 @@ eo:
   number:
     currency:
       format:
-        delimiter: ! ' '
-        format: ! '%n %u'
+        delimiter: " "
+        format: "%n %u"
         precision: 2
-        separator: ! ','
+        separator: ","
         significant: false
         strip_insignificant_zeros: false
-        unit: €
+        unit: "€"
     format:
-      delimiter: ! ' '
+      delimiter: " "
       precision: 3
-      separator: ! ','
+      separator: ","
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: miliardo
           million: miliono
@@ -165,7 +166,7 @@ eo:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: bitoko
@@ -182,13 +183,13 @@ eo:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ' kaj '
-      two_words_connector: ! ' kaj '
-      words_connector: ! ', '
+      last_word_connector: " kaj "
+      two_words_connector: " kaj "
+      words_connector: ", "
   time:
     am: am
     formats:
-      default: ! '%d %B %Y %H:%M:%S'
-      long: ! '%A %d %B %Y %H:%M'
-      short: ! '%d %b %H:%M'
+      default: "%d %B %Y %H:%M:%S"
+      long: "%A %d %B %Y %H:%M"
+      short: "%d %b %H:%M"
     pm: pm

--- a/rails/locale/es-419.yml
+++ b/rails/locale/es-419.yml
@@ -1,12 +1,4 @@
-# "generic" Latin American Spanish translations for Rails
-# to use when contrasting with Spain Spanish (es-ES) without individual country breakouts
-# current "'generic' Latin American" Spanish values are based off of current Latin American locales
-# note: 'currency' value is unspecified and banged out, given the wide variety of currencies in Latin America
-# by Patrick CHEW (pchew@change.org)
-# contributors:
-#  - Patrick CHEW - https://github.com/pchew-change (pchew@change.org)
-# Corrected by {name} : {email}
-
+---
 es-419:
   date:
     abbr_day_names:
@@ -18,7 +10,7 @@ es-419:
     - vie
     - sáb
     abbr_month_names:
-    -
+    - 
     - ene
     - feb
     - mar
@@ -40,11 +32,11 @@ es-419:
     - viernes
     - sábado
     formats:
-      default: ! '%d/%m/%Y'
-      long: ! '%A, %d de %B de %Y'
-      short: ! '%d de %b'
+      default: "%d/%m/%Y"
+      long: "%A, %d de %B de %Y"
+      short: "%d de %b"
     month_names:
-    -
+    - 
     - enero
     - febrero
     - marzo
@@ -87,16 +79,16 @@ es-419:
         other: más de %{count} años
       x_days:
         one: 1 día
-        other: ! '%{count} días'
+        other: "%{count} días"
       x_minutes:
         one: 1 minuto
-        other: ! '%{count} minutos'
+        other: "%{count} minutos"
       x_months:
         one: 1 mes
-        other: ! '%{count} meses'
+        other: "%{count} meses"
       x_seconds:
         one: 1 segundo
-        other: ! '%{count} segundos'
+        other: "%{count} segundos"
     prompts:
       day: Día
       hour: Hora
@@ -105,7 +97,7 @@ es-419:
       second: Segundos
       year: Año
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: debe ser aceptado
       blank: no puede estar en blanco
@@ -123,7 +115,7 @@ es-419:
       not_a_number: no es un número
       not_an_integer: debe ser un entero
       odd: debe ser un número non
-      record_invalid: ! 'La validación falló: %{errors}'
+      record_invalid: 'La validación falló: %{errors}'
       taken: ya ha sido tomado
       too_long:
         one: es demasiado largo (máximo 1 caracter)
@@ -135,10 +127,10 @@ es-419:
         one: longitud errónea (debe ser de 1 caracter)
         other: longitud errónea (debe ser de %{count} caracteres)
     template:
-      body: ! 'Revise que los siguientes campos sean válidos:'
+      body: 'Revise que los siguientes campos sean válidos:'
       header:
-        one: ! '%{model} no pudo guardarse debido a 1 error'
-        other: ! '%{model} no pudo guardarse debido a %{count} errores'
+        one: "%{model} no pudo guardarse debido a 1 error"
+        other: "%{model} no pudo guardarse debido a %{count} errores"
   helpers:
     select:
       prompt: Por favor selecciona
@@ -149,22 +141,22 @@ es-419:
   number:
     currency:
       format:
-        delimiter: ! ','
-        format: ! '%u%n'
+        delimiter: ","
+        format: "%u%n"
         precision: 2
-        separator: .
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
-        unit: '¤'
+        unit: "¤"
     format:
-      delimiter: ! ','
+      delimiter: ","
       precision: 2
-      separator: .
+      separator: "."
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: mil millones
           million: millón
@@ -173,12 +165,12 @@ es-419:
           trillion: billón
           unit: ''
       format:
-        delimiter: ! ','
+        delimiter: ","
         precision: 3
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Byte
@@ -189,19 +181,19 @@ es-419:
           tb: TB
     percentage:
       format:
-        delimiter: ! ','
+        delimiter: ","
     precision:
       format:
-        delimiter: ! ','
+        delimiter: ","
   support:
     array:
-      last_word_connector: ! ' y '
-      two_words_connector: ! ' y '
-      words_connector: ! ', '
+      last_word_connector: " y "
+      two_words_connector: " y "
+      words_connector: ", "
   time:
     am: am
     formats:
-      default: ! '%a, %d de %b de %Y a las %H:%M:%S %Z'
-      long: ! '%A, %d de %B de %Y a las %I:%M %p'
-      short: ! '%d de %b a las %H:%M hrs'
+      default: "%a, %d de %b de %Y a las %H:%M:%S %Z"
+      long: "%A, %d de %B de %Y a las %I:%M %p"
+      short: "%d de %b a las %H:%M hrs"
     pm: pm

--- a/rails/locale/es-AR.yml
+++ b/rails/locale/es-AR.yml
@@ -1,3 +1,4 @@
+---
 es-AR:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ es-AR:
     - vie
     - sáb
     abbr_month_names:
-    -
+    - 
     - ene
     - feb
     - mar
@@ -31,11 +32,11 @@ es-AR:
     - viernes
     - sábado
     formats:
-      default: ! '%d/%m/%Y'
-      long: ! '%A, %d de %B de %Y'
-      short: ! '%d de %b'
+      default: "%d/%m/%Y"
+      long: "%A, %d de %B de %Y"
+      short: "%d de %b"
     month_names:
-    -
+    - 
     - enero
     - febrero
     - marzo
@@ -78,16 +79,16 @@ es-AR:
         other: más de %{count} años
       x_days:
         one: 1 día
-        other: ! '%{count} días'
+        other: "%{count} días"
       x_minutes:
         one: 1 minuto
-        other: ! '%{count} minutos'
+        other: "%{count} minutos"
       x_months:
         one: 1 mes
-        other: ! '%{count} meses'
+        other: "%{count} meses"
       x_seconds:
         one: 1 segundo
-        other: ! '%{count} segundos'
+        other: "%{count} segundos"
     prompts:
       day: Día
       hour: Hora
@@ -96,7 +97,7 @@ es-AR:
       second: Segundos
       year: Año
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: debe ser aceptado
       blank: no puede estar en blanco
@@ -114,7 +115,7 @@ es-AR:
       not_a_number: no es un número
       not_an_integer: debe ser un entero
       odd: debe ser un número non
-      record_invalid: ! 'La validación falló: %{errors}'
+      record_invalid: 'La validación falló: %{errors}'
       taken: ya ha sido tomado
       too_long:
         one: es demasiado largo (máximo 1 caracter)
@@ -126,10 +127,10 @@ es-AR:
         one: longitud errónea (debe ser de 1 caracter)
         other: longitud errónea (debe ser de %{count} caracteres)
     template:
-      body: ! 'Revise que los siguientes campos sean válidos:'
+      body: 'Revise que los siguientes campos sean válidos:'
       header:
-        one: ! '%{model} no pudo guardarse debido a 1 error'
-        other: ! '%{model} no pudo guardarse debido a %{count} errores'
+        one: "%{model} no pudo guardarse debido a 1 error"
+        other: "%{model} no pudo guardarse debido a %{count} errores"
   helpers:
     select:
       prompt: Por favor selecciona
@@ -140,22 +141,22 @@ es-AR:
   number:
     currency:
       format:
-        delimiter: .
-        format: ! '%u%n'
+        delimiter: "."
+        format: "%u%n"
         precision: 2
-        separator: ! ','
+        separator: ","
         significant: false
         strip_insignificant_zeros: false
-        unit: $
+        unit: "$"
     format:
-      delimiter: .
+      delimiter: "."
       precision: 2
-      separator: ! ','
+      separator: ","
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: mil millones
           million: millón
@@ -164,12 +165,12 @@ es-AR:
           trillion: billón
           unit: ''
       format:
-        delimiter: ! ','
+        delimiter: ","
         precision: 3
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Byte
@@ -180,19 +181,19 @@ es-AR:
           tb: TB
     percentage:
       format:
-        delimiter: ! ','
+        delimiter: ","
     precision:
       format:
-        delimiter: ! ','
+        delimiter: ","
   support:
     array:
-      last_word_connector: ! ' y '
-      two_words_connector: ! ' y '
-      words_connector: ! ', '
+      last_word_connector: " y "
+      two_words_connector: " y "
+      words_connector: ", "
   time:
     am: am
     formats:
-      default: ! '%a, %d de %b de %Y a las %H:%M:%S %Z'
-      long: ! '%A, %d de %B de %Y a las %I:%M %p'
-      short: ! '%d de %b a las %H:%M hrs'
+      default: "%a, %d de %b de %Y a las %H:%M:%S %Z"
+      long: "%A, %d de %B de %Y a las %I:%M %p"
+      short: "%d de %b a las %H:%M hrs"
     pm: pm

--- a/rails/locale/es-CL.yml
+++ b/rails/locale/es-CL.yml
@@ -1,3 +1,4 @@
+---
 es-CL:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ es-CL:
     - vie
     - sáb
     abbr_month_names:
-    -
+    - 
     - ene
     - feb
     - mar
@@ -31,11 +32,11 @@ es-CL:
     - viernes
     - sábado
     formats:
-      default: ! '%d/%m/%Y'
-      long: ! '%A %d de %B de %Y'
-      short: ! '%d de %b'
+      default: "%d/%m/%Y"
+      long: "%A %d de %B de %Y"
+      short: "%d de %b"
     month_names:
-    -
+    - 
     - enero
     - febrero
     - marzo
@@ -78,16 +79,16 @@ es-CL:
         other: más de %{count} años
       x_days:
         one: 1 día
-        other: ! '%{count} días'
+        other: "%{count} días"
       x_minutes:
         one: 1 minuto
-        other: ! '%{count} minutos'
+        other: "%{count} minutos"
       x_months:
         one: 1 mes
-        other: ! '%{count} meses'
+        other: "%{count} meses"
       x_seconds:
         one: 1 segundo
-        other: ! '%{count} segundos'
+        other: "%{count} segundos"
     prompts:
       day: Día
       hour: Hora
@@ -96,7 +97,7 @@ es-CL:
       second: Segundos
       year: Año
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: debe ser aceptado
       blank: no puede estar en blanco
@@ -114,13 +115,13 @@ es-CL:
       not_a_number: no es un número
       not_an_integer: debe ser un entero
       odd: debe ser impar
-      record_invalid: ! 'La validación falló: %{errors}'
+      record_invalid: 'La validación falló: %{errors}'
       taken: ya está en uso
       too_long: es demasiado largo (%{count} caracteres máximo)
       too_short: es demasiado corto (%{count} caracteres mínimo)
       wrong_length: no tiene la longitud correcta (%{count} caracteres exactos)
     template:
-      body: ! 'Se encontraron problemas con los siguientes campos:'
+      body: 'Se encontraron problemas con los siguientes campos:'
       header:
         one: No se pudo guardar este/a %{model} porque se encontró 1 error
         other: No se pudo guardar este/a %{model} porque se encontraron %{count} errores
@@ -134,22 +135,22 @@ es-CL:
   number:
     currency:
       format:
-        delimiter: .
-        format: ! '%u %n'
+        delimiter: "."
+        format: "%u %n"
         precision: 0
-        separator: ! ','
+        separator: ","
         significant: false
         strip_insignificant_zeros: false
-        unit: $
+        unit: "$"
     format:
-      delimiter: .
+      delimiter: "."
       precision: 3
-      separator: ! ','
+      separator: ","
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: mil millones
           million: millón
@@ -163,7 +164,7 @@ es-CL:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Byte
@@ -180,13 +181,13 @@ es-CL:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ', y '
-      two_words_connector: ! ' y '
-      words_connector: ! ', '
+      last_word_connector: ", y "
+      two_words_connector: " y "
+      words_connector: ", "
   time:
     am: am
     formats:
-      default: ! '%A, %d de %B de %Y %H:%M:%S %z'
-      long: ! '%A %d de %B de %Y %H:%M'
-      short: ! '%d de %b %H:%M'
+      default: "%A, %d de %B de %Y %H:%M:%S %z"
+      long: "%A %d de %B de %Y %H:%M"
+      short: "%d de %b %H:%M"
     pm: pm

--- a/rails/locale/es-CO.yml
+++ b/rails/locale/es-CO.yml
@@ -1,3 +1,4 @@
+---
 es-CO:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ es-CO:
     - vie
     - sáb
     abbr_month_names:
-    -
+    - 
     - ene
     - feb
     - mar
@@ -31,11 +32,11 @@ es-CO:
     - viernes
     - sábado
     formats:
-      default: ! '%d/%m/%Y'
-      long: ! '%A, %d de %B de %Y'
-      short: ! '%d de %b'
+      default: "%d/%m/%Y"
+      long: "%A, %d de %B de %Y"
+      short: "%d de %b"
     month_names:
-    -
+    - 
     - enero
     - febrero
     - marzo
@@ -78,16 +79,16 @@ es-CO:
         other: más de %{count} años
       x_days:
         one: 1 día
-        other: ! '%{count} días'
+        other: "%{count} días"
       x_minutes:
         one: 1 minuto
-        other: ! '%{count} minutos'
+        other: "%{count} minutos"
       x_months:
         one: 1 mes
-        other: ! '%{count} meses'
+        other: "%{count} meses"
       x_seconds:
         one: 1 segundo
-        other: ! '%{count} segundos'
+        other: "%{count} segundos"
     prompts:
       day: Día
       hour: Hora
@@ -96,7 +97,7 @@ es-CO:
       second: Segundos
       year: Año
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: debe ser aceptado
       blank: no puede estar en blanco
@@ -114,7 +115,7 @@ es-CO:
       not_a_number: no es un número
       not_an_integer: debe ser un entero
       odd: debe ser un número impar
-      record_invalid: ! 'La validación falló: %{errors}'
+      record_invalid: 'La validación falló: %{errors}'
       taken: ya ha sido tomado
       too_long:
         one: es demasiado largo (máximo 1 caracter)
@@ -126,10 +127,10 @@ es-CO:
         one: longitud errónea (debe ser de 1 caracter)
         other: longitud errónea (debe ser de %{count} caracteres)
     template:
-      body: ! 'Revise que los siguientes campos sean válidos:'
+      body: 'Revise que los siguientes campos sean válidos:'
       header:
-        one: ! '%{model} no pudo guardarse debido a 1 error'
-        other: ! '%{model} no pudo guardarse debido a %{count} errores'
+        one: "%{model} no pudo guardarse debido a 1 error"
+        other: "%{model} no pudo guardarse debido a %{count} errores"
   helpers:
     select:
       prompt: Por favor selecciona
@@ -140,22 +141,22 @@ es-CO:
   number:
     currency:
       format:
-        delimiter: ! ','
-        format: ! '%u%n'
+        delimiter: ","
+        format: "%u%n"
         precision: 0
-        separator: .
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
-        unit: $
+        unit: "$"
     format:
-      delimiter: ! ','
+      delimiter: ","
       precision: 2
-      separator: .
+      separator: "."
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: mil millones
           million: millón
@@ -164,12 +165,12 @@ es-CO:
           trillion: billón
           unit: ''
       format:
-        delimiter: ! ','
+        delimiter: ","
         precision: 3
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Byte
@@ -180,19 +181,19 @@ es-CO:
           tb: TB
     percentage:
       format:
-        delimiter: ! ','
+        delimiter: ","
     precision:
       format:
-        delimiter: ! ','
+        delimiter: ","
   support:
     array:
-      last_word_connector: ! ' y '
-      two_words_connector: ! ' y '
-      words_connector: ! ', '
+      last_word_connector: " y "
+      two_words_connector: " y "
+      words_connector: ", "
   time:
     am: am
     formats:
-      default: ! '%a, %d de %b de %Y a las %H:%M:%S %Z'
-      long: ! '%A, %d de %B de %Y a las %I:%M %p'
-      short: ! '%d de %b a las %H:%M hrs'
+      default: "%a, %d de %b de %Y a las %H:%M:%S %Z"
+      long: "%A, %d de %B de %Y a las %I:%M %p"
+      short: "%d de %b a las %H:%M hrs"
     pm: pm

--- a/rails/locale/es-CR.yml
+++ b/rails/locale/es-CR.yml
@@ -1,3 +1,4 @@
+---
 es-CR:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ es-CR:
     - vie
     - sáb
     abbr_month_names:
-    -
+    - 
     - ene
     - feb
     - mar
@@ -31,11 +32,11 @@ es-CR:
     - viernes
     - sábado
     formats:
-      default: ! '%d/%m/%Y'
-      long: ! '%A, %d de %B de %Y'
-      short: ! '%d de %b'
+      default: "%d/%m/%Y"
+      long: "%A, %d de %B de %Y"
+      short: "%d de %b"
     month_names:
-    -
+    - 
     - enero
     - febrero
     - marzo
@@ -78,16 +79,16 @@ es-CR:
         other: más de %{count} años
       x_days:
         one: 1 día
-        other: ! '%{count} días'
+        other: "%{count} días"
       x_minutes:
         one: 1 minuto
-        other: ! '%{count} minutos'
+        other: "%{count} minutos"
       x_months:
         one: 1 mes
-        other: ! '%{count} meses'
+        other: "%{count} meses"
       x_seconds:
         one: 1 segundo
-        other: ! '%{count} segundos'
+        other: "%{count} segundos"
     prompts:
       day: Día
       hour: Hora
@@ -96,7 +97,7 @@ es-CR:
       second: Segundos
       year: Año
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: debe ser aceptado
       blank: no puede estar en blanco
@@ -114,7 +115,7 @@ es-CR:
       not_a_number: no es un número
       not_an_integer: debe ser un entero
       odd: debe ser un número impar
-      record_invalid: ! 'La validación falló: %{errors}'
+      record_invalid: 'La validación falló: %{errors}'
       taken: ya ha sido utilizado
       too_long:
         one: es demasiado largo (máximo 1 caracter)
@@ -126,10 +127,10 @@ es-CR:
         one: longitud errónea (debe ser de 1 caracter)
         other: longitud errónea (debe ser de %{count} caracteres)
     template:
-      body: ! 'Revise que los siguientes campos sean válidos:'
+      body: 'Revise que los siguientes campos sean válidos:'
       header:
-        one: ! '%{model} no pudo guardarse debido a 1 error'
-        other: ! '%{model} no pudo guardarse debido a %{count} errores'
+        one: "%{model} no pudo guardarse debido a 1 error"
+        other: "%{model} no pudo guardarse debido a %{count} errores"
   helpers:
     select:
       prompt: Por favor seleccione
@@ -140,22 +141,22 @@ es-CR:
   number:
     currency:
       format:
-        delimiter: ! ','
-        format: ! '%u%n'
+        delimiter: ","
+        format: "%u%n"
         precision: 0
-        separator: .
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
-        unit: ¢
+        unit: "¢"
     format:
-      delimiter: ! ','
+      delimiter: ","
       precision: 2
-      separator: .
+      separator: "."
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: mil millones
           million: millón
@@ -164,12 +165,12 @@ es-CR:
           trillion: billón
           unit: ''
       format:
-        delimiter: ! ','
+        delimiter: ","
         precision: 3
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Byte
@@ -180,19 +181,19 @@ es-CR:
           tb: TB
     percentage:
       format:
-        delimiter: ! ','
+        delimiter: ","
     precision:
       format:
-        delimiter: ! ','
+        delimiter: ","
   support:
     array:
-      last_word_connector: ! ' y '
-      two_words_connector: ! ' y '
-      words_connector: ! ', '
+      last_word_connector: " y "
+      two_words_connector: " y "
+      words_connector: ", "
   time:
     am: am
     formats:
-      default: ! '%a, %d de %b de %Y a las %H:%M:%S %Z'
-      long: ! '%A, %d de %B de %Y a las %I:%M %p'
-      short: ! '%d de %b a las %H:%M hrs'
+      default: "%a, %d de %b de %Y a las %H:%M:%S %Z"
+      long: "%A, %d de %B de %Y a las %I:%M %p"
+      short: "%d de %b a las %H:%M hrs"
     pm: pm

--- a/rails/locale/es-EC.yml
+++ b/rails/locale/es-EC.yml
@@ -1,3 +1,4 @@
+---
 es-EC:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ es-EC:
     - vie
     - sáb
     abbr_month_names:
-    -
+    - 
     - ene
     - feb
     - mar
@@ -31,11 +32,11 @@ es-EC:
     - viernes
     - sábado
     formats:
-      default: ! '%-d/%m/%Y'
-      long: ! '%A, %-d de %B de %Y'
-      short: ! '%-d de %b'
+      default: "%-d/%m/%Y"
+      long: "%A, %-d de %B de %Y"
+      short: "%-d de %b"
     month_names:
-    -
+    - 
     - enero
     - febrero
     - marzo
@@ -78,16 +79,16 @@ es-EC:
         other: más de %{count} años
       x_days:
         one: 1 día
-        other: ! '%{count} días'
+        other: "%{count} días"
       x_minutes:
         one: 1 minuto
-        other: ! '%{count} minutos'
+        other: "%{count} minutos"
       x_months:
         one: 1 mes
-        other: ! '%{count} meses'
+        other: "%{count} meses"
       x_seconds:
         one: 1 segundo
-        other: ! '%{count} segundos'
+        other: "%{count} segundos"
     prompts:
       day: Día
       hour: Hora
@@ -96,7 +97,7 @@ es-EC:
       second: Segundos
       year: Año
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: debe ser aceptado
       blank: no puede estar en blanco
@@ -115,10 +116,10 @@ es-EC:
       not_a_number: no es un número
       not_an_integer: debe ser un entero
       odd: debe ser un número impar
-      record_invalid: ! 'La validación falló: %{errors}'
+      record_invalid: 'La validación falló: %{errors}'
       restrict_dependent_destroy:
-        one: "No se puede eliminar el registro porque existe un(a) %{record} dependiente"
-        many: "No se puede eliminar el registro porque existen %{record} dependientes"
+        one: No se puede eliminar el registro porque existe un(a) %{record} dependiente
+        many: No se puede eliminar el registro porque existen %{record} dependientes
       taken: ya está en uso
       too_long:
         one: es demasiado largo (máximo 1 caracter)
@@ -129,9 +130,9 @@ es-EC:
       wrong_length:
         one: no tiene la longitud correcta (debe ser de 1 caracter)
         other: no tiene la longitud correcta (debe ser de %{count} caracteres)
-      other_than: "debe ser diferente de %{count}"
+      other_than: debe ser diferente de %{count}
     template:
-      body: ! 'Revise que los siguientes campos sean válidos:'
+      body: 'Revise que los siguientes campos sean válidos:'
       header:
         one: No se pudo guardar este/a %{model} porque se encontró 1 error
         other: No se pudo guardar este/a %{model} porque se encontraron %{count} errores
@@ -145,22 +146,22 @@ es-EC:
   number:
     currency:
       format:
-        delimiter: ! ','
-        format: ! '%u%n'
+        delimiter: ","
+        format: "%u%n"
         precision: 2
-        separator: .
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
-        unit: $
+        unit: "$"
     format:
-      delimiter: ! ','
+      delimiter: ","
       precision: 3
-      separator: .
+      separator: "."
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: mil millones
           million: millón
@@ -174,7 +175,7 @@ es-EC:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Byte
@@ -192,13 +193,13 @@ es-EC:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ' y '
-      two_words_connector: ! ' y '
-      words_connector: ! ', '
+      last_word_connector: " y "
+      two_words_connector: " y "
+      words_connector: ", "
   time:
     am: am
     formats:
-      default: ! '%A, %-d de %B de %Y a las %-I:%M:%S %p %Z'
-      long: ! '%-d de %B de %Y a las %-I:%M %p'
-      short: ! '%-d %b %-I:%M %p'
+      default: "%A, %-d de %B de %Y a las %-I:%M:%S %p %Z"
+      long: "%-d de %B de %Y a las %-I:%M %p"
+      short: "%-d %b %-I:%M %p"
     pm: pm

--- a/rails/locale/es-MX.yml
+++ b/rails/locale/es-MX.yml
@@ -1,3 +1,4 @@
+---
 es-MX:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ es-MX:
     - vie
     - sáb
     abbr_month_names:
-    -
+    - 
     - ene
     - feb
     - mar
@@ -31,11 +32,11 @@ es-MX:
     - viernes
     - sábado
     formats:
-      default: ! '%d/%m/%Y'
-      long: ! '%A, %d de %B de %Y'
-      short: ! '%d de %b'
+      default: "%d/%m/%Y"
+      long: "%A, %d de %B de %Y"
+      short: "%d de %b"
     month_names:
-    -
+    - 
     - enero
     - febrero
     - marzo
@@ -78,16 +79,16 @@ es-MX:
         other: más de %{count} años
       x_days:
         one: 1 día
-        other: ! '%{count} días'
+        other: "%{count} días"
       x_minutes:
         one: 1 minuto
-        other: ! '%{count} minutos'
+        other: "%{count} minutos"
       x_months:
         one: 1 mes
-        other: ! '%{count} meses'
+        other: "%{count} meses"
       x_seconds:
         one: 1 segundo
-        other: ! '%{count} segundos'
+        other: "%{count} segundos"
     prompts:
       day: Día
       hour: Hora
@@ -96,7 +97,7 @@ es-MX:
       second: Segundos
       year: Año
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: debe ser aceptado
       blank: no puede estar en blanco
@@ -115,10 +116,10 @@ es-MX:
       not_a_number: no es un número
       not_an_integer: debe ser un entero
       odd: debe ser un número non
-      record_invalid: ! 'La validación falló: %{errors}'
+      record_invalid: 'La validación falló: %{errors}'
       restrict_dependent_destroy:
-        one: "El registro no puede ser eliminado pues existe un %{record} dependiente"
-        many: "El registro no puede ser eliminado pues existen %{record} dependientes"
+        one: El registro no puede ser eliminado pues existe un %{record} dependiente
+        many: El registro no puede ser eliminado pues existen %{record} dependientes
       taken: ya ha sido tomado
       too_long:
         one: es demasiado largo (máximo 1 caracter)
@@ -129,12 +130,12 @@ es-MX:
       wrong_length:
         one: longitud errónea (debe ser de 1 caracter)
         other: longitud errónea (debe ser de %{count} caracteres)
-      other_than: "debe ser diferente a %{count}"
+      other_than: debe ser diferente a %{count}
     template:
-      body: ! 'Revise que los siguientes campos sean válidos:'
+      body: 'Revise que los siguientes campos sean válidos:'
       header:
-        one: ! '%{model} no pudo guardarse debido a 1 error'
-        other: ! '%{model} no pudo guardarse debido a %{count} errores'
+        one: "%{model} no pudo guardarse debido a 1 error"
+        other: "%{model} no pudo guardarse debido a %{count} errores"
   helpers:
     select:
       prompt: Por favor selecciona
@@ -145,22 +146,22 @@ es-MX:
   number:
     currency:
       format:
-        delimiter: ! ','
-        format: ! '%u%n'
+        delimiter: ","
+        format: "%u%n"
         precision: 2
-        separator: .
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
-        unit: $
+        unit: "$"
     format:
-      delimiter: ! ','
+      delimiter: ","
       precision: 2
-      separator: .
+      separator: "."
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: mil millones
           million: millón
@@ -169,12 +170,12 @@ es-MX:
           trillion: billón
           unit: ''
       format:
-        delimiter: ! ','
+        delimiter: ","
         precision: 3
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Byte
@@ -185,20 +186,20 @@ es-MX:
           tb: TB
     percentage:
       format:
-        delimiter: ! ','
+        delimiter: ","
         format: "%n%"
     precision:
       format:
-        delimiter: ! ','
+        delimiter: ","
   support:
     array:
-      last_word_connector: ! ' y '
-      two_words_connector: ! ' y '
-      words_connector: ! ', '
+      last_word_connector: " y "
+      two_words_connector: " y "
+      words_connector: ", "
   time:
     am: am
     formats:
-      default: ! '%a, %d de %b de %Y a las %H:%M:%S %Z'
-      long: ! '%A, %d de %B de %Y a las %I:%M %p'
-      short: ! '%d de %b a las %H:%M hrs'
+      default: "%a, %d de %b de %Y a las %H:%M:%S %Z"
+      long: "%A, %d de %B de %Y a las %I:%M %p"
+      short: "%d de %b a las %H:%M hrs"
     pm: pm

--- a/rails/locale/es-PA.yml
+++ b/rails/locale/es-PA.yml
@@ -1,3 +1,4 @@
+---
 es-PA:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ es-PA:
     - vie
     - sáb
     abbr_month_names:
-    -
+    - 
     - ene
     - feb
     - mar
@@ -31,11 +32,11 @@ es-PA:
     - viernes
     - sábado
     formats:
-      default: ! '%-d/%m/%Y'
-      long: ! '%A, %-d de %B de %Y'
-      short: ! '%-d de %b'
+      default: "%-d/%m/%Y"
+      long: "%A, %-d de %B de %Y"
+      short: "%-d de %b"
     month_names:
-    -
+    - 
     - enero
     - febrero
     - marzo
@@ -78,16 +79,16 @@ es-PA:
         other: más de %{count} años
       x_days:
         one: 1 día
-        other: ! '%{count} días'
+        other: "%{count} días"
       x_minutes:
         one: 1 minuto
-        other: ! '%{count} minutos'
+        other: "%{count} minutos"
       x_months:
         one: 1 mes
-        other: ! '%{count} meses'
+        other: "%{count} meses"
       x_seconds:
         one: 1 segundo
-        other: ! '%{count} segundos'
+        other: "%{count} segundos"
     prompts:
       day: Día
       hour: Hora
@@ -96,7 +97,7 @@ es-PA:
       second: Segundos
       year: Año
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: debe ser aceptado
       blank: no puede estar en blanco
@@ -115,10 +116,10 @@ es-PA:
       not_a_number: no es un número
       not_an_integer: debe ser un entero
       odd: debe ser un número impar
-      record_invalid: ! 'La validación falló: %{errors}'
+      record_invalid: 'La validación falló: %{errors}'
       restrict_dependent_destroy:
-        one: "No se puede eliminar el registro porque existe un(a) %{record} dependiente"
-        many: "No se puede eliminar el registro porque existen %{record} dependientes"
+        one: No se puede eliminar el registro porque existe un(a) %{record} dependiente
+        many: No se puede eliminar el registro porque existen %{record} dependientes
       taken: ya está en uso
       too_long:
         one: es demasiado largo (máximo 1 caracter)
@@ -129,9 +130,9 @@ es-PA:
       wrong_length:
         one: no tiene la longitud correcta (debe ser de 1 caracter)
         other: no tiene la longitud correcta (debe ser de %{count} caracteres)
-      other_than: "debe ser diferente de %{count}"
+      other_than: debe ser diferente de %{count}
     template:
-      body: ! 'Revise que los siguientes campos sean válidos:'
+      body: 'Revise que los siguientes campos sean válidos:'
       header:
         one: No se pudo guardar este/a %{model} porque se encontró 1 error
         other: No se pudo guardar este/a %{model} porque se encontraron %{count} errores
@@ -145,22 +146,22 @@ es-PA:
   number:
     currency:
       format:
-        delimiter: ! ','
-        format: ! '%u%n'
+        delimiter: ","
+        format: "%u%n"
         precision: 2
-        separator: .
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
         unit: B/.
     format:
-      delimiter: ! ','
+      delimiter: ","
       precision: 3
-      separator: .
+      separator: "."
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: mil millones
           million: millón
@@ -174,7 +175,7 @@ es-PA:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Byte
@@ -192,13 +193,13 @@ es-PA:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ' y '
-      two_words_connector: ! ' y '
-      words_connector: ! ', '
+      last_word_connector: " y "
+      two_words_connector: " y "
+      words_connector: ", "
   time:
     am: am
     formats:
-      default: ! '%A, %-d de %B de %Y a las %-I:%M:%S %p %Z'
-      long: ! '%-d de %B de %Y a las %-I:%M %p'
-      short: ! '%-d %b %-I:%M %p'
+      default: "%A, %-d de %B de %Y a las %-I:%M:%S %p %Z"
+      long: "%-d de %B de %Y a las %-I:%M %p"
+      short: "%-d %b %-I:%M %p"
     pm: pm

--- a/rails/locale/es-PE.yml
+++ b/rails/locale/es-PE.yml
@@ -1,3 +1,4 @@
+---
 es-PE:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ es-PE:
     - vie
     - sáb
     abbr_month_names:
-    -
+    - 
     - ene
     - feb
     - mar
@@ -31,11 +32,11 @@ es-PE:
     - viernes
     - sábado
     formats:
-      default: ! '%d/%m/%Y'
-      long: ! '%A, %d de %B del %Y'
-      short: ! '%d de %b'
+      default: "%d/%m/%Y"
+      long: "%A, %d de %B del %Y"
+      short: "%d de %b"
     month_names:
-    -
+    - 
     - enero
     - febrero
     - marzo
@@ -75,16 +76,16 @@ es-PE:
         other: más de %{count} años
       x_days:
         one: 1 día
-        other: ! '%{count} días'
+        other: "%{count} días"
       x_minutes:
         one: 1 minuto
-        other: ! '%{count} minutos'
+        other: "%{count} minutos"
       x_months:
         one: 1 mes
-        other: ! '%{count} meses'
+        other: "%{count} meses"
       x_seconds:
         one: 1 segundo
-        other: ! '%{count} segundos'
+        other: "%{count} segundos"
     prompts:
       day: Día
       hour: Hora
@@ -93,7 +94,7 @@ es-PE:
       second: Segundos
       year: Año
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: debe ser aceptado
       blank: no puede estar en blanco
@@ -110,7 +111,7 @@ es-PE:
       less_than_or_equal_to: debe ser menor o igual que %{count}
       not_a_number: no es un número
       odd: debe ser un número non
-      record_invalid: ! 'Falla de validación: %{errors}'
+      record_invalid: 'Falla de validación: %{errors}'
       taken: ya ha sido tomado
       too_long:
         one: es demasiado largo (máximo 1 caracter)
@@ -122,38 +123,38 @@ es-PE:
         one: longitud errónea (debe ser de 1 caracter)
         other: longitud errónea (debe ser de %{count} caracteres)
     template:
-      body: ! 'Revise que los siguientes campos sean válidos:'
+      body: 'Revise que los siguientes campos sean válidos:'
       header:
-        one: ! '%{model} no pudo guardarse debido a 1 error'
-        other: ! '%{model} no pudo guardarse debido a %{count} errores'
+        one: "%{model} no pudo guardarse debido a 1 error"
+        other: "%{model} no pudo guardarse debido a %{count} errores"
   number:
     currency:
       format:
-        delimiter: ! ','
-        format: ! '%u%n'
+        delimiter: ","
+        format: "%u%n"
         precision: 2
-        separator: .
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
         unit: S./
     format:
-      delimiter: ! ','
+      delimiter: ","
       precision: 2
-      separator: .
+      separator: "."
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           unit: ''
       format:
-        delimiter: ! ','
+        delimiter: ","
         precision: 2
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Byte
@@ -164,14 +165,14 @@ es-PE:
           tb: TB
     percentage:
       format:
-        delimiter: ! ','
+        delimiter: ","
     precision:
       format:
-        delimiter: ! ','
+        delimiter: ","
   time:
     am: am
     formats:
-      default: ! '%a, %d de %b del %Y a las %H:%M:%S %Z'
-      long: ! '%A, %d de %B del %Y a las %I:%M %p'
-      short: ! '%d de %b a las %H:%M hrs'
+      default: "%a, %d de %b del %Y a las %H:%M:%S %Z"
+      long: "%A, %d de %B del %Y a las %I:%M %p"
+      short: "%d de %b a las %H:%M hrs"
     pm: pm

--- a/rails/locale/es-US.yml
+++ b/rails/locale/es-US.yml
@@ -1,3 +1,4 @@
+---
 es-US:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ es-US:
     - vie
     - sáb
     abbr_month_names:
-    -
+    - 
     - ene
     - feb
     - mar
@@ -31,11 +32,11 @@ es-US:
     - viernes
     - sábado
     formats:
-      default: ! '%d/%m/%Y'
-      long: ! '%A, %d de %B de %Y'
-      short: ! '%d de %b'
+      default: "%d/%m/%Y"
+      long: "%A, %d de %B de %Y"
+      short: "%d de %b"
     month_names:
-    -
+    - 
     - enero
     - febrero
     - marzo
@@ -78,16 +79,16 @@ es-US:
         other: más de %{count} años
       x_days:
         one: 1 día
-        other: ! '%{count} días'
+        other: "%{count} días"
       x_minutes:
         one: 1 minuto
-        other: ! '%{count} minutos'
+        other: "%{count} minutos"
       x_months:
         one: 1 mes
-        other: ! '%{count} meses'
+        other: "%{count} meses"
       x_seconds:
         one: 1 segundo
-        other: ! '%{count} segundos'
+        other: "%{count} segundos"
     prompts:
       day: Día
       hour: Hora
@@ -96,7 +97,7 @@ es-US:
       second: Segundos
       year: Año
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: debe ser aceptado
       blank: no puede estar en blanco
@@ -114,7 +115,7 @@ es-US:
       not_a_number: no es un número
       not_an_integer: debe ser un entero
       odd: debe ser un número non
-      record_invalid: ! 'La validación falló: %{errors}'
+      record_invalid: 'La validación falló: %{errors}'
       taken: ya ha sido tomado
       too_long:
         one: es demasiado largo (máximo 1 caracter)
@@ -126,10 +127,10 @@ es-US:
         one: longitud errónea (debe ser de 1 caracter)
         other: longitud errónea (debe ser de %{count} caracteres)
     template:
-      body: ! 'Revise que los siguientes campos sean válidos:'
+      body: 'Revise que los siguientes campos sean válidos:'
       header:
-        one: ! '%{model} no pudo guardarse debido a 1 error'
-        other: ! '%{model} no pudo guardarse debido a %{count} errores'
+        one: "%{model} no pudo guardarse debido a 1 error"
+        other: "%{model} no pudo guardarse debido a %{count} errores"
   helpers:
     select:
       prompt: Por favor selecciona
@@ -140,22 +141,22 @@ es-US:
   number:
     currency:
       format:
-        delimiter: ! ','
-        format: ! '%u%n'
+        delimiter: ","
+        format: "%u%n"
         precision: 2
-        separator: .
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
-        unit: $
+        unit: "$"
     format:
-      delimiter: ! ','
+      delimiter: ","
       precision: 2
-      separator: .
+      separator: "."
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: mil millones
           million: millón
@@ -164,12 +165,12 @@ es-US:
           trillion: billón
           unit: ''
       format:
-        delimiter: ! ','
+        delimiter: ","
         precision: 3
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Byte
@@ -180,19 +181,19 @@ es-US:
           tb: TB
     percentage:
       format:
-        delimiter: ! ','
+        delimiter: ","
     precision:
       format:
-        delimiter: ! ','
+        delimiter: ","
   support:
     array:
-      last_word_connector: ! ' y '
-      two_words_connector: ! ' y '
-      words_connector: ! ', '
+      last_word_connector: " y "
+      two_words_connector: " y "
+      words_connector: ", "
   time:
     am: am
     formats:
-      default: ! '%a, %d de %b de %Y a las %H:%M:%S %Z'
-      long: ! '%A, %d de %B de %Y a las %I:%M %p'
-      short: ! '%d de %b a las %H:%M hrs'
+      default: "%a, %d de %b de %Y a las %H:%M:%S %Z"
+      long: "%A, %d de %B de %Y a las %I:%M %p"
+      short: "%d de %b a las %H:%M hrs"
     pm: pm

--- a/rails/locale/es-VE.yml
+++ b/rails/locale/es-VE.yml
@@ -1,3 +1,4 @@
+---
 es-VE:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ es-VE:
     - vie
     - sáb
     abbr_month_names:
-    -
+    - 
     - ene
     - feb
     - mar
@@ -31,11 +32,11 @@ es-VE:
     - viernes
     - sábado
     formats:
-      default: ! '%d/%m/%Y'
-      long: ! '%A, %d de %B de %Y'
-      short: ! '%d de %b'
+      default: "%d/%m/%Y"
+      long: "%A, %d de %B de %Y"
+      short: "%d de %b"
     month_names:
-    -
+    - 
     - enero
     - febrero
     - marzo
@@ -78,16 +79,16 @@ es-VE:
         other: más de %{count} años
       x_days:
         one: 1 día
-        other: ! '%{count} días'
+        other: "%{count} días"
       x_minutes:
         one: 1 minuto
-        other: ! '%{count} minutos'
+        other: "%{count} minutos"
       x_months:
         one: 1 mes
-        other: ! '%{count} meses'
+        other: "%{count} meses"
       x_seconds:
         one: 1 segundo
-        other: ! '%{count} segundos'
+        other: "%{count} segundos"
     prompts:
       day: Día
       hour: Hora
@@ -96,7 +97,7 @@ es-VE:
       second: Segundos
       year: Año
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: debe ser aceptado
       blank: no puede estar en blanco
@@ -114,7 +115,7 @@ es-VE:
       not_a_number: no es un número
       not_an_integer: debe ser un entero
       odd: debe ser un número impar
-      record_invalid: ! 'La validación falló: %{errors}'
+      record_invalid: 'La validación falló: %{errors}'
       taken: ya está en  uso
       too_long:
         one: es demasiado largo (máximo 1 caracter)
@@ -126,10 +127,10 @@ es-VE:
         one: longitud errónea (debe ser de 1 caracter)
         other: longitud errónea (debe ser de %{count} caracteres)
     template:
-      body: ! 'Revise que los siguientes campos sean válidos:'
+      body: 'Revise que los siguientes campos sean válidos:'
       header:
-        one: ! '%{model} no pudo guardarse debido a 1 error'
-        other: ! '%{model} no pudo guardarse debido a %{count} errores'
+        one: "%{model} no pudo guardarse debido a 1 error"
+        other: "%{model} no pudo guardarse debido a %{count} errores"
   helpers:
     select:
       prompt: Por favor selecciona
@@ -140,22 +141,22 @@ es-VE:
   number:
     currency:
       format:
-        delimiter: .
-        format: ! '%u%n'
+        delimiter: "."
+        format: "%u%n"
         precision: 2
-        separator: ! ','
+        separator: ","
         significant: false
         strip_insignificant_zeros: false
-        unit: ! 'Bs.'
+        unit: Bs.
     format:
-      delimiter: .
+      delimiter: "."
       precision: 2
-      separator: ! ','
+      separator: ","
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: mil millones
           million: millón
@@ -164,12 +165,12 @@ es-VE:
           trillion: billón
           unit: ''
       format:
-        delimiter: .
+        delimiter: "."
         precision: 3
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Byte
@@ -180,19 +181,19 @@ es-VE:
           tb: TB
     percentage:
       format:
-        delimiter: ! ','
+        delimiter: ","
     precision:
       format:
-        delimiter: ! ','
+        delimiter: ","
   support:
     array:
-      last_word_connector: ! ', y '
-      two_words_connector: ! ' y '
-      words_connector: ! ', '
+      last_word_connector: ", y "
+      two_words_connector: " y "
+      words_connector: ", "
   time:
     am: am
     formats:
-      default: ! '%a, %d de %b de %Y a las %H:%M:%S%p %Z'
-      long: ! '%A, %d de %B de %Y a las %I:%M%p'
-      short: ! '%d de %b a las %H:%M%p'
+      default: "%a, %d de %b de %Y a las %H:%M:%S%p %Z"
+      long: "%A, %d de %B de %Y a las %I:%M%p"
+      short: "%d de %b a las %H:%M%p"
     pm: pm

--- a/rails/locale/es.yml
+++ b/rails/locale/es.yml
@@ -1,3 +1,4 @@
+---
 es:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ es:
     - vie
     - sáb
     abbr_month_names:
-    -
+    - 
     - ene
     - feb
     - mar
@@ -31,11 +32,11 @@ es:
     - viernes
     - sábado
     formats:
-      default: ! '%d/%m/%Y'
-      long: ! '%d de %B de %Y'
-      short: ! '%d de %b'
+      default: "%d/%m/%Y"
+      long: "%d de %B de %Y"
+      short: "%d de %b"
     month_names:
-    -
+    - 
     - enero
     - febrero
     - marzo
@@ -78,16 +79,16 @@ es:
         other: más de %{count} años
       x_days:
         one: 1 día
-        other: ! '%{count} días'
+        other: "%{count} días"
       x_minutes:
         one: 1 minuto
-        other: ! '%{count} minutos'
+        other: "%{count} minutos"
       x_months:
         one: 1 mes
-        other: ! '%{count} meses'
+        other: "%{count} meses"
       x_seconds:
         one: 1 segundo
-        other: ! '%{count} segundos'
+        other: "%{count} segundos"
     prompts:
       day: Día
       hour: Hora
@@ -96,7 +97,7 @@ es:
       second: Segundos
       year: Año
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: debe ser aceptado
       blank: no puede estar en blanco
@@ -114,13 +115,13 @@ es:
       not_a_number: no es un número
       not_an_integer: debe ser un entero
       odd: debe ser impar
-      record_invalid: ! 'La validación falló: %{errors}'
+      record_invalid: 'La validación falló: %{errors}'
       taken: ya está en uso
       too_long: es demasiado largo (%{count} caracteres máximo)
       too_short: es demasiado corto (%{count} caracteres mínimo)
       wrong_length: no tiene la longitud correcta (%{count} caracteres exactos)
     template:
-      body: ! 'Se encontraron problemas con los siguientes campos:'
+      body: 'Se encontraron problemas con los siguientes campos:'
       header:
         one: No se pudo guardar este/a %{model} porque se encontró 1 error
         other: No se pudo guardar este/a %{model} porque se encontraron %{count} errores
@@ -134,22 +135,22 @@ es:
   number:
     currency:
       format:
-        delimiter: .
-        format: ! '%n %u'
+        delimiter: "."
+        format: "%n %u"
         precision: 2
-        separator: ! ','
+        separator: ","
         significant: false
         strip_insignificant_zeros: false
-        unit: €
+        unit: "€"
     format:
-      delimiter: .
+      delimiter: "."
       precision: 3
-      separator: ! ','
+      separator: ","
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: mil millones
           million: millón
@@ -163,7 +164,7 @@ es:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Byte
@@ -180,13 +181,13 @@ es:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ', y '
-      two_words_connector: ! ' y '
-      words_connector: ! ', '
+      last_word_connector: ", y "
+      two_words_connector: " y "
+      words_connector: ", "
   time:
     am: am
     formats:
-      default: ! '%A, %d de %B de %Y %H:%M:%S %z'
-      long: ! '%d de %B de %Y %H:%M'
-      short: ! '%d de %b %H:%M'
+      default: "%A, %d de %B de %Y %H:%M:%S %z"
+      long: "%d de %B de %Y %H:%M"
+      short: "%d de %b %H:%M"
     pm: pm

--- a/rails/locale/et.yml
+++ b/rails/locale/et.yml
@@ -1,3 +1,4 @@
+---
 et:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ et:
     - R
     - L
     abbr_month_names:
-    -
+    - 
     - jaan.
     - veebr.
     - märts
@@ -31,11 +32,11 @@ et:
     - reede
     - laupäev
     formats:
-      default: ! '%d.%m.%Y'
-      long: ! '%d. %B %Y'
-      short: ! '%d.%m.%y'
+      default: "%d.%m.%Y"
+      long: "%d. %B %Y"
+      short: "%d.%m.%y"
     month_names:
-    -
+    - 
     - jaanuar
     - veebruar
     - märts
@@ -77,17 +78,17 @@ et:
         one: üle %{count} aasta
         other: üle %{count} aasta
       x_days:
-        one: ! '%{count} päev'
-        other: ! '%{count} päeva'
+        one: "%{count} päev"
+        other: "%{count} päeva"
       x_minutes:
-        one: ! '%{count} minut'
-        other: ! '%{count} minutit'
+        one: "%{count} minut"
+        other: "%{count} minutit"
       x_months:
-        one: ! '%{count} kuu'
-        other: ! '%{count} kuud'
+        one: "%{count} kuu"
+        other: "%{count} kuud"
       x_seconds:
-        one: ! '%{count} sekund'
-        other: ! '%{count} sekundit'
+        one: "%{count} sekund"
+        other: "%{count} sekundit"
     prompts:
       day: Päev
       hour: Tunde
@@ -96,7 +97,7 @@ et:
       second: Sekundit
       year: Aasta
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: peab olema heaks kiidetud
       blank: on täitmata
@@ -114,16 +115,16 @@ et:
       not_a_number: ei ole number
       not_an_integer: peab olema täisarv
       odd: peab olema paaritu arv
-      record_invalid: ! 'Valideerimine ebaõnnestus: %{errors}'
+      record_invalid: 'Valideerimine ebaõnnestus: %{errors}'
       taken: on juba võetud
       too_long: on liiga pikk (maksimum on %{count} tähemärki)
       too_short: on liiga lühike (miinimum on %{count} tähemärki)
       wrong_length: on vale pikkusega (peab olema %{count} tähemärki)
     template:
-      body: ! 'Probleeme ilmnes järgmiste väljadega:'
+      body: 'Probleeme ilmnes järgmiste väljadega:'
       header:
         one: Üks viga takistas objekti %{model} salvestamist
-        other: ! '%{count} viga takistasid objekti %{model} salvestamist'
+        other: "%{count} viga takistasid objekti %{model} salvestamist"
   helpers:
     select:
       prompt: Palun vali
@@ -134,22 +135,22 @@ et:
   number:
     currency:
       format:
-        delimiter: ! ' '
-        format: ! '%n %u'
+        delimiter: " "
+        format: "%n %u"
         precision: 2
-        separator: ! ','
+        separator: ","
         significant: false
         strip_insignificant_zeros: false
-        unit: €
+        unit: "€"
     format:
-      delimiter: ! ' '
+      delimiter: " "
       precision: 2
-      separator: ! ','
+      separator: ","
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: miljard
           million: miljon
@@ -163,7 +164,7 @@ et:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: bait
@@ -180,13 +181,13 @@ et:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ' ja '
-      two_words_connector: ! ' ja '
-      words_connector: ! ', '
+      last_word_connector: " ja "
+      two_words_connector: " ja "
+      words_connector: ", "
   time:
     am: enne lõunat
     formats:
-      default: ! '%d. %B %Y, %H:%M'
-      long: ! '%a, %d. %b %Y, %H:%M:%S %z'
-      short: ! '%d.%m.%y, %H:%M'
+      default: "%d. %B %Y, %H:%M"
+      long: "%a, %d. %b %Y, %H:%M:%S %z"
+      short: "%d.%m.%y, %H:%M"
     pm: pärast lõunat

--- a/rails/locale/eu.yml
+++ b/rails/locale/eu.yml
@@ -1,3 +1,4 @@
+---
 eu:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ eu:
     - Osti
     - Lar
     abbr_month_names:
-    -
+    - 
     - Urt
     - Ots
     - Mar
@@ -31,11 +32,11 @@ eu:
     - Ostirala
     - Larunbata
     formats:
-      default: ! '%Y/%m/%e'
-      long: ! '%Y(e)ko %Bk %e'
-      short: ! '%b %e'
+      default: "%Y/%m/%e"
+      long: "%Y(e)ko %Bk %e"
+      short: "%b %e"
     month_names:
-    -
+    - 
     - Urtarrila
     - Otsaila
     - Martxoa
@@ -56,38 +57,38 @@ eu:
     distance_in_words:
       about_x_hours:
         one: ordu bat inguru
-        other: ! '%{count} ordu inguru'
+        other: "%{count} ordu inguru"
       about_x_months:
         one: hilabete bat inguru
-        other: ! '%{count} hilabete inguru'
+        other: "%{count} hilabete inguru"
       about_x_years:
         one: urte bat inguru
-        other: ! '%{count} urte inguru'
+        other: "%{count} urte inguru"
       almost_x_years:
         one: ia urte bat
         other: ia %{count} urte
       half_a_minute: minutu erdi
       less_than_x_minutes:
         one: 1 minutu bat baino gutxiago
-        other: ! '%{count} minutu baino gutxiago'
+        other: "%{count} minutu baino gutxiago"
       less_than_x_seconds:
         one: segundu bat baino gutxiago
-        other: ! '%{count} segundu baino gutxiago'
+        other: "%{count} segundu baino gutxiago"
       over_x_years:
         one: urte bat baino gehiago
-        other: ! '%{count} urte baino gehiago'
+        other: "%{count} urte baino gehiago"
       x_days:
         one: egun bat
-        other: ! '%{count} egun'
+        other: "%{count} egun"
       x_minutes:
         one: minutu bat
-        other: ! '%{count} minutu'
+        other: "%{count} minutu"
       x_months:
         one: hilabete bat
-        other: ! '%{count} hilabete'
+        other: "%{count} hilabete"
       x_seconds:
         one: segundu bat
-        other: ! '%{count} segundu'
+        other: "%{count} segundu"
     prompts:
       day: Egun
       hour: Ordu
@@ -96,60 +97,60 @@ eu:
       second: Segundu
       year: Urte
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: onartuta izan behar da
       blank: ezin da zuriz utzi
       confirmation: ez dator bat konfirmazioarekin
       empty: ezin da hutsik egon
-      equal_to: ! '%{count} izan behar da'
+      equal_to: "%{count} izan behar da"
       even: bikoitia izan behar du
       exclusion: erreserbatuta dago
-      greater_than: ! '%{count} baino handiagoa izan behar da'
-      greater_than_or_equal_to: ! '%{count} baino handiago edo berdin izan behar da'
+      greater_than: "%{count} baino handiagoa izan behar da"
+      greater_than_or_equal_to: "%{count} baino handiago edo berdin izan behar da"
       inclusion: ez da zerrendako aukera bat
       invalid: ez da zuzena
-      less_than: ! '%{count} baino txikiago izan behar da'
-      less_than_or_equal_to: ! '%{count} baino txikiago edo berdin izan behar da'
+      less_than: "%{count} baino txikiago izan behar da"
+      less_than_or_equal_to: "%{count} baino txikiago edo berdin izan behar da"
       not_a_number: ez da zenbaki bat
       not_an_integer: zenbaki osoa izan behar da
       odd: bakoitia izan behar du
-      record_invalid: ! 'Balioztatze arazoa: %{errors}'
+      record_invalid: 'Balioztatze arazoa: %{errors}'
       taken: hartuta dago
       too_long: luzeegia da (%{count} karaktere gehienez)
       too_short: laburregia da (%{count} karaktere gutxienez)
       wrong_length: ez du luzeera zuzena (%{count} karaktere izan behar ditu)
     template:
-      body: ! 'Arazoak egon dira ondoko eremuekin:'
+      body: 'Arazoak egon dira ondoko eremuekin:'
       header:
         one: Errore batek ezinezkoa egin du %{model} hau gordetzea
-        other: ! '%{count} errorek ezinezkoa egiten dute %{model} hau gordetzea'
+        other: "%{count} errorek ezinezkoa egiten dute %{model} hau gordetzea"
   helpers:
     select:
       prompt: Mesedez, aukeratu
     submit:
-      create: ! '%{model}a eratu'
-      submit: ! '%{model}a gorde'
-      update: ! '%{model}a eguneratu'
+      create: "%{model}a eratu"
+      submit: "%{model}a gorde"
+      update: "%{model}a eguneratu"
   number:
     currency:
       format:
-        delimiter: .
-        format: ! '%n %u'
+        delimiter: "."
+        format: "%n %u"
         precision: 2
-        separator: ! ','
+        separator: ","
         significant: false
         strip_insignificant_zeros: false
-        unit: €
+        unit: "€"
     format:
-      delimiter: .
+      delimiter: "."
       precision: 3
-      separator: ! ','
+      separator: ","
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: Mila milioi
           million: Milioi
@@ -163,7 +164,7 @@ eu:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Byte
@@ -180,13 +181,13 @@ eu:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ' eta '
-      two_words_connector: ! ' eta '
-      words_connector: ! ', '
+      last_word_connector: " eta "
+      two_words_connector: " eta "
+      words_connector: ", "
   time:
     am: am
     formats:
-      default: ! '%A, %Y(e)ko %Bren %e %H:%M:%S %z'
-      long: ! '%Y(e)ko %Bren %e,  %H:%M'
-      short: ! '%b %e, %H:%M'
+      default: "%A, %Y(e)ko %Bren %e %H:%M:%S %z"
+      long: "%Y(e)ko %Bren %e,  %H:%M"
+      short: "%b %e, %H:%M"
     pm: pm

--- a/rails/locale/fa.yml
+++ b/rails/locale/fa.yml
@@ -1,3 +1,4 @@
+---
 fa:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ fa:
     - ج
     - ش
     abbr_month_names:
-    -
+    - 
     - ژانویه
     - فوریه
     - مارس
@@ -31,11 +32,11 @@ fa:
     - جمعه
     - شنبه
     formats:
-      default: ! '%Y/%m/%d'
-      long: ! '%e %B %Y'
-      short: ! '%m/%d'
+      default: "%Y/%m/%d"
+      long: "%e %B %Y"
+      short: "%m/%d"
     month_names:
-    -
+    - 
     - ژانویه
     - فوریه
     - مارس
@@ -78,16 +79,16 @@ fa:
         other: بیش از %{count} سال
       x_days:
         one: یک روز
-        other: ! '%{count} روز'
+        other: "%{count} روز"
       x_minutes:
         one: یک دقیقه
-        other: ! '%{count} دقیقه'
+        other: "%{count} دقیقه"
       x_months:
         one: یک ماه
-        other: ! '%{count} ماه'
+        other: "%{count} ماه"
       x_seconds:
         one: یک ثانیه
-        other: ! '%{count} ثانیه'
+        other: "%{count} ثانیه"
     prompts:
       day: روز
       hour: ساعت
@@ -96,7 +97,7 @@ fa:
       second: ثانیه
       year: سال
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: باید پذیرفته شود
       blank: نباید خالی باشد
@@ -120,36 +121,36 @@ fa:
       too_short: کوتاه است (حداقل %{count} کاراکتر)
       wrong_length: نااندازه است (باید %{count} کاراکتر باشد)
     template:
-      body: ! 'موارد زیر مشکل داشت:'
+      body: 'موارد زیر مشکل داشت:'
       header:
         one: 1 خطا جلوی ذخیره این %{model} را گرفت
-        other: ! '%{count} خطا جلوی ذخیره این %{model} را گرفت'
+        other: "%{count} خطا جلوی ذخیره این %{model} را گرفت"
   helpers:
     select:
       prompt: لطفا انتخاب کنید
     submit:
-      create: ! 'ایجاد %{model}'
-      submit: ! 'ذخیره‌ی %{model}'
-      update: ! 'بروز رسانی %{model}'
+      create: ایجاد %{model}
+      submit: ذخیره‌ی %{model}
+      update: بروز رسانی %{model}
   number:
     currency:
       format:
-        delimiter: ٬
-        format: ! '%n %u'
+        delimiter: "٬"
+        format: "%n %u"
         precision: 0
-        separator: ٫
+        separator: "٫"
         significant: false
         strip_insignificant_zeros: false
-        unit: ﷼
+        unit: "﷼"
     format:
-      delimiter: ٬
+      delimiter: "٬"
       precision: 2
-      separator: ٫
+      separator: "٫"
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: میلیارد
           million: میلیون
@@ -163,7 +164,7 @@ fa:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: بایت
@@ -180,13 +181,13 @@ fa:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ' و '
-      two_words_connector: ! ' و '
-      words_connector: ! '، '
+      last_word_connector: " و "
+      two_words_connector: " و "
+      words_connector: "، "
   time:
     am: قبل از ظهر
     formats:
-      default: ! '%A، %e %B %Y، ساعت %H:%M:%S (%Z)'
-      long: ! '%e %B %Y، ساعت %H:%M'
-      short: ! '%e %B، ساعت %H:%M'
+      default: "%A، %e %B %Y، ساعت %H:%M:%S (%Z)"
+      long: "%e %B %Y، ساعت %H:%M"
+      short: "%e %B، ساعت %H:%M"
     pm: بعد از ظهر

--- a/rails/locale/fi.yml
+++ b/rails/locale/fi.yml
@@ -1,3 +1,4 @@
+---
 fi:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ fi:
     - pe
     - la
     abbr_month_names:
-    -
+    - 
     - tammi
     - helmi
     - maalis
@@ -31,11 +32,11 @@ fi:
     - perjantai
     - lauantai
     formats:
-      default: ! '%-d.%-m.%Y'
-      long: ! '%A %e. %Bta %Y'
-      short: ! '%d. %b'
+      default: "%-d.%-m.%Y"
+      long: "%A %e. %Bta %Y"
+      short: "%d. %b"
     month_names:
-    -
+    - 
     - tammikuu
     - helmikuu
     - maaliskuu
@@ -78,16 +79,16 @@ fi:
         other: yli %{count} vuotta
       x_days:
         one: päivä
-        other: ! '%{count} päivää'
+        other: "%{count} päivää"
       x_minutes:
         one: minuutti
-        other: ! '%{count} minuuttia'
+        other: "%{count} minuuttia"
       x_months:
         one: kuukausi
-        other: ! '%{count} kuukautta'
+        other: "%{count} kuukautta"
       x_seconds:
         one: sekunti
-        other: ! '%{count} sekuntia'
+        other: "%{count} sekuntia"
     prompts:
       day: päivä
       hour: tunti
@@ -96,7 +97,7 @@ fi:
       second: sekunti
       year: vuosi
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: täytyy olla hyväksytty
       blank: ei voi olla sisällötön
@@ -114,16 +115,16 @@ fi:
       not_a_number: ei ole luku
       not_an_integer: ei ole kokonaisluku
       odd: täytyy olla pariton
-      record_invalid: ! 'Validointi epäonnistui: %{errors}'
+      record_invalid: 'Validointi epäonnistui: %{errors}'
       taken: on jo käytössä
       too_long: on liian pitkä (saa olla enintään %{count} merkkiä)
       too_short: on liian lyhyt (oltava vähintään %{count} merkkiä)
       wrong_length: on väärän pituinen (täytyy olla täsmälleen %{count} merkkiä)
     template:
-      body: ! 'Seuraavat kentät aiheuttivat ongelmia:'
+      body: 'Seuraavat kentät aiheuttivat ongelmia:'
       header:
         one: Virhe syötteessä esti mallin %{model} tallentamisen
-        other: ! '%{count} virhettä esti mallin %{model} tallentamisen'
+        other: "%{count} virhettä esti mallin %{model} tallentamisen"
   helpers:
     select:
       prompt: Valitse
@@ -134,22 +135,22 @@ fi:
   number:
     currency:
       format:
-        delimiter: .
-        format: ! '%n %u'
+        delimiter: "."
+        format: "%n %u"
         precision: 2
-        separator: ! ','
+        separator: ","
         significant: false
         strip_insignificant_zeros: false
-        unit: €
+        unit: "€"
     format:
-      delimiter: .
+      delimiter: "."
       precision: 3
-      separator: ! ','
+      separator: ","
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           thousand: tuhatta
           million: miljoonaa
@@ -163,7 +164,7 @@ fi:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: tavu
@@ -180,13 +181,13 @@ fi:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ' ja '
-      two_words_connector: ! ' ja '
-      words_connector: ! ', '
+      last_word_connector: " ja "
+      two_words_connector: " ja "
+      words_connector: ", "
   time:
     am: aamupäivä
     formats:
-      default: ! '%A %e. %Bta %Y %H:%M:%S %z'
-      long: ! '%e. %Bta %Y %H.%M'
-      short: ! '%e.%m. %H.%M'
+      default: "%A %e. %Bta %Y %H:%M:%S %z"
+      long: "%e. %Bta %Y %H.%M"
+      short: "%e.%m. %H.%M"
     pm: iltapäivä

--- a/rails/locale/fr-CA.yml
+++ b/rails/locale/fr-CA.yml
@@ -1,3 +1,4 @@
+---
 fr-CA:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ fr-CA:
     - ven
     - sam
     abbr_month_names:
-    -
+    - 
     - jan.
     - fév.
     - mar.
@@ -31,11 +32,11 @@ fr-CA:
     - vendredi
     - samedi
     formats:
-      default: ! '%Y-%m-%d'
-      long: ! '%d %B %Y'
-      short: ! '%y-%m-%d'
+      default: "%Y-%m-%d"
+      long: "%d %B %Y"
+      short: "%y-%m-%d"
     month_names:
-    -
+    - 
     - janvier
     - février
     - mars
@@ -80,16 +81,16 @@ fr-CA:
         other: plus de %{count} ans
       x_days:
         one: 1 jour
-        other: ! '%{count} jours'
+        other: "%{count} jours"
       x_minutes:
         one: 1 minute
-        other: ! '%{count} minutes'
+        other: "%{count} minutes"
       x_months:
         one: 1 mois
-        other: ! '%{count} mois'
+        other: "%{count} mois"
       x_seconds:
         one: 1 seconde
-        other: ! '%{count} secondes'
+        other: "%{count} secondes"
     prompts:
       day: Jour
       hour: Heure
@@ -98,7 +99,7 @@ fr-CA:
       second: Seconde
       year: Année
   errors:
-    format: '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: doit être accepté(e)
       blank: doit être rempli(e)
@@ -116,7 +117,7 @@ fr-CA:
       not_a_number: n'est pas un nombre
       not_an_integer: doit être un nombre entier
       odd: doit être impair
-      record_invalid: ! 'La validation a échoué : %{errors}'
+      record_invalid: 'La validation a échoué : %{errors}'
       taken: n'est pas disponible
       too_long:
         one: est trop long (pas plus d'un caractère)
@@ -128,10 +129,10 @@ fr-CA:
         one: ne fait pas la bonne longueur (doit comporter un seul caractère)
         other: ne fait pas la bonne longueur (doit comporter %{count} caractères)
     template:
-      body: ! 'Veuillez vérifier les champs suivants : '
+      body: 'Veuillez vérifier les champs suivants : '
       header:
-        one: ! 'Impossible d''enregistrer ce %{model} : 1 erreur'
-        other: ! 'Impossible d''enregistrer ce %{model} : %{count} erreurs'
+        one: 'Impossible d''enregistrer ce %{model} : 1 erreur'
+        other: 'Impossible d''enregistrer ce %{model} : %{count} erreurs'
   helpers:
     select:
       prompt: Veuillez sélectionner
@@ -142,22 +143,22 @@ fr-CA:
   number:
     currency:
       format:
-        delimiter: ! ' '
-        format: ! '%n %u'
+        delimiter: " "
+        format: "%n %u"
         precision: 2
-        separator: ! ','
+        separator: ","
         significant: false
         strip_insignificant_zeros: false
-        unit: $
+        unit: "$"
     format:
-      delimiter: ! ' '
+      delimiter: " "
       precision: 3
-      separator: ! ','
+      separator: ","
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: Milliard
           million: Million
@@ -171,7 +172,7 @@ fr-CA:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Octet
@@ -188,13 +189,13 @@ fr-CA:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ' et '
-      two_words_connector: ! ' et '
-      words_connector: ! ', '
+      last_word_connector: " et "
+      two_words_connector: " et "
+      words_connector: ", "
   time:
     am: am
     formats:
-      default: ! '%H h %M min %S s'
-      long: ! '%A %d %B %Y %H h %M'
-      short: ! '%H h %M'
+      default: "%H h %M min %S s"
+      long: "%A %d %B %Y %H h %M"
+      short: "%H h %M"
     pm: pm

--- a/rails/locale/fr-CH.yml
+++ b/rails/locale/fr-CH.yml
@@ -1,3 +1,4 @@
+---
 fr-CH:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ fr-CH:
     - ven
     - sam
     abbr_month_names:
-    -
+    - 
     - jan.
     - fév.
     - mar.
@@ -31,11 +32,11 @@ fr-CH:
     - vendredi
     - samedi
     formats:
-      default: ! '%d.%m.%Y'
-      long: ! '%e %B %Y'
-      short: ! '%e %b'
+      default: "%d.%m.%Y"
+      long: "%e %B %Y"
+      short: "%e %b"
     month_names:
-    -
+    - 
     - janvier
     - février
     - mars
@@ -80,16 +81,16 @@ fr-CH:
         other: plus de %{count} ans
       x_days:
         one: 1 jour
-        other: ! '%{count} jours'
+        other: "%{count} jours"
       x_minutes:
         one: 1 minute
-        other: ! '%{count} minutes'
+        other: "%{count} minutes"
       x_months:
         one: 1 mois
-        other: ! '%{count} mois'
+        other: "%{count} mois"
       x_seconds:
         one: 1 seconde
-        other: ! '%{count} secondes'
+        other: "%{count} secondes"
     prompts:
       day: Jour
       hour: Heure
@@ -98,7 +99,7 @@ fr-CH:
       second: Seconde
       year: Année
   errors:
-    format: '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: doit être accepté(e)
       blank: doit être rempli(e)
@@ -116,7 +117,7 @@ fr-CH:
       not_a_number: n'est pas un nombre
       not_an_integer: doit être un nombre entier
       odd: doit être impair
-      record_invalid: ! 'La validation a échoué : %{errors}'
+      record_invalid: 'La validation a échoué : %{errors}'
       taken: n'est pas disponible
       too_long:
         one: est trop long (pas plus d'un caractère)
@@ -128,10 +129,10 @@ fr-CH:
         one: ne fait pas la bonne longueur (doit comporter un seul caractère)
         other: ne fait pas la bonne longueur (doit comporter %{count} caractères)
     template:
-      body: ! 'Veuillez vérifier les champs suivants : '
+      body: 'Veuillez vérifier les champs suivants : '
       header:
-        one: ! 'Impossible d''enregistrer ce %{model} : 1 erreur'
-        other: ! 'Impossible d''enregistrer ce %{model} : %{count} erreurs'
+        one: 'Impossible d''enregistrer ce %{model} : 1 erreur'
+        other: 'Impossible d''enregistrer ce %{model} : %{count} erreurs'
   helpers:
     select:
       prompt: Veuillez sélectionner
@@ -142,22 +143,22 @@ fr-CH:
   number:
     currency:
       format:
-        delimiter: ! ''''
-        format: ! '%n %u'
+        delimiter: "'"
+        format: "%n %u"
         precision: 2
-        separator: .
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
         unit: sFr.
     format:
-      delimiter: ! ''''
+      delimiter: "'"
       precision: 3
-      separator: .
+      separator: "."
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: milliard
           million: million
@@ -171,7 +172,7 @@ fr-CH:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: octet
@@ -188,13 +189,13 @@ fr-CH:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ' et '
-      two_words_connector: ! ' et '
-      words_connector: ! ', '
+      last_word_connector: " et "
+      two_words_connector: " et "
+      words_connector: ", "
   time:
     am: am
     formats:
-      default: ! '%d. %B %Y %H h %M'
-      long: ! '%A, %d %B %Y %H h %M min %S s %Z'
-      short: ! '%d %b %H h %M'
+      default: "%d. %B %Y %H h %M"
+      long: "%A, %d %B %Y %H h %M min %S s %Z"
+      short: "%d %b %H h %M"
     pm: pm

--- a/rails/locale/fr.yml
+++ b/rails/locale/fr.yml
@@ -1,157 +1,150 @@
-# French translations for Ruby on Rails
-# by Christian Lescuyer (christian@flyingcoders.com)
-# contributors:
-#  - Sebastien Grosjean - ZenCocoon.com
-#  - Bruno Michel - http://github.com/nono
-#  - Tsutomu Kuroda - http://github.com/kuroda (t-kuroda@oiax.jp)
-# Emended by Benjamin des Gachons and Patrick Chew : <http://www.fitima.org/docs/fiche.pdf>
-
+---
 fr:
   date:
     abbr_day_names:
-      - dim
-      - lun
-      - mar
-      - mer
-      - jeu
-      - ven
-      - sam
+    - dim
+    - lun
+    - mar
+    - mer
+    - jeu
+    - ven
+    - sam
     abbr_month_names:
-      - ~
-      - jan.
-      - fév.
-      - mar.
-      - avr.
-      - mai
-      - juin
-      - juil.
-      - août
-      - sept.
-      - oct.
-      - nov.
-      - déc.
+    - 
+    - jan.
+    - fév.
+    - mar.
+    - avr.
+    - mai
+    - juin
+    - juil.
+    - août
+    - sept.
+    - oct.
+    - nov.
+    - déc.
     day_names:
-      - dimanche
-      - lundi
-      - mardi
-      - mercredi
-      - jeudi
-      - vendredi
-      - samedi
+    - dimanche
+    - lundi
+    - mardi
+    - mercredi
+    - jeudi
+    - vendredi
+    - samedi
     formats:
       default: "%d/%m/%Y"
       short: "%e %b"
       long: "%e %B %Y"
     month_names:
-      - ~
-      - janvier
-      - février
-      - mars
-      - avril
-      - mai
-      - juin
-      - juillet
-      - août
-      - septembre
-      - octobre
-      - novembre
-      - décembre
+    - 
+    - janvier
+    - février
+    - mars
+    - avril
+    - mai
+    - juin
+    - juillet
+    - août
+    - septembre
+    - octobre
+    - novembre
+    - décembre
     order:
-      - :day
-      - :month
-      - :year
+    - :day
+    - :month
+    - :year
   datetime:
     distance_in_words:
       about_x_hours:
-        one:   "environ une heure"
-        other: "environ %{count} heures"
+        one: environ une heure
+        other: environ %{count} heures
       about_x_months:
-        one:   "environ un mois"
-        other: "environ %{count} mois"
+        one: environ un mois
+        other: environ %{count} mois
       about_x_years:
-        one:   "environ un an"
-        other: "environ %{count} ans"
+        one: environ un an
+        other: environ %{count} ans
       almost_x_years:
-        one:   "presqu'un an"
-        other: "presque %{count} ans"
-      half_a_minute: "une demi-minute"
+        one: presqu'un an
+        other: presque %{count} ans
+      half_a_minute: une demi-minute
       less_than_x_minutes:
-        zero:  "moins d'une minute"
-        one:   "moins d'une minute"
-        other: "moins de %{count} minutes"
+        zero: moins d'une minute
+        one: moins d'une minute
+        other: moins de %{count} minutes
       less_than_x_seconds:
-        zero:  "moins d'une seconde"
-        one:   "moins d'une seconde"
-        other: "moins de %{count} secondes"
+        zero: moins d'une seconde
+        one: moins d'une seconde
+        other: moins de %{count} secondes
       over_x_years:
-        one:   "plus d'un an"
-        other: "plus de %{count} ans"
+        one: plus d'un an
+        other: plus de %{count} ans
       x_days:
-        one:   "1 jour"
+        one: 1 jour
         other: "%{count} jours"
       x_minutes:
-        one:   "1 minute"
+        one: 1 minute
         other: "%{count} minutes"
       x_months:
-        one:   "1 mois"
+        one: 1 mois
         other: "%{count} mois"
       x_seconds:
-        one:   "1 seconde"
+        one: 1 seconde
         other: "%{count} secondes"
     prompts:
-      day:    "Jour"
-      hour:   "Heure"
-      minute: "Minute"
-      month:  "Mois"
-      second: "Seconde"
-      year:   "Année"
+      day: Jour
+      hour: Heure
+      minute: Minute
+      month: Mois
+      second: Seconde
+      year: Année
   errors:
     format: "%{attribute} %{message}"
-    messages: &errors_messages
-      accepted: "doit être accepté(e)"
-      blank: "doit être rempli(e)"
-      present: "doit être vide"
-      confirmation: "ne concorde pas avec la confirmation"
-      empty: "doit être rempli(e)"
-      equal_to: "doit être égal à %{count}"
-      even: "doit être pair"
-      exclusion: "n'est pas disponible"
-      greater_than: "doit être supérieur à %{count}"
-      greater_than_or_equal_to: "doit être supérieur ou égal à %{count}"
-      inclusion: "n'est pas inclus(e) dans la liste"
-      invalid: "n'est pas valide"
-      less_than: "doit être inférieur à %{count}"
-      less_than_or_equal_to: "doit être inférieur ou égal à %{count}"
-      not_a_number: "n'est pas un nombre"
-      not_an_integer: "doit être un nombre entier"
-      odd: "doit être impair"
-      record_invalid: "La validation a échoué : %{errors}"
+    messages:
+      accepted: doit être accepté(e)
+      blank: doit être rempli(e)
+      present: doit être vide
+      confirmation: ne concorde pas avec la confirmation
+      empty: doit être rempli(e)
+      equal_to: doit être égal à %{count}
+      even: doit être pair
+      exclusion: n'est pas disponible
+      greater_than: doit être supérieur à %{count}
+      greater_than_or_equal_to: doit être supérieur ou égal à %{count}
+      inclusion: n'est pas inclus(e) dans la liste
+      invalid: n'est pas valide
+      less_than: doit être inférieur à %{count}
+      less_than_or_equal_to: doit être inférieur ou égal à %{count}
+      not_a_number: n'est pas un nombre
+      not_an_integer: doit être un nombre entier
+      odd: doit être impair
+      record_invalid: 'La validation a échoué : %{errors}'
       restrict_dependent_destroy:
-        one: "Suppression impossible: un autre enregistrement est lié"
-        many: "Suppression impossible: d'autres enregistrements sont liés"
-      taken: "n'est pas disponible"
+        one: 'Suppression impossible: un autre enregistrement est lié'
+        many: 'Suppression impossible: d''autres enregistrements sont liés'
+      taken: n'est pas disponible
       too_long:
-        one: "est trop long (pas plus d'un caractère)"
-        other: "est trop long (pas plus de %{count} caractères)"
+        one: est trop long (pas plus d'un caractère)
+        other: est trop long (pas plus de %{count} caractères)
       too_short:
-        one: "est trop court (au moins un caractère)"
-        other: "est trop court (au moins %{count} caractères)"
+        one: est trop court (au moins un caractère)
+        other: est trop court (au moins %{count} caractères)
       wrong_length:
-        one: "ne fait pas la bonne longueur (doit comporter un seul caractère)"
-        other: "ne fait pas la bonne longueur (doit comporter %{count} caractères)"
-      other_than: "doit être différent de %{count}"
-    template: &errors_template
-      body: "Veuillez vérifier les champs suivants : "
+        one: ne fait pas la bonne longueur (doit comporter un seul caractère)
+        other: ne fait pas la bonne longueur (doit comporter %{count} caractères)
+      other_than: doit être différent de %{count}
+    template:
+      body: 'Veuillez vérifier les champs suivants : '
       header:
-        one:   "Impossible d'enregistrer ce(tte) %{model} : 1 erreur"
-        other: "Impossible d'enregistrer ce(tte) %{model} : %{count} erreurs"
+        one: 'Impossible d''enregistrer ce(tte) %{model} : 1 erreur'
+        other: 'Impossible d''enregistrer ce(tte) %{model} : %{count} erreurs'
   helpers:
     select:
-      prompt: "Veuillez sélectionner"
+      prompt: Veuillez sélectionner
     submit:
-      create: "Créer un(e) %{model}"
-      submit: "Enregistrer ce(tte) %{model}"
-      update: "Modifier ce(tte) %{model}"
+      create: Créer un(e) %{model}
+      submit: Enregistrer ce(tte) %{model}
+      update: Modifier ce(tte) %{model}
   number:
     currency:
       format:
@@ -172,14 +165,14 @@ fr:
       decimal_units:
         format: "%n %u"
         units:
-          billion: "milliard"
-          million: "million"
-          quadrillion: "million de milliards"
-          thousand: "millier"
-          trillion: "billion"
-          unit: ""
+          billion: milliard
+          million: million
+          quadrillion: million de milliards
+          thousand: millier
+          trillion: billion
+          unit: ''
       format:
-        delimiter: ""
+        delimiter: ''
         precision: 2
         significant: true
         strip_insignificant_zeros: true
@@ -187,28 +180,28 @@ fr:
         format: "%n %u"
         units:
           byte:
-            one:   "octet"
-            other: "octets"
-          gb: "Go"
-          kb: "ko"
-          mb: "Mo"
-          tb: "To"
+            one: octet
+            other: octets
+          gb: Go
+          kb: ko
+          mb: Mo
+          tb: To
     percentage:
       format:
-        delimiter: ""
+        delimiter: ''
         format: "%n%"
     precision:
       format:
-        delimiter: ""
+        delimiter: ''
   support:
     array:
       last_word_connector: " et "
       two_words_connector: " et "
       words_connector: ", "
   time:
-    am: 'am'
+    am: am
     formats:
       default: "%d %B %Y %Hh %Mmin %Ss"
       long: "%A %d %B %Y %Hh%M"
       short: "%d %b %Hh%M"
-    pm: 'pm'
+    pm: pm

--- a/rails/locale/gl.yml
+++ b/rails/locale/gl.yml
@@ -1,3 +1,4 @@
+---
 gl:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ gl:
     - Ven
     - Sab
     abbr_month_names:
-    -
+    - 
     - Xan
     - Feb
     - Mar
@@ -31,11 +32,11 @@ gl:
     - Venres
     - Sábado
     formats:
-      default: ! '%e/%m/%Y'
-      long: ! '%A %e de %B de %Y'
-      short: ! '%e %b'
+      default: "%e/%m/%Y"
+      long: "%A %e de %B de %Y"
+      short: "%e %b"
     month_names:
-    -
+    - 
     - Xaneiro
     - Febreiro
     - Marzo
@@ -56,40 +57,40 @@ gl:
     distance_in_words:
       about_x_hours:
         one: aproximadamente unha hora
-        other: ! '%{count} horas'
+        other: "%{count} horas"
       about_x_months:
         one: aproximadamente 1 mes
-        other: ! '%{count} meses'
+        other: "%{count} meses"
       about_x_years:
         one: aproximadamente 1 ano
-        other: ! '%{count} anos'
+        other: "%{count} anos"
       half_a_minute: medio minuto
       less_than_x_minutes:
         one: 1 minuto
-        other: ! '%{count} minutos'
+        other: "%{count} minutos"
         zero: menos dun minuto
       less_than_x_seconds:
         few: poucos segundos
         one: 1 segundo
-        other: ! '%{count} segundos'
+        other: "%{count} segundos"
         zero: menos dun segundo
       over_x_years:
         one: máis dun ano
-        other: ! '%{count} anos'
+        other: "%{count} anos"
       x_days:
         one: 1 día
-        other: ! '%{count} días'
+        other: "%{count} días"
       x_minutes:
         one: 1 minuto
-        other: ! '%{count} minuto'
+        other: "%{count} minuto"
       x_months:
         one: 1 mes
-        other: ! '%{count} meses'
+        other: "%{count} meses"
       x_seconds:
         one: 1 segundo
-        other: ! '%{count} segundos'
+        other: "%{count} segundos"
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: debe ser aceptado
       blank: non pode estar en blanco
@@ -111,29 +112,29 @@ gl:
       too_short: é demasiado curto (non menos de %{count} carácteres)
       wrong_length: non ten a lonxitude correcta (debe ser de %{count} carácteres)
     template:
-      body: ! 'Atopáronse os seguintes problemas:'
+      body: 'Atopáronse os seguintes problemas:'
       header:
         one: 1 erro evitou que se poidese gardar o %{model}
-        other: ! '%{count} erros evitaron que se poidese gardar o %{model}'
+        other: "%{count} erros evitaron que se poidese gardar o %{model}"
   number:
     currency:
       format:
-        delimiter: .
-        format: ! '%n %u'
+        delimiter: "."
+        format: "%n %u"
         precision: 2
-        separator: ! ','
+        separator: ","
         significant: false
         strip_insignificant_zeros: false
-        unit: €
+        unit: "€"
     format:
-      delimiter: .
+      delimiter: "."
       precision: 2
-      separator: ! ','
+      separator: ","
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           unit: ''
       format:
@@ -142,7 +143,7 @@ gl:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Byte
@@ -159,13 +160,13 @@ gl:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ' e '
-      two_words_connector: ! ' e '
-      words_connector: ! ', '
+      last_word_connector: " e "
+      two_words_connector: " e "
+      words_connector: ", "
   time:
     am: ''
     formats:
-      default: ! '%A, %e de %B de %Y ás %H:%M'
-      long: ! '%A %e de %B de %Y ás %H:%M'
-      short: ! '%e/%m, %H:%M'
+      default: "%A, %e de %B de %Y ás %H:%M"
+      long: "%A %e de %B de %Y ás %H:%M"
+      short: "%e/%m, %H:%M"
     pm: ''

--- a/rails/locale/he.yml
+++ b/rails/locale/he.yml
@@ -1,3 +1,4 @@
+---
 he:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ he:
     - ו
     - ש
     abbr_month_names:
-    -
+    - 
     - ינו
     - פבר
     - מרץ
@@ -31,11 +32,11 @@ he:
     - שישי
     - שבת
     formats:
-      default: ! '%d-%m-%Y'
-      long: ! '%e ב%B, %Y'
-      short: ! '%e %b'
+      default: "%d-%m-%Y"
+      long: "%e ב%B, %Y"
+      short: "%e %b"
     month_names:
-    -
+    - 
     - ינואר
     - פברואר
     - מרץ
@@ -80,16 +81,16 @@ he:
         other: מעל %{count} שנים
       x_days:
         one: יום אחד
-        other: ! '%{count} ימים'
+        other: "%{count} ימים"
       x_minutes:
         one: דקה אחת
-        other: ! '%{count} דקות'
+        other: "%{count} דקות"
       x_months:
         one: חודש אחד
-        other: ! '%{count} חודשים'
+        other: "%{count} חודשים"
       x_seconds:
         one: שניה אחת
-        other: ! '%{count} שניות'
+        other: "%{count} שניות"
     prompts:
       day: יום
       hour: שעה
@@ -98,7 +99,7 @@ he:
       second: שניות
       year: שנה
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: חייב באישור
       blank: לא יכול להיות ריק
@@ -116,42 +117,42 @@ he:
       not_a_number: חייב להיות מספר
       not_an_integer: חייב להיות מספר שלם
       odd: חייב להיות אי זוגי
-      record_invalid: ! 'האימות נכשל: %{errors}'
+      record_invalid: 'האימות נכשל: %{errors}'
       taken: כבר בשימוש
-      too_long: "ארוך מדי (יותר מ- %{count} תווים)"
-      too_short: "קצר מדי (פחות מ- %{count} תווים)"
-      wrong_length: "לא באורך הנכון (חייב להיות %{count} תווים)"
+      too_long: ארוך מדי (יותר מ- %{count} תווים)
+      too_short: קצר מדי (פחות מ- %{count} תווים)
+      wrong_length: לא באורך הנכון (חייב להיות %{count} תווים)
     template:
-      body: ! 'אנא בדוק את השדות הבאים:'
+      body: 'אנא בדוק את השדות הבאים:'
       header:
-        one: ! 'לא ניתן לשמור את ה%{model}: שגיאה אחת'
-        other: ! 'לא ניתן לשמור את ה%{model}: %{count} שגיאות.'
+        one: 'לא ניתן לשמור את ה%{model}: שגיאה אחת'
+        other: 'לא ניתן לשמור את ה%{model}: %{count} שגיאות.'
   helpers:
     select:
       prompt: נא לבחור
     submit:
-      create: ! 'יצירת %{model}'
-      submit: ! 'שמור %{model}'
-      update: ! 'עדכון %{model}'
+      create: יצירת %{model}
+      submit: שמור %{model}
+      update: עדכון %{model}
   number:
     currency:
       format:
-        delimiter: ! ','
-        format: ! '%u %n'
+        delimiter: ","
+        format: "%u %n"
         precision: 2
-        separator: .
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
-        unit: ₪
+        unit: "₪"
     format:
-      delimiter: ! ','
+      delimiter: ","
       precision: 3
-      separator: .
+      separator: "."
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: מיליארד
           million: מיליון
@@ -165,7 +166,7 @@ he:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: בייט
@@ -182,13 +183,13 @@ he:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ', את '
-      two_words_connector: ! ' את '
-      words_connector: ! ', '
+      last_word_connector: ", את "
+      two_words_connector: " את "
+      words_connector: ", "
   time:
     am: am
     formats:
-      default: ! '%a %d %b %H:%M:%S %Z %Y'
-      long: ! '%d ב%B, %Y %H:%M'
-      short: ! '%d %b %H:%M'
+      default: "%a %d %b %H:%M:%S %Z %Y"
+      long: "%d ב%B, %Y %H:%M"
+      short: "%d %b %H:%M"
     pm: pm

--- a/rails/locale/hi-IN.yml
+++ b/rails/locale/hi-IN.yml
@@ -1,3 +1,4 @@
+---
 hi-IN:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ hi-IN:
     - शुक्र
     - शनि
     abbr_month_names:
-    -
+    - 
     - Jan
     - Feb
     - Mar
@@ -31,11 +32,11 @@ hi-IN:
     - शुक्रवार
     - शनिवार
     formats:
-      default: ! '%d-%m-%Y'
-      long: ! '%B %d, %Y'
-      short: ! '%b %d'
+      default: "%d-%m-%Y"
+      long: "%B %d, %Y"
+      short: "%b %d"
     month_names:
-    -
+    - 
     - जनवरी
     - फरवरी
     - मार्च
@@ -69,25 +70,25 @@ hi-IN:
       half_a_minute: एक आधा मिनट
       less_than_x_minutes:
         one: एक मिनट से कम
-        other: ! '%{count} मिनट से कम'
+        other: "%{count} मिनट से कम"
       less_than_x_seconds:
         one: एक सेकंड से कम
-        other: ! '%{count}  सेकंड से कम'
+        other: "%{count}  सेकंड से कम"
       over_x_years:
         one: एक साल के ऊपर
-        other: ! '%{count} साल के ऊपर'
+        other: "%{count} साल के ऊपर"
       x_days:
         one: एक दिन
-        other: ! '%{count} दिन'
+        other: "%{count} दिन"
       x_minutes:
         one: एक मिनट
-        other: ! '%{count} मिनट'
+        other: "%{count} मिनट"
       x_months:
         one: एक महीना
-        other: ! '%{count} महीना'
+        other: "%{count} महीना"
       x_seconds:
         one: एक सेकंड
-        other: ! '%{count} सेकंड'
+        other: "%{count} सेकंड"
     prompts:
       day: दिन
       hour: घंटा
@@ -96,34 +97,34 @@ hi-IN:
       second: सेकंड
       year: वर्ष
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: होना स्वीकार किया जाना आवश्यक
       blank: खाली नहीं किया जा सकता
       confirmation: पुष्टिकरण मेल नहीं खाता
       empty: खाली नहीं किया जा सकता
-      equal_to: ! '%{count} के लिए बराबर होना चाहिए'
+      equal_to: "%{count} के लिए बराबर होना चाहिए"
       even: सम होना चाहिए
       exclusion: आरक्षित है
-      greater_than: ! '%{count} से अधिक होना चाहिए'
-      greater_than_or_equal_to: ! '%{count} से बड़ा या बराबर होना आवश्यक है'
+      greater_than: "%{count} से अधिक होना चाहिए"
+      greater_than_or_equal_to: "%{count} से बड़ा या बराबर होना आवश्यक है"
       inclusion: सूची में शामिल नहीं है
       invalid: अवैध है
-      less_than: ! '%{count} से कम होना चाहिए'
-      less_than_or_equal_to: ! '%{count} से कम या बराबर होना आवश्यक है'
+      less_than: "%{count} से कम होना चाहिए"
+      less_than_or_equal_to: "%{count} से कम या बराबर होना आवश्यक है"
       not_a_number: कोई संख्या नहीं है
       not_an_integer: एक पूर्णांक होना चाहिए
       odd: विषम होना चाहिए
-      record_invalid: ! 'सत्यापन विफल: %{errors}'
+      record_invalid: 'सत्यापन विफल: %{errors}'
       taken: पहले ही ले लिया गया है
       too_long: बहुत लंबा है (अधिकतम %{count} अक्षरों है)
       too_short: बहुत छोटा है (न्यूनतम %{count} अक्षरों है)
       wrong_length: गलत लंबाई है (%{count} वर्ण वाले होने चाहिए)
     template:
-      body: ! 'वहाँ निम्नलिखित क्षेत्रों के साथ समस्याओं रहे थे:'
+      body: 'वहाँ निम्नलिखित क्षेत्रों के साथ समस्याओं रहे थे:'
       header:
         one: एक त्रुटि सहेजे जाने से इस %{model} को निषिद्ध
-        other: ! '%{count} त्रुटियों को सहेजे जाने से इस %{model} निषिद्ध'
+        other: "%{count} त्रुटियों को सहेजे जाने से इस %{model} निषिद्ध"
   helpers:
     select:
       prompt: कृपया चुनें
@@ -134,22 +135,22 @@ hi-IN:
   number:
     currency:
       format:
-        delimiter: ! ','
-        format: ! '%u%n'
+        delimiter: ","
+        format: "%u%n"
         precision: 2
-        separator: .
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
-        unit: ₹
+        unit: "₹"
     format:
-      delimiter: ! ','
+      delimiter: ","
       precision: 3
-      separator: .
+      separator: "."
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: अरब
           million: मिल्लिओंन
@@ -163,7 +164,7 @@ hi-IN:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Byte
@@ -180,13 +181,13 @@ hi-IN:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ', और '
-      two_words_connector: ! ' और '
-      words_connector: ! ', '
+      last_word_connector: ", और "
+      two_words_connector: " और "
+      words_connector: ", "
   time:
     am: am
     formats:
-      default: ! '%a, %d %b %Y %H:%M:%S %z'
-      long: ! '%B %d, %Y %H:%M'
-      short: ! '%d %b %H:%M'
+      default: "%a, %d %b %Y %H:%M:%S %z"
+      long: "%B %d, %Y %H:%M"
+      short: "%d %b %H:%M"
     pm: pm

--- a/rails/locale/hi.yml
+++ b/rails/locale/hi.yml
@@ -1,3 +1,4 @@
+---
 hi:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ hi:
     - शुक्र
     - शनि
     abbr_month_names:
-    -
+    - 
     - जन
     - फर
     - मार्च
@@ -31,11 +32,11 @@ hi:
     - शुक्रवार
     - शनिवार
     formats:
-      default: ! '%d-%m-%Y'
-      long: ! '%B %d, %Y'
-      short: ! '%b %d'
+      default: "%d-%m-%Y"
+      long: "%B %d, %Y"
+      short: "%b %d"
     month_names:
-    -
+    - 
     - जनवरी
     - फरवरी
     - मार्च
@@ -69,25 +70,25 @@ hi:
       half_a_minute: एक आधा मिनट
       less_than_x_minutes:
         one: एक मिनट से कम
-        other: ! '%{count} मिनट से कम'
+        other: "%{count} मिनट से कम"
       less_than_x_seconds:
         one: एक सेकेंड से कम
-        other: ! '%{count}  सेकेंड से कम'
+        other: "%{count}  सेकेंड से कम"
       over_x_years:
         one: एक साल के ऊपर
-        other: ! '%{count} साल से अधिक'
+        other: "%{count} साल से अधिक"
       x_days:
         one: एक दिन
-        other: ! '%{count} दिन'
+        other: "%{count} दिन"
       x_minutes:
         one: एक मिनट
-        other: ! '%{count} मिनट'
+        other: "%{count} मिनट"
       x_months:
         one: एक महीना
-        other: ! '%{count} महीना'
+        other: "%{count} महीना"
       x_seconds:
         one: एक सेकेंड
-        other: ! '%{count} सेकेंड'
+        other: "%{count} सेकेंड"
     prompts:
       day: दिन
       hour: घंटा
@@ -96,31 +97,31 @@ hi:
       second: सेकेंड
       year: वर्ष
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: स्वीकार किया जाना जरूरी
       blank: खाली नहीं रह सकता है
       confirmation: पुष्टिकरण मेल नहीं खाता
       empty: रिक्त नहीं रह सकता है
-      equal_to: ! '%{count} के लिए बराबर होना चाहिए'
+      equal_to: "%{count} के लिए बराबर होना चाहिए"
       even: सम होना चाहिए
       exclusion: आरक्षित है
-      greater_than: ! '%{count} से अधिक होना चाहिए'
-      greater_than_or_equal_to: ! '%{count} से बड़ा या बराबर होना आवश्यक है'
+      greater_than: "%{count} से अधिक होना चाहिए"
+      greater_than_or_equal_to: "%{count} से बड़ा या बराबर होना आवश्यक है"
       inclusion: सूची में शामिल नहीं है
       invalid: अवैध है
-      less_than: ! '%{count} से कम होना चाहिए'
-      less_than_or_equal_to: ! '%{count} से कम या बराबर होना आवश्यक है'
+      less_than: "%{count} से कम होना चाहिए"
+      less_than_or_equal_to: "%{count} से कम या बराबर होना आवश्यक है"
       not_a_number: कोई संख्या नहीं है
       not_an_integer: एक पूर्णांक होना चाहिए
       odd: विसम होना चाहिए
-      record_invalid: ! 'सत्यापन विफल: %{errors}'
+      record_invalid: 'सत्यापन विफल: %{errors}'
       taken: पहले ही ले लिया गया है
       too_long: अत्यधिक लंबा है (अधिकतम %{count} वर्ण हैं)
       too_short: अत्यधिक छोटा है (न्यूनतम %{count} वर्ण हैं)
       wrong_length: गलत लंबाई है (%{count} वर्ण युक्त होना चाहिए)
     template:
-      body: ! 'निम्नलिखित क्षेत्रों के साथ समस्या थी:'
+      body: 'निम्नलिखित क्षेत्रों के साथ समस्या थी:'
       header:
         one: इस %{model} को सहेजे जाना एक त्रुटि के कारण नहीं हुआ
         other: इस %{model} को सहेजे जाना %{count} त्रुटि के कारण नहीं हुआ
@@ -128,28 +129,28 @@ hi:
     select:
       prompt: कृपया चुनें
     submit:
-      create: ! '%{model} बनाएँ'
-      submit: ! '%{model} सौंपें'
-      update: ! '%{model} अद्यतन'
+      create: "%{model} बनाएँ"
+      submit: "%{model} सौंपें"
+      update: "%{model} अद्यतन"
   number:
     currency:
       format:
-        delimiter: ! ','
-        format: ! '%u%n'
+        delimiter: ","
+        format: "%u%n"
         precision: 2
-        separator: .
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
-        unit: ₹
+        unit: "₹"
     format:
-      delimiter: ! ','
+      delimiter: ","
       precision: 3
-      separator: .
+      separator: "."
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: अरब
           million: दस करोड़
@@ -163,7 +164,7 @@ hi:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Byte
@@ -180,13 +181,13 @@ hi:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ', और '
-      two_words_connector: ! ' और '
-      words_connector: ! ', '
+      last_word_connector: ", और "
+      two_words_connector: " और "
+      words_connector: ", "
   time:
     am: पूर्वाह्न
     formats:
-      default: ! '%a, %d %b %Y %H:%M:%S %z'
-      long: ! '%B %d, %Y %H:%M'
-      short: ! '%d %b %H:%M'
+      default: "%a, %d %b %Y %H:%M:%S %z"
+      long: "%B %d, %Y %H:%M"
+      short: "%d %b %H:%M"
     pm: अपराह्न

--- a/rails/locale/hr.yml
+++ b/rails/locale/hr.yml
@@ -1,3 +1,4 @@
+---
 hr:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ hr:
     - Pet
     - Sub
     abbr_month_names:
-    -
+    - 
     - Sij
     - Veǉ
     - Ožu
@@ -31,11 +32,11 @@ hr:
     - Petak
     - Subota
     formats:
-      default: ! '%d.%m.%Y.'
-      long: ! '%e. %B %Y.'
-      short: ! '%e.%-m.'
+      default: "%d.%m.%Y."
+      long: "%e. %B %Y."
+      short: "%e.%-m."
     month_names:
-    -
+    - 
     - Siječanj
     - Veljača
     - Ožujak
@@ -91,25 +92,25 @@ hr:
         many: preko %{count} godina
         other: preko %{count} godina
       x_days:
-        one: ! '%{count} dan'
-        few: ! '%{count} dana'
-        many: ! '%{count} dana'
-        other: ! '%{count} dana'
+        one: "%{count} dan"
+        few: "%{count} dana"
+        many: "%{count} dana"
+        other: "%{count} dana"
       x_minutes:
-        one: ! '%{count} minuta'
-        few: ! '%{count} minute'
-        many: ! '%{count} minuta'
-        other: ! '%{count} minuta'
+        one: "%{count} minuta"
+        few: "%{count} minute"
+        many: "%{count} minuta"
+        other: "%{count} minuta"
       x_months:
-        one: ! '%{count} mjesec'
-        few: ! '%{count} mjeseca'
-        many: ! '%{count} mjeseci'
-        other: ! '%{count} mjeseci'
+        one: "%{count} mjesec"
+        few: "%{count} mjeseca"
+        many: "%{count} mjeseci"
+        other: "%{count} mjeseci"
       x_seconds:
-        one: ! '%{count} sekunda'
-        few: ! '%{count} sekunde'
-        many: ! '%{count} sekundi'
-        other: ! '%{count} sekundi'
+        one: "%{count} sekunda"
+        few: "%{count} sekunde"
+        many: "%{count} sekundi"
+        other: "%{count} sekundi"
     prompts:
       day: Dan
       hour: Sat
@@ -118,7 +119,7 @@ hr:
       second: Sekunde
       year: Godina
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: mora biti prihvaćen
       blank: ne smije biti prazan
@@ -137,10 +138,10 @@ hr:
       not_a_number: nije broj
       not_an_integer: nije cijeli broj
       odd: mora biti neparan
-      record_invalid: ! 'Validacija nije uspjela: %{errors}'
+      record_invalid: 'Validacija nije uspjela: %{errors}'
       restrict_dependent_destroy:
-        one: "Nije moguće izbrisati zapis jer postoji ovisan %{record}"
-        many: "Nije moguće izbrisati zapis jer postoje ovisni %{record}"
+        one: Nije moguće izbrisati zapis jer postoji ovisan %{record}
+        many: Nije moguće izbrisati zapis jer postoje ovisni %{record}
       taken: je već zauzet
       too_long:
         one: je predugačak (maksimum je %{count} znak)
@@ -157,14 +158,14 @@ hr:
         few: nije odgovarajuće duljine (treba biti %{count} znaka)
         many: nije odgovarajuće duljine (treba biti %{count} znakova)
         other: nije odgovarajuće duljine (treba biti %{count} znakova)
-      other_than: "mora biti različit od %{count}"
+      other_than: mora biti različit od %{count}
     template:
-      body: ! 'Sljedeća polja su neispravno popunjena:'
+      body: 'Sljedeća polja su neispravno popunjena:'
       header:
-        one: ! '%{count} greška je spriječila %{model} da se spremi'
-        few: ! '%{count} greške su spriječile %{model} da se spremi'
-        many: ! '%{count} grešaka je spriječilo %{model} da se spremi'
-        other: ! '%{count} grešaka je spriječilo %{model} da se spremi'
+        one: "%{count} greška je spriječila %{model} da se spremi"
+        few: "%{count} greške su spriječile %{model} da se spremi"
+        many: "%{count} grešaka je spriječilo %{model} da se spremi"
+        other: "%{count} grešaka je spriječilo %{model} da se spremi"
   helpers:
     select:
       prompt: Izaberite
@@ -175,22 +176,22 @@ hr:
   number:
     currency:
       format:
-        delimiter: ! ','
-        format: ! '%n %u'
+        delimiter: ","
+        format: "%n %u"
         precision: 2
-        separator: .
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
         unit: kn
     format:
-      delimiter: .
+      delimiter: "."
       precision: 3
-      separator: ! ','
+      separator: ","
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           thousand: Tisuća
           million: Milijun
@@ -204,7 +205,7 @@ hr:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: bajt
@@ -224,13 +225,13 @@ hr:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ' i '
-      two_words_connector: ! ' i '
-      words_connector: ! ', '
+      last_word_connector: " i "
+      two_words_connector: " i "
+      words_connector: ", "
   time:
     am: AM
     formats:
-      default: ! '%d.%m.%Y. %H:%M:%S'
-      long: ! '%e. %B %Y. %H:%M'
-      short: ! '%e.%-m. %k:%M'
+      default: "%d.%m.%Y. %H:%M:%S"
+      long: "%e. %B %Y. %H:%M"
+      short: "%e.%-m. %k:%M"
     pm: PM

--- a/rails/locale/hu.yml
+++ b/rails/locale/hu.yml
@@ -1,3 +1,4 @@
+---
 hu:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ hu:
     - p.
     - szo.
     abbr_month_names:
-    -
+    - 
     - jan.
     - febr.
     - márc.
@@ -31,11 +32,11 @@ hu:
     - péntek
     - szombat
     formats:
-      default: ! '%Y.%m.%d.'
-      long: ! '%Y. %B %e.'
-      short: ! '%b %e.'
+      default: "%Y.%m.%d."
+      long: "%Y. %B %e."
+      short: "%b %e."
     month_names:
-    -
+    - 
     - január
     - február
     - március
@@ -78,16 +79,16 @@ hu:
         other: több, mint %{count} éve
       x_days:
         one: 1 napja
-        other: ! '%{count} napja'
+        other: "%{count} napja"
       x_minutes:
         one: 1 perce
-        other: ! '%{count} perce'
+        other: "%{count} perce"
       x_months:
         one: 1 hónapja
-        other: ! '%{count} hónapja'
+        other: "%{count} hónapja"
       x_seconds:
         one: 1 másodperce
-        other: ! '%{count} másodperce'
+        other: "%{count} másodperce"
     prompts:
       day: Nap
       hour: Óra
@@ -96,7 +97,7 @@ hu:
       second: Másodperc
       year: Év
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: nincs elfogadva
       blank: nincs megadva
@@ -120,36 +121,36 @@ hu:
       too_short: túl rövid (legalább %{count} karakter kell legyen)
       wrong_length: nem megfelelő hosszúságú (%{count} karakter szükséges)
     template:
-      body: ! 'Problémás mezők:'
+      body: 'Problémás mezők:'
       header:
-        one: ! '1 hiba miatt nem menthető a következő: %{model}'
-        other: ! '%{count} hiba miatt nem menthető a következő: %{model}'
+        one: '1 hiba miatt nem menthető a következő: %{model}'
+        other: "%{count} hiba miatt nem menthető a következő: %{model}"
   helpers:
     select:
       prompt: Válasszon
     submit:
       create: Új %{model}
-      submit: ! '%{model} mentése'
-      update: ! '%{model} módosítása'
+      submit: "%{model} mentése"
+      update: "%{model} módosítása"
   number:
     currency:
       format:
         delimiter: ''
-        format: ! '%n %u'
+        format: "%n %u"
         precision: 0
-        separator: ! ','
+        separator: ","
         significant: true
         strip_insignificant_zeros: true
         unit: Ft
     format:
-      delimiter: ! ' '
+      delimiter: " "
       precision: 2
-      separator: ! ','
+      separator: ","
       significant: true
       strip_insignificant_zeros: true
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: milliárd
           million: millió
@@ -163,7 +164,7 @@ hu:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: bájt
@@ -180,13 +181,13 @@ hu:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ' és '
-      two_words_connector: ! ' és '
-      words_connector: ! ', '
+      last_word_connector: " és "
+      two_words_connector: " és "
+      words_connector: ", "
   time:
     am: de.
     formats:
-      default: ! '%Y. %b %e., %H:%M'
-      long: ! '%Y. %B %e., %A, %H:%M'
-      short: ! '%b %e., %H:%M'
+      default: "%Y. %b %e., %H:%M"
+      long: "%Y. %B %e., %A, %H:%M"
+      short: "%b %e., %H:%M"
     pm: du.

--- a/rails/locale/id.yml
+++ b/rails/locale/id.yml
@@ -1,3 +1,4 @@
+---
 id:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ id:
     - Jum
     - Sab
     abbr_month_names:
-    -
+    - 
     - Jan
     - Feb
     - Mar
@@ -31,11 +32,11 @@ id:
     - Jum'at
     - Sabtu
     formats:
-      default: ! '%d %B %Y'
-      long: ! '%A, %d %B %Y'
-      short: ! '%d.%m.%Y'
+      default: "%d %B %Y"
+      long: "%A, %d %B %Y"
+      short: "%d.%m.%Y"
     month_names:
-    -
+    - 
     - Januari
     - Februari
     - Maret
@@ -80,16 +81,16 @@ id:
         other: lebih dari %{count} tahun
       x_days:
         one: sehari
-        other: ! '%{count} hari'
+        other: "%{count} hari"
       x_minutes:
         one: satu menit
-        other: ! '%{count} menit'
+        other: "%{count} menit"
       x_months:
         one: sebulan
-        other: ! '%{count} bulan'
+        other: "%{count} bulan"
       x_seconds:
         one: satu detik
-        other: ! '%{count} detik'
+        other: "%{count} detik"
     prompts:
       day: Hari
       hour: Jam
@@ -98,11 +99,11 @@ id:
       second: Detik
       year: Tahun
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: harus diterima
       blank: tidak bisa kosong
-      confirmation: ! 'tidak sesuai dengan %{attribute}'
+      confirmation: tidak sesuai dengan %{attribute}
       empty: tidak bisa kosong
       equal_to: harus sama dengan %{count}
       even: harus genap
@@ -115,16 +116,16 @@ id:
       less_than_or_equal_to: harus sama atau lebih kecil dari %{count}
       not_a_number: bukan angka
       odd: harus ganjil
-      record_invalid: ! 'Verifikasi gagal: %{errors}'
+      record_invalid: 'Verifikasi gagal: %{errors}'
       taken: sudah digunakan
       too_long: terlalu panjang (maksimum %{count} karakter)
       too_short: terlalu pendek (minimum %{count} karakter)
       wrong_length: jumlah karakter salah (seharusnya %{count} karakter)
     template:
-      body: ! 'Ada masalah dengan field berikut:'
+      body: 'Ada masalah dengan field berikut:'
       header:
         one: 1 kesalahan mengakibatkan %{model} ini tidak bisa disimpan
-        other: ! '%{count} kesalahan mengakibatkan %{model} ini tidak bisa disimpan'
+        other: "%{count} kesalahan mengakibatkan %{model} ini tidak bisa disimpan"
   helpers:
     select:
       prompt: Silahkan pilih
@@ -135,22 +136,22 @@ id:
   number:
     currency:
       format:
-        delimiter: .
-        format: ! '%u%n'
+        delimiter: "."
+        format: "%u%n"
         precision: 2
-        separator: ! ','
+        separator: ","
         significant: false
         strip_insignificant_zeros: false
         unit: Rp
     format:
-      delimiter: .
+      delimiter: "."
       precision: 3
-      separator: ! ','
+      separator: ","
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: Miliar
           million: Juta
@@ -164,7 +165,7 @@ id:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Byte
@@ -181,13 +182,13 @@ id:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ' dan '
-      two_words_connector: ! ', '
-      words_connector: ! ', '
+      last_word_connector: " dan "
+      two_words_connector: ", "
+      words_connector: ", "
   time:
     am: am
     formats:
-      default: ! '%a, %d %b %Y %H.%M.%S %z'
-      long: ! '%d %B %Y %H.%M'
-      short: ! '%d %b %H.%M'
+      default: "%a, %d %b %Y %H.%M.%S %z"
+      long: "%d %B %Y %H.%M"
+      short: "%d %b %H.%M"
     pm: pm

--- a/rails/locale/is.yml
+++ b/rails/locale/is.yml
@@ -1,3 +1,4 @@
+---
 is:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ is:
     - fös
     - lau
     abbr_month_names:
-    -
+    - 
     - jan
     - feb
     - mar
@@ -31,11 +32,11 @@ is:
     - föstudaginn
     - laugardaginn
     formats:
-      default: ! '%d.%m.%Y'
-      long: ! '%e. %B %Y'
-      short: ! '%e. %b'
+      default: "%d.%m.%Y"
+      long: "%e. %B %Y"
+      short: "%e. %b"
     month_names:
-    -
+    - 
     - janúar
     - febrúar
     - mars
@@ -78,16 +79,16 @@ is:
         other: meira en %{count} ár
       x_days:
         one: 1 dagur
-        other: ! '%{count} dagar'
+        other: "%{count} dagar"
       x_minutes:
         one: 1 mínúta
-        other: ! '%{count} mínútur'
+        other: "%{count} mínútur"
       x_months:
         one: 1 mánuður
-        other: ! '%{count} mánuðir'
+        other: "%{count} mánuðir"
       x_seconds:
         one: 1 sekúnda
-        other: ! '%{count} sekúndur'
+        other: "%{count} sekúndur"
     prompts:
       day: Dagur
       hour: Klukkustund
@@ -96,7 +97,7 @@ is:
       second: Sekúnda
       year: Ár
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: þarf að vera tekið gilt
       blank: má ekki vera autt
@@ -115,10 +116,10 @@ is:
       not_a_number: er ekki tala
       not_an_integer: þarf að vera heiltala
       odd: þarf að vera oddatala
-      record_invalid: ! 'Villur: %{errors}'
+      record_invalid: 'Villur: %{errors}'
       restrict_dependent_destroy:
-        one: "Ekki hægt að eyða færslu því %{record} sem hún er háð er til"
-        many: "Ekki hægt að eyða færslur því %{record} sem hún er háð er til"
+        one: Ekki hægt að eyða færslu því %{record} sem hún er háð er til
+        many: Ekki hægt að eyða færslur því %{record} sem hún er háð er til
       taken: er þegar í notkun
       too_long:
         one: er of langt (má mest vera 1 stafur)
@@ -129,9 +130,9 @@ is:
       wrong_length:
         one: er af rangri lengd (má mest vera 1 stafur)
         other: er af rangri lengd (má mest vera %{count} stafir)
-      other_than: "verður að vera annað en %{count}"
+      other_than: verður að vera annað en %{count}
     template:
-      body: ! 'Villur fundust í eftirfarandi dálkum:'
+      body: 'Villur fundust í eftirfarandi dálkum:'
       header:
         one: Ekki var hægt að vista %{model} vegna einnar villu.
         other: Ekki var hægt að vista %{model} vegna %{count} villna.
@@ -145,22 +146,22 @@ is:
   number:
     currency:
       format:
-        delimiter: .
-        format: ! '%n %u'
+        delimiter: "."
+        format: "%n %u"
         precision: 2
-        separator: ! ','
+        separator: ","
         significant: false
         strip_insignificant_zeros: false
         unit: kr.
     format:
-      delimiter: .
+      delimiter: "."
       precision: 3
-      separator: ! ','
+      separator: ","
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion:
             one: milljarður
@@ -182,7 +183,7 @@ is:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: bæti
@@ -200,13 +201,13 @@ is:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ' og '
-      two_words_connector: ! ' og '
-      words_connector: ! ', '
+      last_word_connector: " og "
+      two_words_connector: " og "
+      words_connector: ", "
   time:
     am: ''
     formats:
-      default: ! '%A %e. %B %Y kl. %H:%M'
-      long: ! '%A %e. %B %Y kl. %H:%M'
-      short: ! '%e. %B kl. %H:%M'
+      default: "%A %e. %B %Y kl. %H:%M"
+      long: "%A %e. %B %Y kl. %H:%M"
+      short: "%e. %B kl. %H:%M"
     pm: ''

--- a/rails/locale/it-CH.yml
+++ b/rails/locale/it-CH.yml
@@ -1,3 +1,4 @@
+---
 it-CH:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ it-CH:
     - Ven
     - Sab
     abbr_month_names:
-    -
+    - 
     - Gen
     - Feb
     - Mar
@@ -31,11 +32,11 @@ it-CH:
     - Venerdì
     - Sabato
     formats:
-      default: ! '%d-%m-%Y'
-      long: ! '%d %B %Y'
-      short: ! '%d %b'
+      default: "%d-%m-%Y"
+      long: "%d %B %Y"
+      short: "%d %b"
     month_names:
-    -
+    - 
     - Gennaio
     - Febbraio
     - Marzo
@@ -78,16 +79,16 @@ it-CH:
         other: oltre %{count} anni
       x_days:
         one: 1 giorno
-        other: ! '%{count} giorni'
+        other: "%{count} giorni"
       x_minutes:
         one: 1 minuto
-        other: ! '%{count} minuti'
+        other: "%{count} minuti"
       x_months:
         one: 1 mese
-        other: ! '%{count} mesi'
+        other: "%{count} mesi"
       x_seconds:
         one: 1 secondo
-        other: ! '%{count} secondi'
+        other: "%{count} secondi"
     prompts:
       day: Giorno
       hour: Ora
@@ -96,7 +97,7 @@ it-CH:
       second: Secondi
       year: Anno
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: deve essere accettata
       blank: non può essere lasciato in bianco
@@ -114,7 +115,7 @@ it-CH:
       not_a_number: non è un numero
       not_an_integer: non è un intero
       odd: deve essere dispari
-      record_invalid: ! 'Validazione fallita: %{errors}'
+      record_invalid: 'Validazione fallita: %{errors}'
       taken: è già in uso
       too_long:
         one: è troppo lungo (il massimo è 1 carattere)
@@ -126,10 +127,10 @@ it-CH:
         one: è della lunghezza sbagliata (deve essere di 1 carattere)
         other: è della lunghezza sbagliata (deve essere di %{count} caratteri)
     template:
-      body: ! 'Per favore ricontrolla i seguenti campi:'
+      body: 'Per favore ricontrolla i seguenti campi:'
       header:
-        one: ! 'Non posso salvare questo %{model}: 1 errore'
-        other: ! 'Non posso salvare questo %{model}: %{count} errori.'
+        one: 'Non posso salvare questo %{model}: 1 errore'
+        other: 'Non posso salvare questo %{model}: %{count} errori.'
   helpers:
     select:
       prompt: Per favore, seleziona
@@ -140,22 +141,22 @@ it-CH:
   number:
     currency:
       format:
-        delimiter: ! ''''
-        format: ! '%u %n'
+        delimiter: "'"
+        format: "%u %n"
         precision: 2
-        separator: .
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
         unit: CHF
     format:
-      delimiter: ! ','
+      delimiter: ","
       precision: 2
-      separator: .
+      separator: "."
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: Miliardi
           million: Milioni
@@ -169,7 +170,7 @@ it-CH:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Byte
@@ -186,13 +187,13 @@ it-CH:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ' e '
-      two_words_connector: ! ' e '
-      words_connector: ! ', '
+      last_word_connector: " e "
+      two_words_connector: " e "
+      words_connector: ", "
   time:
     am: am
     formats:
-      default: ! '%a %d %b %Y, %H:%M:%S %z'
-      long: ! '%d %B %Y %H:%M'
-      short: ! '%d %b %H:%M'
+      default: "%a %d %b %Y, %H:%M:%S %z"
+      long: "%d %B %Y %H:%M"
+      short: "%d %b %H:%M"
     pm: pm

--- a/rails/locale/it.yml
+++ b/rails/locale/it.yml
@@ -1,3 +1,4 @@
+---
 it:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ it:
     - ven
     - sab
     abbr_month_names:
-    -
+    - 
     - gen
     - feb
     - mar
@@ -31,11 +32,11 @@ it:
     - venerdì
     - sabato
     formats:
-      default: ! '%d/%m/%Y'
-      long: ! '%d %B %Y'
-      short: ! '%d %b'
+      default: "%d/%m/%Y"
+      long: "%d %B %Y"
+      short: "%d %b"
     month_names:
-    -
+    - 
     - gennaio
     - febbraio
     - marzo
@@ -78,16 +79,16 @@ it:
         other: oltre %{count} anni
       x_days:
         one: 1 giorno
-        other: ! '%{count} giorni'
+        other: "%{count} giorni"
       x_minutes:
         one: 1 minuto
-        other: ! '%{count} minuti'
+        other: "%{count} minuti"
       x_months:
         one: 1 mese
-        other: ! '%{count} mesi'
+        other: "%{count} mesi"
       x_seconds:
         one: 1 secondo
-        other: ! '%{count} secondi'
+        other: "%{count} secondi"
     prompts:
       day: Giorno
       hour: Ora
@@ -96,7 +97,7 @@ it:
       second: Secondi
       year: Anno
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: deve essere accettata
       blank: non può essere lasciato in bianco
@@ -115,10 +116,10 @@ it:
       not_a_number: non è un numero
       not_an_integer: non è un numero intero
       odd: deve essere dispari
-      record_invalid: ! 'Validazione fallita: %{errors}'
+      record_invalid: 'Validazione fallita: %{errors}'
       restrict_dependent_destroy:
-        one: "Il record non può essere cancellato perchè esiste un %{record} dipendente"
-        many: "Il record non può essere cancellato perchè esistono %{record} dipendenti"
+        one: Il record non può essere cancellato perchè esiste un %{record} dipendente
+        many: Il record non può essere cancellato perchè esistono %{record} dipendenti
       taken: è già presente
       too_long:
         one: è troppo lungo (il massimo è 1 carattere)
@@ -129,12 +130,12 @@ it:
       wrong_length:
         one: è della lunghezza sbagliata (deve essere di 1 carattere)
         other: è della lunghezza sbagliata (deve essere di %{count} caratteri)
-      other_than: "devono essere di numero diverso da %{count}"
+      other_than: devono essere di numero diverso da %{count}
     template:
-      body: ! 'Ricontrolla i seguenti campi:'
+      body: 'Ricontrolla i seguenti campi:'
       header:
-        one: ! 'Non posso salvare questo %{model}: 1 errore'
-        other: ! 'Non posso salvare questo %{model}: %{count} errori.'
+        one: 'Non posso salvare questo %{model}: 1 errore'
+        other: 'Non posso salvare questo %{model}: %{count} errori.'
   helpers:
     select:
       prompt: Seleziona...
@@ -145,22 +146,22 @@ it:
   number:
     currency:
       format:
-        delimiter: .
-        format: ! '%n %u'
+        delimiter: "."
+        format: "%n %u"
         precision: 2
-        separator: ! ','
+        separator: ","
         significant: false
         strip_insignificant_zeros: false
-        unit: €
+        unit: "€"
     format:
-      delimiter: .
+      delimiter: "."
       precision: 2
-      separator: ! ','
+      separator: ","
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: Miliardi
           million: Milioni
@@ -174,7 +175,7 @@ it:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Byte
@@ -192,13 +193,13 @@ it:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ' e '
-      two_words_connector: ! ' e '
-      words_connector: ! ', '
+      last_word_connector: " e "
+      two_words_connector: " e "
+      words_connector: ", "
   time:
     am: am
     formats:
-      default: ! '%a %d %b %Y, %H:%M:%S %z'
-      long: ! '%d %B %Y %H:%M'
-      short: ! '%d %b %H:%M'
+      default: "%a %d %b %Y, %H:%M:%S %z"
+      long: "%d %B %Y %H:%M"
+      short: "%d %b %H:%M"
     pm: pm

--- a/rails/locale/ja.yml
+++ b/rails/locale/ja.yml
@@ -1,3 +1,4 @@
+---
 ja:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ ja:
     - 金
     - 土
     abbr_month_names:
-    -
+    - 
     - 1月
     - 2月
     - 3月
@@ -31,11 +32,11 @@ ja:
     - 金曜日
     - 土曜日
     formats:
-      default: ! '%Y/%m/%d'
-      long: ! '%Y年%m月%d日(%a)'
-      short: ! '%m/%d'
+      default: "%Y/%m/%d"
+      long: "%Y年%m月%d日(%a)"
+      short: "%m/%d"
     month_names:
-    -
+    - 
     - 1月
     - 2月
     - 3月
@@ -65,29 +66,29 @@ ja:
         other: 約%{count}年
       almost_x_years:
         one: 1年弱
-        other: ! '%{count}年弱'
+        other: "%{count}年弱"
       half_a_minute: 30秒前後
       less_than_x_minutes:
         one: 1分以内
-        other: ! '%{count}分未満'
+        other: "%{count}分未満"
       less_than_x_seconds:
         one: 1秒以内
-        other: ! '%{count}秒未満'
+        other: "%{count}秒未満"
       over_x_years:
         one: 1年以上
-        other: ! '%{count}年以上'
+        other: "%{count}年以上"
       x_days:
         one: 1日
-        other: ! '%{count}日'
+        other: "%{count}日"
       x_minutes:
         one: 1分
-        other: ! '%{count}分'
+        other: "%{count}分"
       x_months:
         one: 1ヶ月
-        other: ! '%{count}ヶ月'
+        other: "%{count}ヶ月"
       x_seconds:
         one: 1秒
-        other: ! '%{count}秒'
+        other: "%{count}秒"
     prompts:
       day: 日
       hour: 時
@@ -96,7 +97,7 @@ ja:
       second: 秒
       year: 年
   errors:
-    format: ! '%{attribute}%{message}'
+    format: "%{attribute}%{message}"
     messages:
       accepted: を受諾してください。
       blank: を入力してください。
@@ -116,17 +117,17 @@ ja:
       not_an_integer: は整数で入力してください。
       odd: は奇数にしてください。
       record_invalid: バリデーションに失敗しました。 %{errors}
-      restrict_dependent_destroy: ! '%{record}が存在しているので削除できません。'
+      restrict_dependent_destroy: "%{record}が存在しているので削除できません。"
       taken: はすでに存在します。
       too_long: は%{count}文字以内で入力してください。
       too_short: は%{count}文字以上で入力してください。
       wrong_length: は%{count}文字で入力してください。
-      other_than: "は%{count}以外の値にしてください。"
+      other_than: は%{count}以外の値にしてください。
     template:
       body: 次の項目を確認してください。
       header:
-        one: ! '%{model}にエラーが発生しました。'
-        other: ! '%{model}に%{count}個のエラーが発生しました。'
+        one: "%{model}にエラーが発生しました。"
+        other: "%{model}に%{count}個のエラーが発生しました。"
   helpers:
     select:
       prompt: 選択してください。
@@ -137,22 +138,22 @@ ja:
   number:
     currency:
       format:
-        delimiter: ! ','
-        format: ! '%n%u'
+        delimiter: ","
+        format: "%n%u"
         precision: 0
-        separator: .
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
         unit: 円
     format:
-      delimiter: ! ','
+      delimiter: ","
       precision: 3
-      separator: .
+      separator: "."
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: 十億
           million: 百万
@@ -166,7 +167,7 @@ ja:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n%u'
+        format: "%n%u"
         units:
           byte: バイト
           gb: ギガバイト
@@ -188,7 +189,7 @@ ja:
   time:
     am: 午前
     formats:
-      default: ! '%Y/%m/%d %H:%M:%S'
-      long: ! '%Y年%m月%d日(%a) %H時%M分%S秒 %z'
-      short: ! '%y/%m/%d %H:%M'
+      default: "%Y/%m/%d %H:%M:%S"
+      long: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
+      short: "%y/%m/%d %H:%M"
     pm: 午後

--- a/rails/locale/km.yml
+++ b/rails/locale/km.yml
@@ -1,3 +1,4 @@
+---
 km:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ km:
     - សុ
     - សៅ
     abbr_month_names:
-    -
+    - 
     - មករា
     - កុម្ភៈ
     - មិនា
@@ -31,11 +32,11 @@ km:
     - ថ្ងៃសៅរ៍
     - ថ្ងៃអាទិត្យ
     formats:
-      long: ! ”ថ្ងៃទី%e %B %Y %H:%M %Z"
-      default: ! “%d %B %Y”
-      short: ! “%d %b”
+      long: ”ថ្ងៃទី%e %B %Y %H:%M %Z"
+      default: "“%d %B %Y”"
+      short: "“%d %b”"
     month_names:
-    -
+    - 
     - ខែមករា
     - ខែកុម្ភៈ
     - ខែមិនា
@@ -53,12 +54,12 @@ km:
     - :month
     - :year
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: ត្រូវតែព្រម
       blank: មិនអាចរំលង
       present: ត្រូវតែរំលង
-      confirmation: ! "ផ្ទៀងផ្ទាត់មិនត្រូវនឹង %{attribute}"
+      confirmation: ផ្ទៀងផ្ទាត់មិនត្រូវនឹង %{attribute}
       empty: មិនអាចរំលង
       equal_to: ត្រូវតែស្មើ %{count}
       even: ត្រូវតែជាចំនួនគត់
@@ -72,10 +73,10 @@ km:
       not_a_number: មិនមែនជាលេខទេ
       not_an_integer: ត្រូវតែជាចំនួនពេញ
       odd: ត្រូវតែជាចំនួនសេស
-      record_invalid: ! 'មិនមានសុពលភាព: %{errors}'
+      record_invalid: 'មិនមានសុពលភាព: %{errors}'
       restrict_dependent_destroy:
-        one: "មិនអាចលុបបានទេពីព្រោះមាន %{record} នៅឡើយ"
-        many: "មិនអាចលុបបានទេពីព្រោះមាន %{record} នៅឡើយ"
+        one: មិនអាចលុបបានទេពីព្រោះមាន %{record} នៅឡើយ
+        many: មិនអាចលុបបានទេពីព្រោះមាន %{record} នៅឡើយ
       taken: មានរួចហើយ
       too_long:
         one: វែងពេក (អតិបរមា 1 អក្សរ)
@@ -86,9 +87,9 @@ km:
       wrong_length:
         one: ប្រវែងមិនត្រូវ (គួរតែមាន 1 អក្សរ)
         other: ប្រវែងមិនត្រូវ (គួរតែមាន %{count} អក្សរ)
-      other_than: "ត្រូវតែខុសពី %{count}"
+      other_than: ត្រូវតែខុសពី %{count}
     template:
-      body: ! 'សូមពិនិត្យមើលកំហុសនៅខាងក្រោម:'
+      body: 'សូមពិនិត្យមើលកំហុសនៅខាងក្រោម:'
       header:
         one: មានកំហុស1ដែលបានបញ្ឈប់ %{model} នេះពីការរក្សាទុក
-        other: ! មានកំហុស%{count}ដែលបានបញ្ឈប់ %{model} នេះពីការរក្សាទុក'
+        other: មានកំហុស%{count}ដែលបានបញ្ឈប់ %{model} នេះពីការរក្សាទុក'

--- a/rails/locale/kn.yml
+++ b/rails/locale/kn.yml
@@ -1,3 +1,4 @@
+---
 kn:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ kn:
     - ಶುಕ್ರ
     - ಶನಿ
     abbr_month_names:
-    -
+    - 
     - Jan
     - Feb
     - Mar
@@ -31,11 +32,11 @@ kn:
     - ಶುಕ್ರವಾರ
     - ಶನಿವಾರ
     formats:
-      default: ! '%Y-%m-%d'
-      long: ! '%B %d, %Y'
-      short: ! '%b %d'
+      default: "%Y-%m-%d"
+      long: "%B %d, %Y"
+      short: "%b %d"
     month_names:
-    -
+    - 
     - ಜನವರಿ
     - ಫೆಬ್ರವರಿ
     - ಮಾರ್ಚ್
@@ -69,25 +70,25 @@ kn:
       half_a_minute: ಒಂದು ಅರ್ಧ ನಿಮಿಷ
       less_than_x_minutes:
         one: ಒಂದು ನಿಮಿಷಕ್ಕೂ ಕಡಿಮೆ
-        other: ! '%{count} ನಿಮಿಷಕ್ಕಿಂತ ಕಡಿಮೆ'
+        other: "%{count} ನಿಮಿಷಕ್ಕಿಂತ ಕಡಿಮೆ"
       less_than_x_seconds:
         one: ಒಂದು ಸೆಕೆಂಡಿಗೂ ಕಡಿಮೆ
-        other: ! '%{count} ಸೆಕೆಂಡಿಗಿಂತ ಕಡಿಮೆ'
+        other: "%{count} ಸೆಕೆಂಡಿಗಿಂತ ಕಡಿಮೆ"
       over_x_years:
         one: ಒಂದು ವರುಷಕ್ಕಿಂತ ಹೆಚ್ಚು
-        other: ! '%{count} ವರುಷಗಳಿಗಿಂತ ಹೆಚ್ಚು'
+        other: "%{count} ವರುಷಗಳಿಗಿಂತ ಹೆಚ್ಚು"
       x_days:
         one: 1 ದಿನ
-        other: ! '%{count} ದಿನಗಳು'
+        other: "%{count} ದಿನಗಳು"
       x_minutes:
         one: 1 ನಿಮಿಷ
-        other: ! '%{count} ನಿಮಿಷಗಳು'
+        other: "%{count} ನಿಮಿಷಗಳು"
       x_months:
         one: 1 ತಿಂಗಳು
-        other: ! '%{count} ತಿಂಗಳುಗಳು'
+        other: "%{count} ತಿಂಗಳುಗಳು"
       x_seconds:
         one: 1 ಸೆಕೆಂಡ್
-        other: ! '%{count} ಸೆಕೆಂಡುಗಳು'
+        other: "%{count} ಸೆಕೆಂಡುಗಳು"
     prompts:
       day: ದಿನ
       hour: ಗಂಟೆ
@@ -96,60 +97,60 @@ kn:
       second: ಸೆಕೆಂಡು
       year: ವರುಷ
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: ಒಪ್ಪಿಕೊಳ್ಳಬೇಕು
       blank: ಖಾಲಿ ಬಿಡಲು ಸಧ್ಯವಿಲ್ಲ
       confirmation: ಸಮರ್ಥನೆ ಸರಿಬರಲ್ಲಿಲ್ಲ
       empty: ಖಾಲಿ ಬಿಡಲು ಸಧ್ಯವಿಲ್ಲ
-      equal_to: ! '%{count} ಕ್ಕೆ ಸಮಾನವಾಗಿರಬೇಕು'
+      equal_to: "%{count} ಕ್ಕೆ ಸಮಾನವಾಗಿರಬೇಕು"
       even: ಸಮ ಆಗಿರಬೇಕು
       exclusion: ಕಾಯ್ದಿರಿಸಲಾಗಿದೆ
-      greater_than: ! '%{count} ಕ್ಕಿಂತ ಹೆಚ್ಚಿರಬೇಕು'
-      greater_than_or_equal_to: ! '%{count} ಕಿಂತ ಹೆಚ್ಚು ಅಥವಾ ಸಮಾನವಾಗಿರ ಇರಬೇಕು'
+      greater_than: "%{count} ಕ್ಕಿಂತ ಹೆಚ್ಚಿರಬೇಕು"
+      greater_than_or_equal_to: "%{count} ಕಿಂತ ಹೆಚ್ಚು ಅಥವಾ ಸಮಾನವಾಗಿರ ಇರಬೇಕು"
       inclusion: ಪಟ್ಟಿಯಲ್ಲಿ ಶಾಮೀಲು ಆಗಿಲ್ಲ
       invalid: ನಿರರ್ಥಕವಾಗಿದೆ
-      less_than: ! '%{count} ಕ್ಕಿಂತ ಕಡಿಮೆ ಆಗಿರಬೇಕು'
-      less_than_or_equal_to: ! '%{count} ಕಿಂತ ಕಡಿಮೆ ಅಥವಾ ಸಮಾನವಾಗಿರ ಇರಬೇಕು'
+      less_than: "%{count} ಕ್ಕಿಂತ ಕಡಿಮೆ ಆಗಿರಬೇಕು"
+      less_than_or_equal_to: "%{count} ಕಿಂತ ಕಡಿಮೆ ಅಥವಾ ಸಮಾನವಾಗಿರ ಇರಬೇಕು"
       not_a_number: ಸಂಖೆ ಆಗಿಲ್ಲ
       not_an_integer: ಸಂಖೆ ಆಗಿರಬೇಕು
       odd: ಬೆಸ ಆಗಿರಬೇಕು
-      record_invalid: ! 'ತಪ್ಪು ಆಧಾರ: %{errors}'
+      record_invalid: 'ತಪ್ಪು ಆಧಾರ: %{errors}'
       taken: ತೆಗೆದುಕೊಂಡಾಗಿದೆ
       too_long: ಬಹಳ ದೊಡ್ಡದಾಗಿದೆ (ಗರಿಷ್ಟ %{count} ಅಕ್ಷರಗಳು)
       too_short: ಬಹಳ ಚಿಕ್ಕದಾಗಿದೆ (ಕನಿಷ್ಠ %{count} ಅಕ್ಷರಗಳು)
       wrong_length: ತಪ್ಪು ಉದ್ದವಿದೆ (%{count} ಅಕ್ಷರಗಳಿರಬೇಕು)
     template:
-      body: ! 'ಸಮಸ್ಯೆಗಳಿರುವ ಜಾಗಗಳು:'
+      body: 'ಸಮಸ್ಯೆಗಳಿರುವ ಜಾಗಗಳು:'
       header:
         one: 1 ಧೋಷದ ಪರಿಣಾಮ %{model} ಅನ್ನು ರಚಿಸಲು ಸಾಧ್ಯವಾಗಲಿಲ್ಲ
-        other: ! '%{count} ಧೋಷಗಳ ಪರಿಣಾಮ %{model} ಅನ್ನು ರಚಿಸಲು ಸಾಧ್ಯವಾಗಲಿಲ್ಲ'
+        other: "%{count} ಧೋಷಗಳ ಪರಿಣಾಮ %{model} ಅನ್ನು ರಚಿಸಲು ಸಾಧ್ಯವಾಗಲಿಲ್ಲ"
   helpers:
     select:
       prompt: ದಯವಿಟ್ಟು ಆರಿಸಿ
     submit:
-      create: ! '%{model} ರಚಿಸಿ'
-      submit: ! '%{model} ಕಳುಹಿಸು'
-      update: ! '%{model} ರಚಿಸಿ'
+      create: "%{model} ರಚಿಸಿ"
+      submit: "%{model} ಕಳುಹಿಸು"
+      update: "%{model} ರಚಿಸಿ"
   number:
     currency:
       format:
-        delimiter: ! ','
-        format: ! '%u%n'
+        delimiter: ","
+        format: "%u%n"
         precision: 2
-        separator: .
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
-        unit: $
+        unit: "$"
     format:
-      delimiter: ! ','
+      delimiter: ","
       precision: 3
-      separator: .
+      separator: "."
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: ಲಕ್ಷಕೋಟಿ
           million: ದಶಲಕ್ಷ
@@ -163,7 +164,7 @@ kn:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Byte
@@ -180,13 +181,13 @@ kn:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ', ಮತ್ತು  '
-      two_words_connector: ! ' ಮತ್ತು  '
-      words_connector: ! ', '
+      last_word_connector: ", ಮತ್ತು  "
+      two_words_connector: " ಮತ್ತು  "
+      words_connector: ", "
   time:
     am: ಪ್ರಾತಃಕಾಲ
     formats:
-      default: ! '%a, %d %b %Y %H:%M:%S %z'
-      long: ! '%B %d, %Y %H:%M'
-      short: ! '%d %b %H:%M'
+      default: "%a, %d %b %Y %H:%M:%S %z"
+      long: "%B %d, %Y %H:%M"
+      short: "%d %b %H:%M"
     pm: ಅಪರನ್ನಃ

--- a/rails/locale/ko.yml
+++ b/rails/locale/ko.yml
@@ -1,3 +1,4 @@
+---
 ko:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ ko:
     - 금
     - 토
     abbr_month_names:
-    -
+    - 
     - 1월
     - 2월
     - 3월
@@ -31,11 +32,11 @@ ko:
     - 금요일
     - 토요일
     formats:
-      default: ! '%Y/%m/%d'
-      long: ! '%Y년 %m월 %d일 (%a)'
-      short: ! '%m/%d'
+      default: "%Y/%m/%d"
+      long: "%Y년 %m월 %d일 (%a)"
+      short: "%m/%d"
     month_names:
-    -
+    - 
     - 1월
     - 2월
     - 3월
@@ -65,29 +66,29 @@ ko:
         other: 약 %{count}년
       almost_x_years:
         one: 일 년 이하
-        other: ! '%{count}년 이하'
+        other: "%{count}년 이하"
       half_a_minute: 30초
       less_than_x_minutes:
         one: 일 분 이하
-        other: ! '%{count}분 이하'
+        other: "%{count}분 이하"
       less_than_x_seconds:
         one: 일 초 이하
-        other: ! '%{count}초 이하'
+        other: "%{count}초 이하"
       over_x_years:
         one: 일 년 이상
-        other: ! '%{count}년 이상'
+        other: "%{count}년 이상"
       x_days:
         one: 하루
-        other: ! '%{count}일'
+        other: "%{count}일"
       x_minutes:
         one: 일 분
-        other: ! '%{count}분'
+        other: "%{count}분"
       x_months:
         one: 한 달
-        other: ! '%{count}달'
+        other: "%{count}달"
       x_seconds:
         one: 일 초
-        other: ! '%{count}초'
+        other: "%{count}초"
     prompts:
       day: 일
       hour: 시
@@ -96,7 +97,7 @@ ko:
       second: 초
       year: 년
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: 을(를) 반드시 확인해야 합니다
       blank: 에 내용을 입력해 주세요
@@ -120,10 +121,10 @@ ko:
       too_short: 은(는) 적어도 %{count}자를 넘어야 합니다
       wrong_length: 은(는) %{count}자여야 합니다
     template:
-      body: ! '다음 항목에 문제가 발견되었습니다:'
+      body: '다음 항목에 문제가 발견되었습니다:'
       header:
         one: 한 개의 오류가 발생해 %{model}를 저장 할 수 없습니다
-        other: ! '%{count}개의 오류가 발생해 %{model}를 저장 할 수 없습니다'
+        other: "%{count}개의 오류가 발생해 %{model}를 저장 할 수 없습니다"
   helpers:
     select:
       prompt: 선택해주세요
@@ -134,22 +135,22 @@ ko:
   number:
     currency:
       format:
-        delimiter: ! ','
-        format: ! '%n%u'
+        delimiter: ","
+        format: "%n%u"
         precision: 0
-        separator: .
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
         unit: 원
     format:
-      delimiter: ! ','
+      delimiter: ","
       precision: 3
-      separator: .
+      separator: "."
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n%u'
+        format: "%n%u"
         units:
           billion: 십억
           million: 백만
@@ -163,7 +164,7 @@ ko:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n%u'
+        format: "%n%u"
         units:
           byte: 바이트
           gb: 기가바이트
@@ -178,13 +179,13 @@ ko:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ', '
-      two_words_connector: ! '와(과) '
-      words_connector: ! ', '
+      last_word_connector: ", "
+      two_words_connector: '와(과) '
+      words_connector: ", "
   time:
     am: 오전
     formats:
-      default: ! '%Y/%m/%d %H:%M:%S'
-      long: ! '%Y년 %m월 %d일, %H시 %M분 %S초 %Z'
-      short: ! '%y/%m/%d %H:%M'
+      default: "%Y/%m/%d %H:%M:%S"
+      long: "%Y년 %m월 %d일, %H시 %M분 %S초 %Z"
+      short: "%y/%m/%d %H:%M"
     pm: 오후

--- a/rails/locale/lo.yml
+++ b/rails/locale/lo.yml
@@ -1,3 +1,4 @@
+---
 lo:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ lo:
     - ''
     - ''
     abbr_month_names:
-    -
+    - 
     - ''
     - ''
     - ''
@@ -31,11 +32,11 @@ lo:
     - ສຸກ
     - ເສົາ
     formats:
-      default: ! '%d-%m-%Y'
-      long: ! '%e %B %Y'
-      short: ! '%e %b'
+      default: "%d-%m-%Y"
+      long: "%e %B %Y"
+      short: "%e %b"
     month_names:
-    -
+    - 
     - ມັງກອນ
     - ກຸມພາ
     - ມີນາ
@@ -69,62 +70,62 @@ lo:
         many: ປະມານ %{count} ເດືອນ
         other: ປະມານ %{count} ເດືອນ
       about_x_years:
-        zero: ! 'ປະມານ %{count} ປີ '
-        one: ! 'ປະມານ 1 ປີ '
-        two: ! 'ປະມານ %{count} ປີ '
-        few: ! 'ປະມານ %{count} ປີ '
-        many: ! 'ປະມານ %{count} ປີ '
-        other: ! 'ປະມານ %{count} ປີ '
-      half_a_minute: ! 'ເຄິ່ງນາທີ '
+        zero: 'ປະມານ %{count} ປີ '
+        one: 'ປະມານ 1 ປີ '
+        two: 'ປະມານ %{count} ປີ '
+        few: 'ປະມານ %{count} ປີ '
+        many: 'ປະມານ %{count} ປີ '
+        other: 'ປະມານ %{count} ປີ '
+      half_a_minute: 'ເຄິ່ງນາທີ '
       less_than_x_minutes:
-        zero: ! 'ນ້ອຍກວ່າ %{count} ນາທີ '
-        one: ! 'ນ້ອຍກວ່າ 1 ນາທີ '
-        two: ! 'ນ້ອຍກວ່າ %{count} ນາທີ '
-        few: ! 'ນ້ອຍກວ່າ %{count} ນາທີ '
-        many: ! 'ນ້ອຍກວ່າ %{count} ນາທີ '
-        other: ! 'ນ້ອຍກວ່າ %{count} ນາທີ '
+        zero: 'ນ້ອຍກວ່າ %{count} ນາທີ '
+        one: 'ນ້ອຍກວ່າ 1 ນາທີ '
+        two: 'ນ້ອຍກວ່າ %{count} ນາທີ '
+        few: 'ນ້ອຍກວ່າ %{count} ນາທີ '
+        many: 'ນ້ອຍກວ່າ %{count} ນາທີ '
+        other: 'ນ້ອຍກວ່າ %{count} ນາທີ '
       less_than_x_seconds:
-        zero: ! 'ນ້ອຍກວ່າ %{count} ວິນາທີ '
-        one: ! 'ນ້ອຍກວ່າ 1 ວິນາທີ '
-        two: ! 'ນ້ອຍກວ່າ %{count} ວິນາທີ '
-        few: ! 'ນ້ອຍກວ່າ %{count} ວິນາທີ '
-        many: ! 'ນ້ອຍກວ່າ %{count} ວິນາທີ '
-        other: ! 'ນ້ອຍກວ່າ %{count} ວິນາທີ '
+        zero: 'ນ້ອຍກວ່າ %{count} ວິນາທີ '
+        one: 'ນ້ອຍກວ່າ 1 ວິນາທີ '
+        two: 'ນ້ອຍກວ່າ %{count} ວິນາທີ '
+        few: 'ນ້ອຍກວ່າ %{count} ວິນາທີ '
+        many: 'ນ້ອຍກວ່າ %{count} ວິນາທີ '
+        other: 'ນ້ອຍກວ່າ %{count} ວິນາທີ '
       over_x_years:
-        zero: ! 'ຫຼາຍກວ່າ %{count} ປີ '
-        one: ! 'ຫຼາຍກວ່າ 1 ປີ '
-        two: ! 'ຫຼາຍກວ່າ %{count} ປີ '
-        few: ! 'ຫຼາຍກວ່າ %{count} ປີ '
-        many: ! 'ຫຼາຍກວ່າ %{count} ປີ '
-        other: ! 'ຫຼາຍກວ່າ %{count} ປີ '
+        zero: 'ຫຼາຍກວ່າ %{count} ປີ '
+        one: 'ຫຼາຍກວ່າ 1 ປີ '
+        two: 'ຫຼາຍກວ່າ %{count} ປີ '
+        few: 'ຫຼາຍກວ່າ %{count} ປີ '
+        many: 'ຫຼາຍກວ່າ %{count} ປີ '
+        other: 'ຫຼາຍກວ່າ %{count} ປີ '
       x_days:
-        zero: ! '%{count} ມື້ '
-        one: ! '1 ມື້ '
-        two: ! '%{count} ມື້ '
-        few: ! '%{count} ມື້ '
-        many: ! '%{count} ມື້ '
-        other: ! '%{count} ມື້ '
+        zero: "%{count} ມື້ "
+        one: '1 ມື້ '
+        two: "%{count} ມື້ "
+        few: "%{count} ມື້ "
+        many: "%{count} ມື້ "
+        other: "%{count} ມື້ "
       x_minutes:
-        zero: ! '%{count} ນາທີ '
-        one: ! '1 ນາທີ '
-        two: ! '%{count} ນາທີ '
-        few: ! '%{count} ນາທີ '
-        many: ! '%{count} ນາທີ '
-        other: ! '%{count} ນາທີ '
+        zero: "%{count} ນາທີ "
+        one: '1 ນາທີ '
+        two: "%{count} ນາທີ "
+        few: "%{count} ນາທີ "
+        many: "%{count} ນາທີ "
+        other: "%{count} ນາທີ "
       x_months:
-        zero: ! '%{count} ເດືອນ'
+        zero: "%{count} ເດືອນ"
         one: 1 ເດືອນ
-        two: ! '%{count} ເດືອນ'
-        few: ! '%{count} ເດືອນ'
-        many: ! '%{count} ເດືອນ'
-        other: ! '%{count} ເດືອນ'
+        two: "%{count} ເດືອນ"
+        few: "%{count} ເດືອນ"
+        many: "%{count} ເດືອນ"
+        other: "%{count} ເດືອນ"
       x_seconds:
-        zero: ! '%{count} ວິນາທີ '
-        one: ! '1 ວິນາທີ '
-        two: ! '%{count} ວິນາທີ '
-        few: ! '%{count} ວິນາທີ '
-        many: ! '%{count} ວິນາທີ '
-        other: ! '%{count} ວິນາທີ '
+        zero: "%{count} ວິນາທີ "
+        one: '1 ວິນາທີ '
+        two: "%{count} ວິນາທີ "
+        few: "%{count} ວິນາທີ "
+        many: "%{count} ວິນາທີ "
+        other: "%{count} ວິນາທີ "
     prompts:
       day: ວັນ
       hour: ຊົ່ວໂມງ
@@ -133,7 +134,7 @@ lo:
       second: ວິນາທີ
       year: ປີ
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: ຕ້ອງຍອມຮັບ
       blank: ເປົ່າບໍ່ໄດ້
@@ -150,13 +151,13 @@ lo:
       less_than_or_equal_to: ຕ້ອງຕຳ່ກວ່າ ຫຼື ເທົ່າກັບ %{count}
       not_a_number: ບໍ່ແມ່ນຕົວເລກ
       odd: ຕ້ອງເປັນເລກຄີກ
-      record_invalid: ! 'ການຢືນຢັນບໍ່ສຳເລັດ : %{errors}'
+      record_invalid: 'ການຢືນຢັນບໍ່ສຳເລັດ : %{errors}'
       taken: ຮັບເອົາໄປແລ້ວ
       too_long: ຍາວໂພດ (ສູງສຸດຄື %{count} ຕົວອັກສອນ)
       too_short: ສັ້ນໂພດ (ຕຳ່ສຸດຄື %{count} ຕົວອັກສອນ)
       wrong_length: ຄວາມຍາວຜິດ (ຄວນຈະເປັນ %{count} ຕົວອັກສອນ)
     template:
-      body: ! 'ກະລຸນາກວດສອບຂໍ້ມູນໃນຫ້ອງຕໍ່ໄປນີ້ :'
+      body: 'ກະລຸນາກວດສອບຂໍ້ມູນໃນຫ້ອງຕໍ່ໄປນີ້ :'
       header:
         zero: ບໍ່ສາມາດບັນທຶກ %{model} ໄດ້ເນື່ອງຈາກ ເກີດ %{count} ຂໍ້ຜິດພາດ
         one: ບໍ່ສາມາດບັນທຶກ %{model} ໄດ້ເນື່ອງຈາກເກີດຂໍ້ຜິດພາດ
@@ -170,22 +171,22 @@ lo:
   number:
     currency:
       format:
-        delimiter: ! ','
-        format: ! '%n %u'
+        delimiter: ","
+        format: "%n %u"
         precision: 2
-        separator: .
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
         unit: Kip
     format:
-      delimiter: ! ','
+      delimiter: ","
       precision: 3
-      separator: .
+      separator: "."
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           unit: ''
       format:
@@ -194,7 +195,7 @@ lo:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             zero: Bytes
@@ -215,13 +216,13 @@ lo:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ', ແລະ '
-      two_words_connector: ! 'ແລະ '
-      words_connector: ! ', '
+      last_word_connector: ", ແລະ "
+      two_words_connector: 'ແລະ '
+      words_connector: ", "
   time:
     am: ''
     formats:
-      default: ! '%a %d %b %Y %H:%M:%S %z'
-      long: ! '%d %B %Y %H:%M น.'
-      short: ! '%d %b %H:%M น.'
+      default: "%a %d %b %Y %H:%M:%S %z"
+      long: "%d %B %Y %H:%M น."
+      short: "%d %b %H:%M น."
     pm: ''

--- a/rails/locale/lt.yml
+++ b/rails/locale/lt.yml
@@ -1,3 +1,4 @@
+---
 lt:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ lt:
     - Pen
     - Šeš
     abbr_month_names:
-    -
+    - 
     - Sau
     - Vas
     - Kov
@@ -31,11 +32,11 @@ lt:
     - penktadienis
     - šeštadienis
     formats:
-      default: ! '%Y-%m-%d'
-      long: ! '%B %d, %Y'
-      short: ! '%b %d'
+      default: "%Y-%m-%d"
+      long: "%B %d, %Y"
+      short: "%b %d"
     month_names:
-    -
+    - 
     - sausio
     - vasario
     - kovo
@@ -84,21 +85,21 @@ lt:
         few: virš %{count} metų
         other: virš %{count} metų
       x_days:
-        one: ! '%{count} diena'
-        few: ! '%{count} dienos'
-        other: ! '%{count} dienų'
+        one: "%{count} diena"
+        few: "%{count} dienos"
+        other: "%{count} dienų"
       x_minutes:
-        one: ! '%{count} minutė'
-        few: ! '%{count} minutės'
-        other: ! '%{count} minučių'
+        one: "%{count} minutė"
+        few: "%{count} minutės"
+        other: "%{count} minučių"
       x_months:
-        one: ! '%{count} mėnesis'
-        few: ! '%{count} mėnesiai'
-        other: ! '%{count} mėnesių'
+        one: "%{count} mėnesis"
+        few: "%{count} mėnesiai"
+        other: "%{count} mėnesių"
       x_seconds:
-        one: ! '%{count} sekundė'
-        few: ! '%{count} sekundės'
-        other: ! '%{count} sekundžių'
+        one: "%{count} sekundė"
+        few: "%{count} sekundės"
+        other: "%{count} sekundžių"
     prompts:
       day: Diena
       hour: Valanda
@@ -107,7 +108,7 @@ lt:
       second: Sekundės
       year: Metai
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: turi būti patvirtintas
       blank: negali būti tuščias
@@ -126,10 +127,10 @@ lt:
       not_a_number: ne skaičius
       not_an_integer: privalo būti sveikas skaičius
       odd: turi būti nelyginis
-      record_invalid: ! 'Nepraeitos patikros: %{errors}'
+      record_invalid: 'Nepraeitos patikros: %{errors}'
       restrict_dependent_destroy:
-        one: "Negalima ištrinti įrašo nes priklausomas %{record} egzistuoja"
-        many: "Negalima ištrinti įrašų nes priklausomi %{record} egzistuoja"
+        one: Negalima ištrinti įrašo nes priklausomas %{record} egzistuoja
+        many: Negalima ištrinti įrašų nes priklausomi %{record} egzistuoja
       taken: jau užimtas
       too_long:
         one: per ilgas (daugiausiai %{count} simbolis)
@@ -140,9 +141,9 @@ lt:
         few: per trumpas (mažiausiai %{count} simboliai)
         other: per trumpas (mažiausiai %{count} simbolių)
       wrong_length: neteisingo ilgio (turi būti %{count} simboliai)
-      other_than: "privalo būti kitoks nei %{count}"
+      other_than: privalo būti kitoks nei %{count}
     template:
-      body: ! 'Šiuose laukuose yra klaidų:'
+      body: 'Šiuose laukuose yra klaidų:'
       header:
         one: Išsaugant objektą %{model} rasta %{count} klaida
         few: Išsaugant objektą %{model} rastos %{count} klaidos
@@ -151,28 +152,28 @@ lt:
     select:
       prompt: Prašom pasirinkti
     submit:
-       create: Sukurti %{model}
-       submit: Išsaugoti %{model}
-       update: Atnaujinti %{model}
+      create: Sukurti %{model}
+      submit: Išsaugoti %{model}
+      update: Atnaujinti %{model}
   number:
     currency:
       format:
-        delimiter: ! ' '
-        format: ! '%n %u'
+        delimiter: " "
+        format: "%n %u"
         precision: 2
-        separator: ! ','
+        separator: ","
         significant: false
         strip_insignificant_zeros: false
-        unit: €
+        unit: "€"
     format:
-      delimiter: ! ' '
+      delimiter: " "
       precision: 3
-      separator: ! ','
+      separator: ","
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: Milijardas
           million: Milijonas
@@ -186,7 +187,7 @@ lt:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Baitas
@@ -205,13 +206,13 @@ lt:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ' ir '
-      two_words_connector: ! ' ir '
-      words_connector: ! ', '
+      last_word_connector: " ir "
+      two_words_connector: " ir "
+      words_connector: ", "
   time:
     am: am
     formats:
-      default: ! '%a, %d %b %Y %H:%M:%S %z'
-      long: ! '%B %d, %Y %H:%M'
-      short: ! '%d %b %H:%M'
+      default: "%a, %d %b %Y %H:%M:%S %z"
+      long: "%B %d, %Y %H:%M"
+      short: "%d %b %H:%M"
     pm: pm

--- a/rails/locale/lv.yml
+++ b/rails/locale/lv.yml
@@ -1,3 +1,4 @@
+---
 lv:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ lv:
     - Pk.
     - S.
     abbr_month_names:
-    -
+    - 
     - Janv
     - Febr
     - Marts
@@ -31,11 +32,11 @@ lv:
     - piektdiena
     - sestdiena
     formats:
-      default: ! '%d.%m.%Y.'
-      long: ! '%Y. gada %e. %B'
-      short: ! '%e. %B'
+      default: "%d.%m.%Y."
+      long: "%Y. gada %e. %B"
+      short: "%e. %B"
     month_names:
-    -
+    - 
     - Janvāris
     - Februāris
     - Marts
@@ -84,21 +85,21 @@ lv:
         one: vairāk kā %{count} gads
         other: vairāk kā %{count} gadi
       x_days:
-        zero: ! '%{count} dienas'
-        one: ! '%{count} diena'
-        other: ! '%{count} dienas'
+        zero: "%{count} dienas"
+        one: "%{count} diena"
+        other: "%{count} dienas"
       x_minutes:
-        zero: ! '%{count} minūtes'
-        one: ! '%{count} minūte'
-        other: ! '%{count} minūtes'
+        zero: "%{count} minūtes"
+        one: "%{count} minūte"
+        other: "%{count} minūtes"
       x_months:
-        zero: ! '%{count} mēneši'
-        one: ! '%{count} mēnesis'
-        other: ! '%{count} mēneši'
+        zero: "%{count} mēneši"
+        one: "%{count} mēnesis"
+        other: "%{count} mēneši"
       x_seconds:
-        zero: ! '%{count} sekundes'
-        one: ! '%{count} sekunde'
-        other: ! '%{count} sekundes'
+        zero: "%{count} sekundes"
+        one: "%{count} sekunde"
+        other: "%{count} sekundes"
     prompts:
       day: diena
       hour: stunda
@@ -107,7 +108,7 @@ lv:
       second: sekunde
       year: gads
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: ir jāpiekrīt
       blank: ir jābūt aizpildītam
@@ -125,7 +126,7 @@ lv:
       not_a_number: nav skaitlis
       not_an_integer: ir jābūt veselam skaitlim
       odd: ir jābūt nepāra skaitlim
-      record_invalid: ! 'Pārbaude neizdevās: %{errors}'
+      record_invalid: 'Pārbaude neizdevās: %{errors}'
       taken: ir jau aizņemts
       too_long:
         zero: ir par garu (maksimums ir %{count} simboli)
@@ -140,7 +141,7 @@ lv:
         one: ir nepareizs garums (jābūt %{count} simbolam)
         other: ir nepareizs garums (jābūt %{count} simboliem)
     template:
-      body: ! 'Problēmas ir šajos ievades laukos:'
+      body: 'Problēmas ir šajos ievades laukos:'
       header:
         zero: Dēļ %{count} kļūdām šis %{model} netika saglabāts
         one: Dēļ %{count} kļūdas šis %{model} netika saglabāts
@@ -155,22 +156,22 @@ lv:
   number:
     currency:
       format:
-        delimiter: .
-        format: ! '%n %u'
+        delimiter: "."
+        format: "%n %u"
         precision: 2
-        separator: ! ','
+        separator: ","
         significant: false
         strip_insignificant_zeros: false
-        unit: €
+        unit: "€"
     format:
-      delimiter: .
+      delimiter: "."
       precision: 2
-      separator: ! ','
+      separator: ","
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion:
             zero: miljardi
@@ -199,7 +200,7 @@ lv:
         significant: false
         strip_insignificant_zeros: false
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             zero: baiti
@@ -217,13 +218,13 @@ lv:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ' un '
-      two_words_connector: ! ' un '
-      words_connector: ! ', '
+      last_word_connector: " un "
+      two_words_connector: " un "
+      words_connector: ", "
   time:
     am: priekšpusdiena
     formats:
-      default: ! '%Y. gada %e. %B, %H:%M'
-      long: ! '%Y. gada %e. %B, %H:%M:%S'
-      short: ! '%d.%m.%Y., %H:%M'
+      default: "%Y. gada %e. %B, %H:%M"
+      long: "%Y. gada %e. %B, %H:%M:%S"
+      short: "%d.%m.%Y., %H:%M"
     pm: pēcpusdiena

--- a/rails/locale/mk.yml
+++ b/rails/locale/mk.yml
@@ -1,3 +1,4 @@
+---
 mk:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ mk:
     - Пет
     - Саб
     abbr_month_names:
-    -
+    - 
     - Јан
     - Фев
     - Мар
@@ -31,11 +32,11 @@ mk:
     - Петок
     - Сабота
     formats:
-      default: ! '%d/%m/%Y'
-      long: ! '%B %e, %Y'
-      short: ! '%e %b'
+      default: "%d/%m/%Y"
+      long: "%B %e, %Y"
+      short: "%e %b"
     month_names:
-    -
+    - 
     - Јануари
     - Февруари
     - Март
@@ -77,17 +78,17 @@ mk:
         one: над %{count} година
         other: над %{count} години
       x_days:
-        one: ! '%{count} ден'
-        other: ! '%{count} денови'
+        one: "%{count} ден"
+        other: "%{count} денови"
       x_minutes:
-        one: ! '%{count} минута'
-        other: ! '%{count} минути'
+        one: "%{count} минута"
+        other: "%{count} минути"
       x_months:
-        one: ! '%{count} месец'
-        other: ! '%{count} месеци'
+        one: "%{count} месец"
+        other: "%{count} месеци"
       x_seconds:
-        one: ! '%{count} секунда'
-        other: ! '%{count} секунди'
+        one: "%{count} секунда"
+        other: "%{count} секунди"
     prompts:
       day: Ден
       hour: Час
@@ -96,7 +97,7 @@ mk:
       second: Секунди
       year: Година
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: мора да биде прифатен
       blank: мора да биде зададен
@@ -111,10 +112,10 @@ mk:
       invalid: не е исправен
       less_than: мора да биде помало од %{count}
       less_than_or_equal_to: мора да биде помало или еднакво на %{count}
-      not_a_number: ! 'не е број '
+      not_a_number: 'не е број '
       not_an_integer: не е цел број
       odd: мора да биде непарно
-      record_invalid: ! 'неуспешна валидација: %{errors}'
+      record_invalid: 'неуспешна валидација: %{errors}'
       taken: е зафатено
       too_long:
         one: е предолг (не повеќе од %{count} карактер)
@@ -126,10 +127,10 @@ mk:
         one: несоодветна должина (мора да имате %{count} карактер)
         other: несоодветна должина (мора да имате %{count} карактери)
     template:
-      body: ! 'Ве молиме проверете ги следните полиња:'
+      body: 'Ве молиме проверете ги следните полиња:'
       header:
-        one: ! 'Не успеав да го зачувам %{model}: %{count} грешка.'
-        other: ! 'Не успеав да го зачувам %{model}: %{count} грешки.'
+        one: 'Не успеав да го зачувам %{model}: %{count} грешка.'
+        other: 'Не успеав да го зачувам %{model}: %{count} грешки.'
   helpers:
     select:
       prompt: Одберете
@@ -140,22 +141,22 @@ mk:
   number:
     currency:
       format:
-        delimiter: ! ','
-        format: ! '%n %u'
+        delimiter: ","
+        format: "%n %u"
         precision: 2
-        separator: .
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
         unit: MKD
     format:
-      delimiter: .
+      delimiter: "."
       precision: 3
-      separator: ! ','
+      separator: ","
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: илјади
           million: милјони
@@ -169,7 +170,7 @@ mk:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: бајт
@@ -186,13 +187,13 @@ mk:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ', и '
-      two_words_connector: ! ' и '
-      words_connector: ! ', '
+      last_word_connector: ", и "
+      two_words_connector: " и "
+      words_connector: ", "
   time:
     am: АМ
     formats:
-      default: ! '%a %b %d %H:%M:%S %Z %Y'
-      long: ! '%B %d, %Y %H:%M'
-      short: ! '%d %b %H:%M'
+      default: "%a %b %d %H:%M:%S %Z %Y"
+      long: "%B %d, %Y %H:%M"
+      short: "%d %b %H:%M"
     pm: ПМ

--- a/rails/locale/mn.yml
+++ b/rails/locale/mn.yml
@@ -1,3 +1,4 @@
+---
 mn:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ mn:
     - Ба
     - Бя
     abbr_month_names:
-    -
+    - 
     - 1 сар
     - 2 сар
     - 3 сар
@@ -31,11 +32,11 @@ mn:
     - Баасан
     - Бямба
     formats:
-      default: ! '%Y-%m-%d'
-      long: ! '%Y %B %d'
-      short: ! '%y-%m-%d'
+      default: "%Y-%m-%d"
+      long: "%Y %B %d"
+      short: "%y-%m-%d"
     month_names:
-    -
+    - 
     - 1 сар
     - 2 сар
     - 3 сар
@@ -55,39 +56,39 @@ mn:
   datetime:
     distance_in_words:
       about_x_hours:
-        one: ! '1 цаг орчим'
-        other: ! '%{count} цаг орчим'
+        one: 1 цаг орчим
+        other: "%{count} цаг орчим"
       about_x_months:
-        one: ! '1 сар орчим'
-        other: ! '%{count} сар орчим'
+        one: 1 сар орчим
+        other: "%{count} сар орчим"
       about_x_years:
-        one: ! '1 жил орчим'
-        other: ! '%{count} жил орчим'
+        one: 1 жил орчим
+        other: "%{count} жил орчим"
       almost_x_years:
         one: бараг 1 жил
         other: бараг %{count} жил
       half_a_minute: хагас минут
       less_than_x_minutes:
-        one: ! '1 минутаас бага'
-        other: ! '%{count} минутаас бага'
+        one: 1 минутаас бага
+        other: "%{count} минутаас бага"
       less_than_x_seconds:
-        one: ! '1 секундээс бага'
-        other: ! '%{count} секундээс бага'
+        one: 1 секундээс бага
+        other: "%{count} секундээс бага"
       over_x_years:
-        one: ! '1 жилээс илүү'
-        other: ! '%{count} жилээс илүү'
+        one: 1 жилээс илүү
+        other: "%{count} жилээс илүү"
       x_days:
-        one: ! '1 өдөр'
-        other: ! '%{count} өдөр'
+        one: 1 өдөр
+        other: "%{count} өдөр"
       x_minutes:
-        one: ! '1 минут'
-        other: ! '%{count} минут'
+        one: 1 минут
+        other: "%{count} минут"
       x_months:
-        one: ! '1 сар'
-        other: ! '%{count} сар'
+        one: 1 сар
+        other: "%{count} сар"
       x_seconds:
-        one: ! '1 секунд'
-        other: ! '%{count} секунд'
+        one: 1 секунд
+        other: "%{count} секунд"
     prompts:
       day: Өдөр
       hour: Цаг
@@ -96,25 +97,25 @@ mn:
       second: Секунд
       year: Жил
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: хүлээн зөвшөөрөгдсөн байх ёстой
       blank: хоосон байж болохгүй
       confirmation: адилгүй байна
       empty: байхгүй байж болохгүй
-      equal_to: ! '%{count}-тэй тэнцүү байх ёстой'
+      equal_to: "%{count}-тэй тэнцүү байх ёстой"
       even: тэгш байх ёстой
       exclusion: бол ашиглахад хориотой
-      greater_than: ! '%{count}-с их байх ёстой'
-      greater_than_or_equal_to: ! '%{count}-с их юмуу эсвэл тэнцүү байх ёстой'
+      greater_than: "%{count}-с их байх ёстой"
+      greater_than_or_equal_to: "%{count}-с их юмуу эсвэл тэнцүү байх ёстой"
       inclusion: жагсаалтанд алга байна
       invalid: буруу байна
-      less_than: ! '%{count}-с бага байх ёстой'
-      less_than_or_equal_to: ! '%{count}-с бага юмуу эсвэл тэнцүү байх ёстой'
+      less_than: "%{count}-с бага байх ёстой"
+      less_than_or_equal_to: "%{count}-с бага юмуу эсвэл тэнцүү байх ёстой"
       not_a_number: тоо биш байна
       not_an_integer: бүхэл тоо байх ёстой
       odd: сонгой байх ёстой
-      record_invalid: ! 'Шалгалт амжилтгүй: %{errors}'
+      record_invalid: 'Шалгалт амжилтгүй: %{errors}'
       taken: аль хэдийн авчихсан байна
       too_long:
         one: урт байна (хамгийн уртдаа 1 тэмдэгт)
@@ -126,36 +127,36 @@ mn:
         one: урт нь буруу байна (1 тэмдэгт байх ёстой)
         other: урт нь буруу байна (%{count} тэмдэгт байх ёстой)
     template:
-      body: ! 'Дараах талбарууд дээр алдаа гарлаа:'
+      body: 'Дараах талбарууд дээр алдаа гарлаа:'
       header:
         one: 1 алдаа гарсан тул %{model} хадгалагдахгүй байна
-        other: ! '%{count} алдаа гарсан тул %{model} хадгалагдахгүй байна'
+        other: "%{count} алдаа гарсан тул %{model} хадгалагдахгүй байна"
   helpers:
     select:
       prompt: Сонгоно уу
     submit:
-      create: ! 'Үүсгэх'
-      submit: ! 'Хадгалах'
-      update: ! 'Шинэчлэх'
+      create: Үүсгэх
+      submit: Хадгалах
+      update: Шинэчлэх
   number:
     currency:
       format:
-        delimiter: ! ' '
-        format: ! '%n %u'
+        delimiter: " "
+        format: "%n %u"
         precision: 2
-        separator: .
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
         unit: төг.
     format:
-      delimiter: ! ' '
+      delimiter: " "
       precision: 3
-      separator: .
+      separator: "."
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: Тэрбум
           million: Сая
@@ -169,7 +170,7 @@ mn:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Байт
@@ -186,13 +187,13 @@ mn:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ' болон '
-      two_words_connector: ! ' болон '
-      words_connector: ! ', '
+      last_word_connector: " болон "
+      two_words_connector: " болон "
+      words_connector: ", "
   time:
     am: өглөө
     formats:
-      default: ! '%Y-%m-%d %H:%M'
-      long: ! '%Y %B %d, %H:%M:%S'
-      short: ! '%y-%m-%d'
+      default: "%Y-%m-%d %H:%M"
+      long: "%Y %B %d, %H:%M:%S"
+      short: "%y-%m-%d"
     pm: орой

--- a/rails/locale/ms.yml
+++ b/rails/locale/ms.yml
@@ -1,5 +1,4 @@
-#Bahasa Malaysia
-
+---
 ms:
   date:
     abbr_day_names:
@@ -33,9 +32,9 @@ ms:
     - Jumaat
     - Sabtu
     formats:
-      default: ! '%d-%m-%Y'
-      long: ! '%d %B, %Y'
-      short: ! '%d %b'
+      default: "%d-%m-%Y"
+      long: "%d %B, %Y"
+      short: "%d %b"
     month_names:
     - 
     - Januari
@@ -80,16 +79,16 @@ ms:
         other: lebih %{count} tahun
       x_days:
         one: 1 hari
-        other: ! '%{count} hari'
+        other: "%{count} hari"
       x_minutes:
         one: 1 minit
-        other: ! '%{count} minit'
+        other: "%{count} minit"
       x_months:
         one: 1 bulan
-        other: ! '%{count} bulan'
+        other: "%{count} bulan"
       x_seconds:
         one: 1 saat
-        other: ! '%{count} saat'
+        other: "%{count} saat"
     prompts:
       day: Hari
       hour: Jam
@@ -98,7 +97,7 @@ ms:
       second: Saat
       year: Tahun
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: wajib diterima
       blank: tidak boleh dikosongkan
@@ -116,7 +115,7 @@ ms:
       not_a_number: bukan nombor
       not_an_integer: mestilah integer
       odd: mesti ganjil
-      record_invalid: ! 'Pengesahan gagal: %{errors}'
+      record_invalid: 'Pengesahan gagal: %{errors}'
       taken: telah digunakan
       too_long:
         one: terlalu panjang (maksima adalah 1 karakter)
@@ -128,10 +127,10 @@ ms:
         one: mempunyai panjang yang salah (sepatutnya 1 karakter sahaja)
         other: mempunyai panjang yang salah(sepatutnya %{count} karakter sahaja)
     template:
-      body: ! 'Terdapat masalah dengan medan data tersebut:'
+      body: 'Terdapat masalah dengan medan data tersebut:'
       header:
         one: 1 ralat menhalang  %{model} ini dari disimpan
-        other: ! '%{count} ralat menhalang %{model} ini dari disimpan'
+        other: "%{count} ralat menhalang %{model} ini dari disimpan"
   helpers:
     select:
       prompt: Sila pilih
@@ -142,22 +141,22 @@ ms:
   number:
     currency:
       format:
-        delimiter: ! ','
-        format: ! '%u%n'
+        delimiter: ","
+        format: "%u%n"
         precision: 2
-        separator: .
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
         unit: RM
     format:
-      delimiter: ! ','
+      delimiter: ","
       precision: 3
-      separator: .
+      separator: "."
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: Ribu Juta
           million: Juta
@@ -171,7 +170,7 @@ ms:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Bait
@@ -188,13 +187,13 @@ ms:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ', dan '
-      two_words_connector: ! ' dan '
-      words_connector: ! ', '
+      last_word_connector: ", dan "
+      two_words_connector: " dan "
+      words_connector: ", "
   time:
     am: am
     formats:
-      default: ! '%a, %d %b %Y %H:%M:%S %z'
-      long: ! '%d %B, %Y %H:%M'
-      short: ! '%d %b %H:%M'
+      default: "%a, %d %b %Y %H:%M:%S %z"
+      long: "%d %B, %Y %H:%M"
+      short: "%d %b %H:%M"
     pm: pm

--- a/rails/locale/nb.yml
+++ b/rails/locale/nb.yml
@@ -1,3 +1,4 @@
+---
 nb:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ nb:
     - fre
     - lør
     abbr_month_names:
-    -
+    - 
     - jan
     - feb
     - mar
@@ -31,11 +32,11 @@ nb:
     - fredag
     - lørdag
     formats:
-      default: ! '%d.%m.%Y'
-      long: ! '%e. %B %Y'
-      short: ! '%e. %b'
+      default: "%d.%m.%Y"
+      long: "%e. %B %Y"
+      short: "%e. %b"
     month_names:
-    -
+    - 
     - januar
     - februar
     - mars
@@ -78,16 +79,16 @@ nb:
         other: over %{count} år
       x_days:
         one: 1 dag
-        other: ! '%{count} dager'
+        other: "%{count} dager"
       x_minutes:
         one: 1 minutt
-        other: ! '%{count} minutter'
+        other: "%{count} minutter"
       x_months:
         one: 1 måned
-        other: ! '%{count} måneder'
+        other: "%{count} måneder"
       x_seconds:
         one: 1 sekund
-        other: ! '%{count} sekunder'
+        other: "%{count} sekunder"
     prompts:
       day: Dag
       hour: Time
@@ -96,7 +97,7 @@ nb:
       second: Sekund
       year: År
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: må være akseptert
       blank: kan ikke være blank
@@ -115,17 +116,17 @@ nb:
       not_a_number: er ikke et tall
       not_an_integer: er ikke et heltall
       odd: må være oddetall
-      record_invalid: ! 'Det oppstod feil: %{errors}'
+      record_invalid: 'Det oppstod feil: %{errors}'
       restrict_dependent_destroy:
-        one: "Kan ikke slette registreringen, fordi 1 %{record} avhenger av denne."
-        many: "Kan ikke slette registreringen, fordi %{record} avhenger av denne."
+        one: Kan ikke slette registreringen, fordi 1 %{record} avhenger av denne.
+        many: Kan ikke slette registreringen, fordi %{record} avhenger av denne.
       taken: er allerede i bruk
       too_long: er for lang (maksimum %{count} tegn)
       too_short: er for kort (minimum %{count} tegn)
       wrong_length: er av feil lengde (maksimum %{count} tegn)
-      other_than: "kan ikke være nøyaktig %{count}"
+      other_than: kan ikke være nøyaktig %{count}
     template:
-      body: ! 'Det oppstod problemer i følgende felt:'
+      body: 'Det oppstod problemer i følgende felt:'
       header:
         one: Kunne ikke lagre %{model} på grunn av én feil.
         other: Kunne ikke lagre %{model} på grunn av %{count} feil.
@@ -139,22 +140,22 @@ nb:
   number:
     currency:
       format:
-        delimiter: ! ' '
-        format: ! '%n %u'
+        delimiter: " "
+        format: "%n %u"
         precision: 2
-        separator: ! ','
+        separator: ","
         significant: false
         strip_insignificant_zeros: false
         unit: kr
     format:
-      delimiter: ! ' '
+      delimiter: " "
       precision: 2
-      separator: ! ','
+      separator: ","
       significant: false
       strip_insignificant_zeros: true
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion:
             one: milliard
@@ -171,12 +172,12 @@ nb:
             other: billioner
           unit: ''
       format:
-        delimiter: ! ' '
+        delimiter: " "
         precision: 1
         significant: false
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Byte
@@ -193,13 +194,13 @@ nb:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ' og '
-      two_words_connector: ! ' og '
-      words_connector: ! ', '
+      last_word_connector: " og "
+      two_words_connector: " og "
+      words_connector: ", "
   time:
     am: ''
     formats:
-      default: ! '%A, %e. %B %Y, %H:%M'
-      long: ! '%A, %e. %B %Y, %H:%M'
-      short: ! '%e. %B, %H:%M'
+      default: "%A, %e. %B %Y, %H:%M"
+      long: "%A, %e. %B %Y, %H:%M"
+      short: "%e. %B, %H:%M"
     pm: ''

--- a/rails/locale/ne.yml
+++ b/rails/locale/ne.yml
@@ -1,3 +1,4 @@
+---
 ne:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ ne:
     - शुक्र
     - शनि
     abbr_month_names:
-    -
+    - 
     - जन.
     - फेब्रु.
     - मार्च
@@ -31,11 +32,11 @@ ne:
     - शुक्रबार
     - शनिबार
     formats:
-      default: ! '%Y-%m-%d'
-      long: ! '%B %d, %Y'
-      short: ! '%b %d'
+      default: "%Y-%m-%d"
+      long: "%B %d, %Y"
+      short: "%b %d"
     month_names:
-    -
+    - 
     - जनवरी
     - फेब्रुवरी
     - मार्च
@@ -69,25 +70,25 @@ ne:
       half_a_minute: आधा मिनेट
       less_than_x_minutes:
         one: 1 मिनेटभन्दा कम्ति
-        other: ! '%{count} मिनेटभन्दा कम्ति'
+        other: "%{count} मिनेटभन्दा कम्ति"
       less_than_x_seconds:
         one: 1 सेकेण्डभन्दा कम्ति
-        other: ! '%{count} सेकेण्डभन्दा कम्ति'
+        other: "%{count} सेकेण्डभन्दा कम्ति"
       over_x_years:
         one: 1 बर्षभन्दा बेसी
-        other: ! '%{count} बर्षभन्दा बेसी'
+        other: "%{count} बर्षभन्दा बेसी"
       x_days:
         one: 1 दिन
-        other: ! '%{count} दिन'
+        other: "%{count} दिन"
       x_minutes:
         one: 1 मिनेट
-        other: ! '%{count} मिनेट'
+        other: "%{count} मिनेट"
       x_months:
         one: 1 महिना
-        other: ! '%{count} महिना'
+        other: "%{count} महिना"
       x_seconds:
         one: 1 सेकेण्ड
-        other: ! '%{count} सेकेण्ड'
+        other: "%{count} सेकेण्ड"
     prompts:
       day: दिन
       hour: घण्टा
@@ -96,25 +97,25 @@ ne:
       second: सेकेण्ड
       year: बर्ष
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: स्वीकार गरिनुपर्नेछ
       blank: खाली हुन सक्दैन
       confirmation: पुष्ठिकरणसँग मेल खाँदैन
       empty: रित्तो हुन सक्दैन
-      equal_to: ! '%{count} सँग बराबर हुनुपर्नेछ'
+      equal_to: "%{count} सँग बराबर हुनुपर्नेछ"
       even: जोर संख्या हुनुपर्नेछ
       exclusion: प्रयोगको लागी संरक्षित छ
-      greater_than: ! '%{count} भन्दा बेसी हुनुपर्नेछ'
-      greater_than_or_equal_to: ! '%{count} सँग बराबर अथवा बेसी हुनुपर्नेछ'
+      greater_than: "%{count} भन्दा बेसी हुनुपर्नेछ"
+      greater_than_or_equal_to: "%{count} सँग बराबर अथवा बेसी हुनुपर्नेछ"
       inclusion: सुचीमा सामेल गरिएको छैन
       invalid: अमान्य छ
-      less_than: ! '%{count} भन्दा कम हुनुपर्नेछ'
-      less_than_or_equal_to: ! '%{count} सँग बराबर अथवा कम हुनुपर्नेछ'
+      less_than: "%{count} भन्दा कम हुनुपर्नेछ"
+      less_than_or_equal_to: "%{count} सँग बराबर अथवा कम हुनुपर्नेछ"
       not_a_number: अंक होईन
       not_an_integer: पुर्णाकं हुनुपर्नेछ
       odd: बिजोर संख्या हुनुपर्नेछ
-      record_invalid: ! 'मान्य भएन: %{errors}'
+      record_invalid: 'मान्य भएन: %{errors}'
       taken: पहिल्यै प्रयोग गरीएको छ
       too_long:
         one: धेरै लामो छ (अधिक्तम 1 character हो)
@@ -126,36 +127,36 @@ ne:
         one: गलत लम्बाई हो (1 character हुनुपर्नेछ)
         other: गलत लम्बाई हो (%{count} characters हुनुपर्नेछ)
     template:
-      body: ! 'तलका क्षेत्रधारकहरु समस्याहरु देखियो:'
+      body: 'तलका क्षेत्रधारकहरु समस्याहरु देखियो:'
       header:
         one: 1 गल्तीले यस %{model} लाई बचत गर्नबाट रोक्यो
-        other: ! '%{count} गल्तीले यस %{model} लाई बचत गर्नबाट रोक्यो'
+        other: "%{count} गल्तीले यस %{model} लाई बचत गर्नबाट रोक्यो"
   helpers:
     select:
       prompt: कृपया छान्नुहोस्
     submit:
-      create: ! 'नयाँ %{model} बनाउ'
-      submit: ! '%{model} बचत गर'
-      update: ! '%{model} सामयिक बनाउ'
+      create: नयाँ %{model} बनाउ
+      submit: "%{model} बचत गर"
+      update: "%{model} सामयिक बनाउ"
   number:
     currency:
       format:
-        delimiter: ! ','
-        format: ! '%u%n'
+        delimiter: ","
+        format: "%u%n"
         precision: 2
-        separator: .
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
-        unit: $
+        unit: "$"
     format:
-      delimiter: ! ','
+      delimiter: ","
       precision: 3
-      separator: .
+      separator: "."
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: Billion
           million: Million
@@ -169,7 +170,7 @@ ne:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Byte
@@ -186,13 +187,13 @@ ne:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ', र '
-      two_words_connector: ! ' र '
-      words_connector: ! ', '
+      last_word_connector: ", र "
+      two_words_connector: " र "
+      words_connector: ", "
   time:
     am: बिहान
     formats:
-      default: ! '%a, %d %b %Y %H:%M:%S %z'
-      long: ! '%B %d, %Y %H:%M'
-      short: ! '%d %b %H:%M'
+      default: "%a, %d %b %Y %H:%M:%S %z"
+      long: "%B %d, %Y %H:%M"
+      short: "%d %b %H:%M"
     pm: बेलुका

--- a/rails/locale/nl.yml
+++ b/rails/locale/nl.yml
@@ -1,3 +1,4 @@
+---
 nl:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ nl:
     - vr
     - za
     abbr_month_names:
-    -
+    - 
     - jan
     - feb
     - mrt
@@ -31,11 +32,11 @@ nl:
     - vrijdag
     - zaterdag
     formats:
-      default: ! '%d-%m-%Y'
-      long: ! '%e %B %Y'
-      short: ! '%e %b'
+      default: "%d-%m-%Y"
+      long: "%e %B %Y"
+      short: "%e %b"
     month_names:
-    -
+    - 
     - januari
     - februari
     - maart
@@ -78,16 +79,16 @@ nl:
         other: meer dan %{count} jaar
       x_days:
         one: 1 dag
-        other: ! '%{count} dagen'
+        other: "%{count} dagen"
       x_minutes:
         one: 1 minuut
-        other: ! '%{count} minuten'
+        other: "%{count} minuten"
       x_months:
         one: 1 maand
-        other: ! '%{count} maanden'
+        other: "%{count} maanden"
       x_seconds:
         one: 1 seconde
-        other: ! '%{count} seconden'
+        other: "%{count} seconden"
     prompts:
       day: dag
       hour: uur
@@ -96,12 +97,12 @@ nl:
       second: seconde
       year: jaar
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: moet worden geaccepteerd
       blank: moet opgegeven zijn
       present: moet leeg zijn
-      confirmation: ! "komt niet overeen met %{attribute}"
+      confirmation: komt niet overeen met %{attribute}
       empty: moet opgegeven zijn
       equal_to: moet gelijk zijn aan %{count}
       even: moet even zijn
@@ -115,10 +116,10 @@ nl:
       not_a_number: is geen getal
       not_an_integer: moet een geheel getal zijn
       odd: moet oneven zijn
-      record_invalid: ! 'Validatie mislukt: %{errors}'
+      record_invalid: 'Validatie mislukt: %{errors}'
       restrict_dependent_destroy:
-        one: "Kan item niet verwijderen omdat %{record} afhankelijk is"
-        many: "Kan item niet verwijderen omdat afhankelijke %{record} bestaan"
+        one: Kan item niet verwijderen omdat %{record} afhankelijk is
+        many: Kan item niet verwijderen omdat afhankelijke %{record} bestaan
       taken: is al in gebruik
       too_long:
         one: is te lang (maximaal %{count} teken)
@@ -129,38 +130,38 @@ nl:
       wrong_length:
         one: heeft onjuiste lengte (moet %{count} teken lang zijn)
         other: heeft onjuiste lengte (moet %{count} tekens lang zijn)
-      other_than: "moet anders zijn dan %{count}"
+      other_than: moet anders zijn dan %{count}
     template:
-      body: ! 'Controleer de volgende velden:'
+      body: 'Controleer de volgende velden:'
       header:
-        one: ! '%{model} niet opgeslagen: 1 fout gevonden'
-        other: ! '%{model} niet opgeslagen: %{count} fouten gevonden'
+        one: "%{model} niet opgeslagen: 1 fout gevonden"
+        other: "%{model} niet opgeslagen: %{count} fouten gevonden"
   helpers:
     select:
       prompt: Selecteer
     submit:
-      create: ! '%{model} toevoegen'
-      submit: ! '%{model} opslaan'
-      update: ! '%{model} bewaren'
+      create: "%{model} toevoegen"
+      submit: "%{model} opslaan"
+      update: "%{model} bewaren"
   number:
     currency:
       format:
-        delimiter: .
-        format: ! '%u%n'
+        delimiter: "."
+        format: "%u%n"
         precision: 2
-        separator: ! ','
+        separator: ","
         significant: false
         strip_insignificant_zeros: false
-        unit: €
+        unit: "€"
     format:
-      delimiter: .
+      delimiter: "."
       precision: 2
-      separator: ! ','
+      separator: ","
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: miljard
           million: miljoen
@@ -174,7 +175,7 @@ nl:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Byte
@@ -192,13 +193,13 @@ nl:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ' en '
-      two_words_connector: ! ' en '
-      words_connector: ! ', '
+      last_word_connector: " en "
+      two_words_connector: " en "
+      words_connector: ", "
   time:
-    am: ! '''s ochtends'
+    am: "'s ochtends"
     formats:
-      default: ! '%a %d %b %Y %H:%M:%S %Z'
-      long: ! '%d %B %Y %H:%M'
-      short: ! '%d %b %H:%M'
-    pm: ! '''s middags'
+      default: "%a %d %b %Y %H:%M:%S %Z"
+      long: "%d %B %Y %H:%M"
+      short: "%d %b %H:%M"
+    pm: "'s middags"

--- a/rails/locale/nn.yml
+++ b/rails/locale/nn.yml
@@ -1,3 +1,4 @@
+---
 nn:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ nn:
     - fre
     - lau
     abbr_month_names:
-    -
+    - 
     - jan
     - feb
     - mar
@@ -31,11 +32,11 @@ nn:
     - fredag
     - laurdag
     formats:
-      default: ! '%d.%m.%Y'
-      long: ! '%e. %B %Y'
-      short: ! '%e. %b'
+      default: "%d.%m.%Y"
+      long: "%e. %B %Y"
+      short: "%e. %b"
     month_names:
-    -
+    - 
     - januar
     - februar
     - mars
@@ -76,16 +77,16 @@ nn:
         other: over %{count} år
       x_days:
         one: 1 dag
-        other: ! '%{count} dagar'
+        other: "%{count} dagar"
       x_minutes:
         one: 1 minutt
-        other: ! '%{count} minutt'
+        other: "%{count} minutt"
       x_months:
         one: 1 månad
-        other: ! '%{count} månader'
+        other: "%{count} månader"
       x_seconds:
         one: 1 sekund
-        other: ! '%{count} sekund'
+        other: "%{count} sekund"
     prompts:
       day: Dag
       hour: Time
@@ -94,7 +95,7 @@ nn:
       second: Sekund
       year: År
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: må vera akseptert
       blank: kan ikkje vera blank
@@ -113,17 +114,17 @@ nn:
       not_a_number: er ikkje eit tal
       not_an_integer: er ikkje eit heiltal
       odd: må vera oddetal
-      record_invalid: ! 'Valideringa mislukka: %{errors}'
+      record_invalid: 'Valideringa mislukka: %{errors}'
       restrict_dependent_destroy:
-        one: "Kan ikkje sletta registreringa, fordi 1 avhengig %{record} finst."
-        many: "Kan ikkje sletta registreringa, fordi avhengige %{record} finst."
+        one: Kan ikkje sletta registreringa, fordi 1 avhengig %{record} finst.
+        many: Kan ikkje sletta registreringa, fordi avhengige %{record} finst.
       taken: er allereie i bruk
       too_long: er for lang (maksimum %{count} teikn)
       too_short: er for kort (minimum %{count} teikn)
       wrong_length: har feil lengde (maksimum %{count} teikn)
-      other_than: "må vera noko anna enn %{count}"
+      other_than: må vera noko anna enn %{count}
     template:
-      body: ! 'det oppstod problem i følgjande felt:'
+      body: 'det oppstod problem i følgjande felt:'
       header: kunne ikkje lagra %{model} grunna %{count} feil.
   helpers:
     select:
@@ -135,22 +136,22 @@ nn:
   number:
     currency:
       format:
-        delimiter: ! ','
-        format: ! '%n %u'
+        delimiter: ","
+        format: "%n %u"
         precision: 2
-        separator: .
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
         unit: kr
     format:
-      delimiter: ! ','
+      delimiter: ","
       precision: 2
-      separator: .
+      separator: "."
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion:
             one: milliard
@@ -172,7 +173,7 @@ nn:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Byte
@@ -189,13 +190,13 @@ nn:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ' og '
-      two_words_connector: ! ' og '
-      words_connector: ', '
+      last_word_connector: " og "
+      two_words_connector: " og "
+      words_connector: ", "
   time:
     am: ''
     formats:
-      default: ! '%A, %e. %B %Y, %H:%M'
-      long: ! '%A, %e. %B %Y, %H:%M'
-      short: ! '%e. %B, %H:%M'
+      default: "%A, %e. %B %Y, %H:%M"
+      long: "%A, %e. %B %Y, %H:%M"
+      short: "%e. %B, %H:%M"
     pm: ''

--- a/rails/locale/or.yml
+++ b/rails/locale/or.yml
@@ -1,3 +1,4 @@
+---
 or:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ or:
     - ଶୁକ୍ର
     - ଶନି
     abbr_month_names:
-    -
+    - 
     - ଜାନୁ
     - ଫେବରୁ
     - ମାର
@@ -31,11 +32,11 @@ or:
     - ଶୁକ୍ରବାର
     - ଶନିବାର
     formats:
-      default: ! '%Y-%m-%d'
-      long: ! '%B %d, %Y'
-      short: ! '%b %d'
+      default: "%Y-%m-%d"
+      long: "%B %d, %Y"
+      short: "%b %d"
     month_names:
-    -
+    - 
     - ଜାନୁୟାରୀ
     - ଫେବୃୟାରୀ
     - ମାର୍ଚ଼
@@ -69,25 +70,25 @@ or:
       half_a_minute: ଦେଢ ମିନଟ୍
       less_than_x_minutes:
         one: 1 ମିନଟ ବାକ
-        other: ! '%{count} ମିନଟ ବାକ'
+        other: "%{count} ମିନଟ ବାକ"
       less_than_x_seconds:
         one: 1 ସେକଣ୍ଢ ବାକ
-        other: ! '%{count} ସେକଣ୍ଢ ବାକ'
+        other: "%{count} ସେକଣ୍ଢ ବାକ"
       over_x_years:
         one: 1 ବର୍ଷରୁ ଅଧିକ
-        other: ! '%{count} ବର୍ଷରୁ ଅଧିକ'
+        other: "%{count} ବର୍ଷରୁ ଅଧିକ"
       x_days:
         one: 1  ଦିନ
-        other: ! '%{count} ଦିନ'
+        other: "%{count} ଦିନ"
       x_minutes:
         one: 1 ମିନଟ
-        other: ! '%{count} ମିନଟ'
+        other: "%{count} ମିନଟ"
       x_months:
         one: 1 ମାସ
-        other: ! '%{count} ମାସ'
+        other: "%{count} ମାସ"
       x_seconds:
         one: 1 ସେକଣ୍ଢ
-        other: ! '%{count} ସେକଣ୍ଢ'
+        other: "%{count} ସେକଣ୍ଢ"
     prompts:
       day: ଦିନ
       hour: ଘଣ୍ତ
@@ -96,60 +97,60 @@ or:
       second: ସେକଣ୍ଢ
       year: ବର୍ଷ
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: ଗ୍ରହଣ କରିବାର ଅଛି
       blank: ଖାଲି ହେଇ ପାରୀବନ
       confirmation: ପ୍ରମାଣ ହେଇନି
       empty: ଖାଲି ହେଇପାରିବନି
-      equal_to: ! '%{count} କୁ ସମାନ'
+      equal_to: "%{count} କୁ ସମାନ"
       even: ଯୁଗ୍ମ ହେବାର ଅଛି
       exclusion: ସୁରଖିତ ଅଟେ
-      greater_than: ! '%{count} ରୁ ବଡ ହେବାର ଅଛି'
-      greater_than_or_equal_to: ! '%{count} ରୁ ବଡ କିମ୍ବା ସମାନ ହେବାର ଅଛି'
+      greater_than: "%{count} ରୁ ବଡ ହେବାର ଅଛି"
+      greater_than_or_equal_to: "%{count} ରୁ ବଡ କିମ୍ବା ସମାନ ହେବାର ଅଛି"
       inclusion: ସୁଚୀ ରେ ଅନ୍ତର୍ଭୁକ୍ତ ନୁହେଁ
       invalid: ଠିକ୍ ନୁହେଁ
-      less_than: ! '%{count} ରୁ ଛୋଟ'
-      less_than_or_equal_to: ! '%{count} ରୁ ଛୋଟ କିମ୍ବା ସମାନ ହେବାର ଅଛି'
+      less_than: "%{count} ରୁ ଛୋଟ"
+      less_than_or_equal_to: "%{count} ରୁ ଛୋଟ କିମ୍ବା ସମାନ ହେବାର ଅଛି"
       not_a_number: ସଂଖ୍ଯ ନୁହେଁ
       not_an_integer: ଗଣନ ସଂଖ୍ଯା ହେବାର ଅଛି
       odd: ଅଯୁଗ୍ମ ହେବାର ଅଛି
-      record_invalid: ! 'ସଠିକ୍ ନୁହ: %{errors}'
+      record_invalid: 'ସଠିକ୍ ନୁହ: %{errors}'
       taken: ଗ୍ରହଣ  କରା ଯାଇଛି
       too_long: ଦିର୍ଘତମ ଅଟେ(ଅତ୍ୟଧୀକ %{count} ଅଖ୍ଯର)
       too_short: ଅତି ସଂଖିପ୍ତ ଅଟେ (ଅତ୍ଯଳ୍ପ %{count} ଅଖ୍ଯର ଅଟେ)
       wrong_length: ଲମ୍ବା ଭୁଲ ଅଟେ (%{count} ଅଖ୍ଯର ହେବା ଉଚିତ୍)
     template:
-      body: ! 'ନିମ୍ନ ଜାଗା ରେ ଅସୁବିଧା ହେଇଛି:'
+      body: 'ନିମ୍ନ ଜାଗା ରେ ଅସୁବିଧା ହେଇଛି:'
       header:
-        one: ! '1 ଭୁଲ ଯଗୁଁ ନିମ୍ନ %{model} ସୁରଖିତ ହେଇପାରି ନଥିଲା'
-        other: ! '%{count} ଭୁଲ ଯଗୁଁ ଏହି %{model} ସୁରଖିତ ହେଇପାରି ନଥିଲା'
+        one: 1 ଭୁଲ ଯଗୁଁ ନିମ୍ନ %{model} ସୁରଖିତ ହେଇପାରି ନଥିଲା
+        other: "%{count} ଭୁଲ ଯଗୁଁ ଏହି %{model} ସୁରଖିତ ହେଇପାରି ନଥିଲା"
   helpers:
     select:
       prompt: ପସନ୍ଦ କର
     submit:
-      create: ! '%{model} ବନାଅ'
-      submit: ! '%{model} ସୁରଖିତ କର'
-      update: ! '%{model} ଅାଧୂନିକରଣ କର'
+      create: "%{model} ବନାଅ"
+      submit: "%{model} ସୁରଖିତ କର"
+      update: "%{model} ଅାଧୂନିକରଣ କର"
   number:
     currency:
       format:
-        delimiter: ! ','
-        format: ! '%u%n'
+        delimiter: ","
+        format: "%u%n"
         precision: 2
-        separator: .
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
-        unit: ₹
+        unit: "₹"
     format:
-      delimiter: ! ','
+      delimiter: ","
       precision: 3
-      separator: .
+      separator: "."
       significant: ମିଥ୍ଯା
       strip_insignificant_zeros: ମିଥ୍ଯା
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: ବିଲିୟନ୍
           million: ମିଲିୟନ୍
@@ -163,7 +164,7 @@ or:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Byte
@@ -180,13 +181,13 @@ or:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ', ଏବଂ '
-      two_words_connector: ! ' ଏବଂ '
-      words_connector: ! ', '
+      last_word_connector: ", ଏବଂ "
+      two_words_connector: " ଏବଂ "
+      words_connector: ", "
   time:
     am: ପୁର୍ଵାହ୍ନ
     formats:
-      default: ! '%a, %d %b %Y %H:%M:%S %z'
-      long: ! '%B %d, %Y %H:%M'
-      short: ! '%d %b %H:%M'
+      default: "%a, %d %b %Y %H:%M:%S %z"
+      long: "%B %d, %Y %H:%M"
+      short: "%d %b %H:%M"
     pm: ଅପରାହ୍ନ

--- a/rails/locale/pl.yml
+++ b/rails/locale/pl.yml
@@ -1,3 +1,4 @@
+---
 pl:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ pl:
     - pią
     - sob
     abbr_month_names:
-    -
+    - 
     - sty
     - lut
     - mar
@@ -31,11 +32,11 @@ pl:
     - piątek
     - sobota
     formats:
-      default: ! '%d-%m-%Y'
-      long: ! '%B %d, %Y'
-      short: ! '%d %b'
+      default: "%d-%m-%Y"
+      long: "%B %d, %Y"
+      short: "%d %b"
     month_names:
-    -
+    - 
     - styczeń
     - luty
     - marzec
@@ -91,25 +92,25 @@ pl:
         one: ponad rok
         other: ponad %{count} lat
       x_days:
-        few: ! '%{count} dni'
-        many: ! '%{count} dni'
+        few: "%{count} dni"
+        many: "%{count} dni"
         one: 1 dzień
-        other: ! '%{count} dni'
+        other: "%{count} dni"
       x_minutes:
-        few: ! '%{count} minuty'
-        many: ! '%{count} minut'
+        few: "%{count} minuty"
+        many: "%{count} minut"
         one: 1 minuta
-        other: ! '%{count} minut'
+        other: "%{count} minut"
       x_months:
-        few: ! '%{count} miesiące'
-        many: ! '%{count} miesięcy'
+        few: "%{count} miesiące"
+        many: "%{count} miesięcy"
         one: 1 miesiąc
-        other: ! '%{count} miesięcy'
+        other: "%{count} miesięcy"
       x_seconds:
-        few: ! '%{count} sekundy'
-        many: ! '%{count} sekund'
+        few: "%{count} sekundy"
+        many: "%{count} sekund"
         one: 1 sekunda
-        other: ! '%{count} sekund'
+        other: "%{count} sekund"
     prompts:
       day: Dzień
       hour: Godzina
@@ -118,11 +119,11 @@ pl:
       second: Sekundy
       year: Rok
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: musi zostać zaakceptowane
       blank: nie może być puste
-      confirmation: ! 'nie zgadza się z polem %{attribute}'
+      confirmation: nie zgadza się z polem %{attribute}
       empty: nie może być puste
       equal_to: musi być równe %{count}
       even: musi być parzyste
@@ -137,15 +138,15 @@ pl:
       not_an_integer: musi być liczbą całkowitą
       odd: musi być nieparzyste
       present: musi być puste
-      record_invalid: ! 'Negatywne sprawdzenie poprawności: %{errors}'
+      record_invalid: 'Negatywne sprawdzenie poprawności: %{errors}'
       restrict_dependent_destroy:
-        many: 'Nie może zostać usunięte, gdyż istnieją zależne od niego %{record}'
-        one: 'Nie może zostać usunięte, gdyż istnieje zależny od niego %{record}'
+        many: Nie może zostać usunięte, gdyż istnieją zależne od niego %{record}
+        one: Nie może zostać usunięte, gdyż istnieje zależny od niego %{record}
       taken: zostało już zajęte
       too_long:
         few: jest za długie (maksymalnie %{count} znaki)
         many: jest za długie (maksymalnie %{count} znaków)
-        one: jest za długie (maksymalnie jeden znak) 
+        one: jest za długie (maksymalnie jeden znak)
         other: jest za długie (maksymalnie %{count} znaków)
       too_short:
         few: jest za krótkie (przynajmniej %{count} znaki)
@@ -157,14 +158,14 @@ pl:
         many: ma nieprawidłową długość (powinna wynosić %{count} znaków)
         one: ma nieprawidłową długość (powinna wynosić jeden znak)
         other: ma nieprawidłową długość (powinna wynosić %{count} znaków)
-      other_than: 'musi być inna niż %{count}'
+      other_than: musi być inna niż %{count}
     template:
-      body: ! 'Błędy dotyczą następujących pól:'
+      body: 'Błędy dotyczą następujących pól:'
       header:
-        few: ! '%{model} nie został zachowany z powodu %{count} błędów'
-        many: ! '%{model} nie został zachowany z powodu %{count} błędów'
-        one: ! '%{model} nie został zachowany z powodu jednego błędu'
-        other: ! '%{model} nie został zachowany z powodu %{count} błędów'
+        few: "%{model} nie został zachowany z powodu %{count} błędów"
+        many: "%{model} nie został zachowany z powodu %{count} błędów"
+        one: "%{model} nie został zachowany z powodu jednego błędu"
+        other: "%{model} nie został zachowany z powodu %{count} błędów"
   helpers:
     select:
       prompt: Proszę wybrać
@@ -175,22 +176,22 @@ pl:
   number:
     currency:
       format:
-        delimiter: ! ' '
-        format: ! '%n %u'
+        delimiter: " "
+        format: "%n %u"
         precision: 2
-        separator: ! ','
+        separator: ","
         significant: false
         strip_insignificant_zeros: true
         unit: zł
     format:
-      delimiter: ! ' '
+      delimiter: " "
       precision: 3
-      separator: ! ','
+      separator: ","
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: Miliard
           million: Milion
@@ -204,7 +205,7 @@ pl:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             few: bajty
@@ -218,19 +219,19 @@ pl:
     percentage:
       format:
         delimiter: ''
-        format: '%n%'
+        format: "%n%"
     precision:
       format:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ' oraz '
-      two_words_connector: ! ' i '
-      words_connector: ! ', '
+      last_word_connector: " oraz "
+      two_words_connector: " i "
+      words_connector: ", "
   time:
     am: przed południem
     formats:
-      default: ! '%a, %d %b %Y %H:%M:%S %z'
-      long: ! '%B %d, %Y %H:%M'
-      short: ! '%d %b %H:%M'
+      default: "%a, %d %b %Y %H:%M:%S %z"
+      long: "%B %d, %Y %H:%M"
+      short: "%d %b %H:%M"
     pm: po południu

--- a/rails/locale/pt-BR.yml
+++ b/rails/locale/pt-BR.yml
@@ -1,3 +1,4 @@
+---
 pt-BR:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ pt-BR:
     - Sex
     - Sáb
     abbr_month_names:
-    -
+    - 
     - Jan
     - Fev
     - Mar
@@ -31,11 +32,11 @@ pt-BR:
     - Sexta
     - Sábado
     formats:
-      default: ! '%d/%m/%Y'
-      long: ! '%d de %B de %Y'
-      short: ! '%d de %B'
+      default: "%d/%m/%Y"
+      long: "%d de %B de %Y"
+      short: "%d de %B"
     month_names:
-    -
+    - 
     - Janeiro
     - Fevereiro
     - Março
@@ -78,16 +79,16 @@ pt-BR:
         other: mais de %{count} anos
       x_days:
         one: 1 dia
-        other: ! '%{count} dias'
+        other: "%{count} dias"
       x_minutes:
         one: 1 minuto
-        other: ! '%{count} minutos'
+        other: "%{count} minutos"
       x_months:
         one: 1 mês
-        other: ! '%{count} meses'
+        other: "%{count} meses"
       x_seconds:
         one: 1 segundo
-        other: ! '%{count} segundos'
+        other: "%{count} segundos"
     prompts:
       day: Dia
       hour: Hora
@@ -96,7 +97,7 @@ pt-BR:
       second: Segundo
       year: Ano
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: deve ser aceito
       blank: não pode ficar em branco
@@ -115,20 +116,20 @@ pt-BR:
       not_a_number: não é um número
       not_an_integer: não é um número inteiro
       odd: deve ser ímpar
-      record_invalid: ! 'A validação falhou: %{errors}'
+      record_invalid: 'A validação falhou: %{errors}'
       restrict_dependent_destroy:
-        one: "Não é possível excluir o registro pois existe um %{record} dependente"
-        many: "Não é possível excluir o registro pois existem %{record} dependentes"
+        one: Não é possível excluir o registro pois existe um %{record} dependente
+        many: Não é possível excluir o registro pois existem %{record} dependentes
       taken: já está em uso
-      too_long: ! 'é muito longo (máximo: %{count} caracteres)'
-      too_short: ! 'é muito curto (mínimo: %{count} caracteres)'
+      too_long: 'é muito longo (máximo: %{count} caracteres)'
+      too_short: 'é muito curto (mínimo: %{count} caracteres)'
       wrong_length: não possui o tamanho esperado (%{count} caracteres)
-      other_than: "deve ser diferente de %{count}"
+      other_than: deve ser diferente de %{count}
     template:
-      body: ! 'Por favor, verifique o(s) seguinte(s) campo(s):'
+      body: 'Por favor, verifique o(s) seguinte(s) campo(s):'
       header:
-        one: ! 'Não foi possível gravar %{model}: 1 erro'
-        other: ! 'Não foi possível gravar %{model}: %{count} erros.'
+        one: 'Não foi possível gravar %{model}: 1 erro'
+        other: 'Não foi possível gravar %{model}: %{count} erros.'
   helpers:
     select:
       prompt: Por favor selecione
@@ -139,22 +140,22 @@ pt-BR:
   number:
     currency:
       format:
-        delimiter: .
-        format: ! '%u %n'
+        delimiter: "."
+        format: "%u %n"
         precision: 2
-        separator: ! ','
+        separator: ","
         significant: false
         strip_insignificant_zeros: false
         unit: R$
     format:
-      delimiter: .
+      delimiter: "."
       precision: 3
-      separator: ! ','
+      separator: ","
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion:
             one: bilhão
@@ -171,12 +172,12 @@ pt-BR:
             other: trilhões
           unit: ''
       format:
-        delimiter: .
+        delimiter: "."
         precision: 2
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Byte
@@ -187,20 +188,20 @@ pt-BR:
           tb: TB
     percentage:
       format:
-        delimiter: .
+        delimiter: "."
         format: "%n%"
     precision:
       format:
-        delimiter: .
+        delimiter: "."
   support:
     array:
-      last_word_connector: ! ' e '
-      two_words_connector: ! ' e '
-      words_connector: ! ', '
+      last_word_connector: " e "
+      two_words_connector: " e "
+      words_connector: ", "
   time:
     am: ''
     formats:
-      default: ! '%a, %d de %B de %Y, %H:%M:%S %z'
-      long: ! '%d de %B de %Y, %H:%M'
-      short: ! '%d de %B, %H:%M'
+      default: "%a, %d de %B de %Y, %H:%M:%S %z"
+      long: "%d de %B de %Y, %H:%M"
+      short: "%d de %B, %H:%M"
     pm: ''

--- a/rails/locale/pt.yml
+++ b/rails/locale/pt.yml
@@ -1,3 +1,4 @@
+---
 pt:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ pt:
     - Sex
     - Sáb
     abbr_month_names:
-    -
+    - 
     - Jan
     - Fev
     - Mar
@@ -31,11 +32,11 @@ pt:
     - Sexta
     - Sábado
     formats:
-      default: ! '%d/%m/%Y'
-      long: ! '%d de %B de %Y'
-      short: ! '%d de %B'
+      default: "%d/%m/%Y"
+      long: "%d de %B de %Y"
+      short: "%d de %B"
     month_names:
-    -
+    - 
     - Janeiro
     - Fevereiro
     - Março
@@ -78,16 +79,16 @@ pt:
         other: mais de %{count} anos
       x_days:
         one: 1 dia
-        other: ! '%{count} dias'
+        other: "%{count} dias"
       x_minutes:
         one: 1 minuto
-        other: ! '%{count} minutos'
+        other: "%{count} minutos"
       x_months:
         one: 1 mês
-        other: ! '%{count} meses'
+        other: "%{count} meses"
       x_seconds:
         one: 1 segundo
-        other: ! '%{count} segundos'
+        other: "%{count} segundos"
     prompts:
       day: Dia
       hour: Hora
@@ -96,7 +97,7 @@ pt:
       second: Segundo
       year: Ano
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: tem de ser aceite
       blank: não pode estar em branco
@@ -114,16 +115,16 @@ pt:
       not_a_number: não é um número
       not_an_integer: tem de ser um inteiro
       odd: tem de ser ímpar
-      record_invalid: ! 'A validação falhou: %{errors}'
+      record_invalid: 'A validação falhou: %{errors}'
       taken: não está disponível
       too_long: é demasiado grande (o máximo é de %{count} caracteres)
       too_short: é demasiado pequeno (o mínimo é de %{count} caracteres)
       wrong_length: comprimento errado (deve ter %{count} caracteres)
     template:
-      body: ! 'Por favor, verifique os seguintes campos:'
+      body: 'Por favor, verifique os seguintes campos:'
       header:
-        one: ! 'Não foi possível guardar %{model}: 1 erro'
-        other: ! 'Não foi possível guardar %{model}: %{count} erros'
+        one: 'Não foi possível guardar %{model}: 1 erro'
+        other: 'Não foi possível guardar %{model}: %{count} erros'
   helpers:
     select:
       prompt: Por favor seleccione
@@ -134,22 +135,22 @@ pt:
   number:
     currency:
       format:
-        delimiter: .
-        format: ! '%u%n'
+        delimiter: "."
+        format: "%u%n"
         precision: 2
-        separator: ! ','
+        separator: ","
         significant: false
         strip_insignificant_zeros: false
-        unit: €
+        unit: "€"
     format:
-      delimiter: .
+      delimiter: "."
       precision: 3
-      separator: ! ','
+      separator: ","
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion:
             one: mil milhões
@@ -171,7 +172,7 @@ pt:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Byte
@@ -188,13 +189,13 @@ pt:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ', e'
-      two_words_connector: ! ' e '
-      words_connector: ! ', '
+      last_word_connector: ", e"
+      two_words_connector: " e "
+      words_connector: ", "
   time:
     am: am
     formats:
-      default: ! '%A, %d de %B de %Y, %H:%Mh'
-      long: ! '%A, %d de %B de %Y, %H:%Mh'
-      short: ! '%d/%m, %H:%M hs'
+      default: "%A, %d de %B de %Y, %H:%Mh"
+      long: "%A, %d de %B de %Y, %H:%Mh"
+      short: "%d/%m, %H:%M hs"
     pm: pm

--- a/rails/locale/rm.yml
+++ b/rails/locale/rm.yml
@@ -1,3 +1,4 @@
+---
 rm:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ rm:
     - ve
     - so
     abbr_month_names:
-    -
+    - 
     - schan
     - favr
     - mars
@@ -31,11 +32,11 @@ rm:
     - venderdi
     - sonda
     formats:
-      default: ! '%d.%m.%Y'
-      long: ! '%e. %B %Y'
-      short: ! '%e. %b'
+      default: "%d.%m.%Y"
+      long: "%e. %B %Y"
+      short: "%e. %b"
     month_names:
-    -
+    - 
     - schaner
     - favrer
     - mars
@@ -98,33 +99,33 @@ rm:
         many: dapli che %{count} onns
         other: dapli che %{count} onns
       x_days:
-        zero: ! '%{count} dis'
+        zero: "%{count} dis"
         one: in di
-        two: ! '%{count} dis'
-        few: ! '%{count} dis'
-        many: ! '%{count} dis'
-        other: ! '%{count} dis'
+        two: "%{count} dis"
+        few: "%{count} dis"
+        many: "%{count} dis"
+        other: "%{count} dis"
       x_minutes:
-        zero: ! '%{count} minutas'
+        zero: "%{count} minutas"
         one: 1 minuta
-        two: ! '%{count} minutas'
-        few: ! '%{count} minutas'
-        many: ! '%{count} minutas'
-        other: ! '%{count} minutas'
+        two: "%{count} minutas"
+        few: "%{count} minutas"
+        many: "%{count} minutas"
+        other: "%{count} minutas"
       x_months:
-        zero: ! '%{count} mais'
+        zero: "%{count} mais"
         one: in mais
-        two: ! '%{count} mais'
-        few: ! '%{count} mais'
-        many: ! '%{count} mais'
-        other: ! '%{count} mais'
+        two: "%{count} mais"
+        few: "%{count} mais"
+        many: "%{count} mais"
+        other: "%{count} mais"
       x_seconds:
-        zero: ! '%{count} secundas'
+        zero: "%{count} secundas"
         one: ina secunda
-        two: ! '%{count} secundas'
-        few: ! '%{count} secundas'
-        many: ! '%{count} secundas'
-        other: ! '%{count} secundas'
+        two: "%{count} secundas"
+        few: "%{count} secundas"
+        many: "%{count} secundas"
+        other: "%{count} secundas"
     prompts:
       day: dis
       hour: uras
@@ -133,7 +134,7 @@ rm:
       second: secundas
       year: onns
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: sto vegnir acceptà
       blank: sto vegnir emplenì ora
@@ -155,33 +156,33 @@ rm:
       too_short: è memia curt (betg pli pauc che %{count} caracters)
       wrong_length: ha la fallida lunghezza (sto avair %{count} caracters)
     template:
-      body: ! 'Faschai uschè bain e controllai ils suandants champs:'
+      body: 'Faschai uschè bain e controllai ils suandants champs:'
       header:
-        zero: ! 'Betg pussaivel da memorisar quest %{model}: %{count} errurs.'
-        one: ! 'Betg pussaivel da memorisar quest %{model}: 1 errur.'
-        two: ! 'Betg pussaivel da memorisar quest %{model}: %{count} errurs.'
-        few: ! 'Betg pussaivel da memorisar quest %{model}: %{count} errurs.'
-        many: ! 'Betg pussaivel da memorisar quest %{model}: %{count} errurs.'
-        other: ! 'Betg pussaivel da memorisar quest %{model}: %{count} errurs.'
+        zero: 'Betg pussaivel da memorisar quest %{model}: %{count} errurs.'
+        one: 'Betg pussaivel da memorisar quest %{model}: 1 errur.'
+        two: 'Betg pussaivel da memorisar quest %{model}: %{count} errurs.'
+        few: 'Betg pussaivel da memorisar quest %{model}: %{count} errurs.'
+        many: 'Betg pussaivel da memorisar quest %{model}: %{count} errurs.'
+        other: 'Betg pussaivel da memorisar quest %{model}: %{count} errurs.'
   number:
     currency:
       format:
-        delimiter: ! ''''
-        format: ! '%n %u'
+        delimiter: "'"
+        format: "%n %u"
         precision: 2
-        separator: .
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
         unit: CHF
     format:
-      delimiter: ! ''''
+      delimiter: "'"
       precision: 2
-      separator: .
+      separator: "."
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           unit: ''
       format:
@@ -190,7 +191,7 @@ rm:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             zero: bytes
@@ -211,13 +212,13 @@ rm:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ' e '
-      two_words_connector: ! ' e '
-      words_connector: ! ', '
+      last_word_connector: " e "
+      two_words_connector: " e "
+      words_connector: ", "
   time:
     am: avantmezdi
     formats:
-      default: ! '%A, %d. %B %Y, %H:%M Uhr'
-      long: ! '%A, %d. %B %Y, %H:%M Uhr'
-      short: ! '%d. %B, %H:%M Uhr'
+      default: "%A, %d. %B %Y, %H:%M Uhr"
+      long: "%A, %d. %B %Y, %H:%M Uhr"
+      short: "%d. %B, %H:%M Uhr"
     pm: suentermezdi

--- a/rails/locale/ro.yml
+++ b/rails/locale/ro.yml
@@ -1,3 +1,4 @@
+---
 ro:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ ro:
     - Vin
     - Sâm
     abbr_month_names:
-    -
+    - 
     - Ian
     - Feb
     - Mar
@@ -31,11 +32,11 @@ ro:
     - Vineri
     - Sâmbată
     formats:
-      default: ! '%d-%m-%Y'
-      long: ! '%d %B %Y'
-      short: ! '%d %b'
+      default: "%d-%m-%Y"
+      long: "%d %B %Y"
+      short: "%d %b"
     month_names:
-    -
+    - 
     - Ianuarie
     - Februarie
     - Martie
@@ -85,20 +86,20 @@ ro:
         other: mai mult de %{count} ani
       x_days:
         one: 1 zi
-        few: ! '%{count} zile'
-        other: ! '%{count} zile'
+        few: "%{count} zile"
+        other: "%{count} zile"
       x_minutes:
         one: 1 minut
-        few: ! '%{count} minute'
-        other: ! '%{count} minute'
+        few: "%{count} minute"
+        other: "%{count} minute"
       x_months:
         one: 1 lună
-        few: ! '%{count} luni'
-        other: ! '%{count} luni'
+        few: "%{count} luni"
+        other: "%{count} luni"
       x_seconds:
         one: 1 secundă
-        few: ! '%{count} secunde'
-        other: ! '%{count} secunde'
+        few: "%{count} secunde"
+        other: "%{count} secunde"
     prompts:
       day: Ziua
       hour: Ora
@@ -107,7 +108,7 @@ ro:
       second: Secunda
       year: Anul
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: trebuie dat acceptul
       blank: nu poate fi gol
@@ -131,11 +132,11 @@ ro:
       too_short: este prea scurt (minimum de caractere este %{count})
       wrong_length: nu are lungimea corectă (trebuie să aiba %{count} caractere)
     template:
-      body: ! 'Încearcă să corectezi urmatoarele câmpuri:'
+      body: 'Încearcă să corectezi urmatoarele câmpuri:'
       header:
-        one: ! 'Nu am putut salva acest %{model}: o eroare'
-        few: ! 'Nu am putut salva acest %{model}: %{count} erori.'
-        other: ! 'Nu am putut salva acest %{model}: %{count} erori.'
+        one: 'Nu am putut salva acest %{model}: o eroare'
+        few: 'Nu am putut salva acest %{model}: %{count} erori.'
+        other: 'Nu am putut salva acest %{model}: %{count} erori.'
   helpers:
     select:
       prompt: Alegeţi
@@ -146,22 +147,22 @@ ro:
   number:
     currency:
       format:
-        delimiter: .
-        format: ! '%n %u'
+        delimiter: "."
+        format: "%n %u"
         precision: 2
-        separator: ','
+        separator: ","
         significant: false
         strip_insignificant_zeros: false
         unit: RON
     format:
-      delimiter: .
+      delimiter: "."
       precision: 3
-      separator: ','
+      separator: ","
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: Miliard
           million: Milion
@@ -170,12 +171,12 @@ ro:
           trillion: Trilion
           unit: ''
       format:
-        delimiter: ! ','
+        delimiter: ","
         precision: 3
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Byte
@@ -187,19 +188,19 @@ ro:
           tb: TB
     percentage:
       format:
-        delimiter: ! ','
+        delimiter: ","
     precision:
       format:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ' şi '
-      two_words_connector: ! ' şi '
-      words_connector: ! ', '
+      last_word_connector: " şi "
+      two_words_connector: " şi "
+      words_connector: ", "
   time:
     am: ''
     formats:
-      default: ! '%a %d %b %Y, %H:%M:%S %z'
-      long: ! '%d %B %Y %H:%M'
-      short: ! '%d %b %H:%M'
+      default: "%a %d %b %Y, %H:%M:%S %z"
+      long: "%d %B %Y %H:%M"
+      short: "%d %b %H:%M"
     pm: ''

--- a/rails/locale/ru.yml
+++ b/rails/locale/ru.yml
@@ -1,3 +1,4 @@
+---
 ru:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ ru:
     - Пт
     - Сб
     abbr_month_names:
-    -
+    - 
     - янв.
     - февр.
     - марта
@@ -31,11 +32,11 @@ ru:
     - пятница
     - суббота
     formats:
-      default: ! '%d.%m.%Y'
-      long: ! '%-d %B %Y'
-      short: ! '%-d %b'
+      default: "%d.%m.%Y"
+      long: "%-d %B %Y"
+      short: "%-d %b"
     month_names:
-    -
+    - 
     - января
     - февраля
     - марта
@@ -91,25 +92,25 @@ ru:
         one: больше %{count} года
         other: больше %{count} лет
       x_days:
-        few: ! '%{count} дня'
-        many: ! '%{count} дней'
-        one: ! '%{count} день'
-        other: ! '%{count} дня'
+        few: "%{count} дня"
+        many: "%{count} дней"
+        one: "%{count} день"
+        other: "%{count} дня"
       x_minutes:
-        few: ! '%{count} минуты'
-        many: ! '%{count} минут'
-        one: ! '%{count} минуту'
-        other: ! '%{count} минуты'
+        few: "%{count} минуты"
+        many: "%{count} минут"
+        one: "%{count} минуту"
+        other: "%{count} минуты"
       x_months:
-        few: ! '%{count} месяца'
-        many: ! '%{count} месяцев'
-        one: ! '%{count} месяц'
-        other: ! '%{count} месяца'
+        few: "%{count} месяца"
+        many: "%{count} месяцев"
+        one: "%{count} месяц"
+        other: "%{count} месяца"
       x_seconds:
-        few: ! '%{count} секунды'
-        many: ! '%{count} секунд'
-        one: ! '%{count} секундy'
-        other: ! '%{count} секунды'
+        few: "%{count} секунды"
+        many: "%{count} секунд"
+        one: "%{count} секундy"
+        other: "%{count} секунды"
     prompts:
       day: День
       hour: Часов
@@ -118,12 +119,12 @@ ru:
       second: Секунд
       year: Год
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: нужно подтвердить
       blank: не может быть пустым
       present: нужно оставить пустым
-      confirmation: 'не совпадает со значением поля %{attribute}'
+      confirmation: не совпадает со значением поля %{attribute}
       empty: не может быть пустым
       equal_to: может иметь лишь значение, равное %{count}
       even: может иметь лишь нечетное значение
@@ -137,10 +138,10 @@ ru:
       not_a_number: не является числом
       not_an_integer: не является целым числом
       odd: может иметь лишь четное значение
-      record_invalid: ! 'Возникли ошибки: %{errors}'
+      record_invalid: 'Возникли ошибки: %{errors}'
       restrict_dependent_destroy:
-        one: "Невозможно удалить запись, так как существует зависимость: %{record}"
-        many: "Невозможно удалить запись, так как существуют зависимости: %{record}"
+        one: 'Невозможно удалить запись, так как существует зависимость: %{record}'
+        many: 'Невозможно удалить запись, так как существуют зависимости: %{record}'
       taken: уже существует
       too_long:
         few: слишком большой длины (не может быть больше чем %{count} символа)
@@ -157,17 +158,17 @@ ru:
         many: неверной длины (может быть длиной ровно %{count} символов)
         one: неверной длины (может быть длиной ровно %{count} символ)
         other: неверной длины (может быть длиной ровно %{count} символа)
-      other_than: "должно отличаться от %{count}"
+      other_than: должно отличаться от %{count}
     template:
-      body: ! 'Проблемы возникли со следующими полями:'
+      body: 'Проблемы возникли со следующими полями:'
       header:
-        few: ! '%{model}: сохранение не удалось из-за %{count} ошибок'
-        many: ! '%{model}: сохранение не удалось из-за %{count} ошибок'
-        one: ! '%{model}: сохранение не удалось из-за %{count} ошибки'
-        other: ! '%{model}: сохранение не удалось из-за %{count} ошибки'
+        few: "%{model}: сохранение не удалось из-за %{count} ошибок"
+        many: "%{model}: сохранение не удалось из-за %{count} ошибок"
+        one: "%{model}: сохранение не удалось из-за %{count} ошибки"
+        other: "%{model}: сохранение не удалось из-за %{count} ошибки"
   helpers:
     select:
-      prompt: ! 'Выберите: '
+      prompt: 'Выберите: '
     submit:
       create: Создать %{model}
       submit: Сохранить %{model}
@@ -175,22 +176,22 @@ ru:
   number:
     currency:
       format:
-        delimiter: ! ' '
-        format: ! '%n %u'
+        delimiter: " "
+        format: "%n %u"
         precision: 2
-        separator: ','
+        separator: ","
         significant: false
         strip_insignificant_zeros: false
         unit: руб.
     format:
-      delimiter: ! ' '
+      delimiter: " "
       precision: 3
-      separator: ','
+      separator: ","
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion:
             few: миллиардов
@@ -224,7 +225,7 @@ ru:
         significant: false
         strip_insignificant_zeros: false
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             few: байта
@@ -244,13 +245,13 @@ ru:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ' и '
-      two_words_connector: ! ' и '
-      words_connector: ! ', '
+      last_word_connector: " и "
+      two_words_connector: " и "
+      words_connector: ", "
   time:
     am: утра
     formats:
-      default: ! '%a, %d %b %Y, %H:%M:%S %z'
-      long: ! '%d %B %Y, %H:%M'
-      short: ! '%d %b, %H:%M'
+      default: "%a, %d %b %Y, %H:%M:%S %z"
+      long: "%d %B %Y, %H:%M"
+      short: "%d %b, %H:%M"
     pm: вечера

--- a/rails/locale/sk.yml
+++ b/rails/locale/sk.yml
@@ -1,4 +1,4 @@
-# maintainer: Ivan Stana <stiipa@centrum.sk>
+---
 sk:
   date:
     abbr_day_names:
@@ -10,7 +10,7 @@ sk:
     - Pi
     - So
     abbr_month_names:
-    -
+    - 
     - Jan
     - Feb
     - Mar
@@ -32,11 +32,11 @@ sk:
     - Piatok
     - Sobota
     formats:
-      default: ! '%d.%m.%Y'
-      long: ! '%d. %B %Y'
-      short: ! '%d %b'
+      default: "%d.%m.%Y"
+      long: "%d. %B %Y"
+      short: "%d %b"
     month_names:
-    -
+    - 
     - Január
     - Február
     - Marec
@@ -86,20 +86,20 @@ sk:
         other: viac ako %{count} rokmi
       x_days:
         one: dňom
-        few: ! '%{count} dňami'
-        other: ! '%{count} dňami'
+        few: "%{count} dňami"
+        other: "%{count} dňami"
       x_minutes:
         one: minútou
-        few: ! '%{count} minútami'
-        other: ! '%{count} minútami'
+        few: "%{count} minútami"
+        other: "%{count} minútami"
       x_months:
         one: mesiacom
-        few: ! '%{count} mesiacmi'
-        other: ! '%{count} mesiacmi'
+        few: "%{count} mesiacmi"
+        other: "%{count} mesiacmi"
       x_seconds:
         one: sekundou
-        few: ! '%{count} sekundami'
-        other: ! '%{count} sekundami'
+        few: "%{count} sekundami"
+        other: "%{count} sekundami"
     prompts:
       day: Deň
       hour: Hodina
@@ -108,7 +108,7 @@ sk:
       second: Sekunda
       year: Rok
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: musí byť potvrdené
       blank: je povinná položka
@@ -126,17 +126,19 @@ sk:
       not_a_number: nie je číslo
       not_an_integer: musí byť celé číslo
       odd: musí byť nepárne číslo
-      record_invalid: ! 'Validácia neúspešná: %{errors}'
+      record_invalid: 'Validácia neúspešná: %{errors}'
       taken: ste už použili
       too_long: je príliš dlhá/ý (max. %{count} znakov)
       too_short: je príliš krátky/a (min. %{count} znakov)
       wrong_length: nemá správnu dĺžku (očakáva sa %{count} znakov)
     template:
-      body: ! 'Nasledujúce polia obsahujú chybne vyplnené údaje:'
+      body: 'Nasledujúce polia obsahujú chybne vyplnené údaje:'
       header:
         one: Pri ukladaní objektu %{model} došlo k chybám a nebolo ho možné uložiť
-        few: Pri ukladaní objektu %{model} došlo k %{count} chybám a nebolo ho možné uložiť
-        other: Pri ukladaní objektu %{model} došlo k %{count} chybám a nebolo ho možné uložiť
+        few: Pri ukladaní objektu %{model} došlo k %{count} chybám a nebolo ho možné
+          uložiť
+        other: Pri ukladaní objektu %{model} došlo k %{count} chybám a nebolo ho možné
+          uložiť
   helpers:
     select:
       prompt: Prosím vyberte si
@@ -147,22 +149,22 @@ sk:
   number:
     currency:
       format:
-        delimiter: ! ' '
-        format: ! '%n %u'
+        delimiter: " "
+        format: "%n %u"
         precision: 2
-        separator: ! ','
+        separator: ","
         significant: false
         strip_insignificant_zeros: false
-        unit: €
+        unit: "€"
     format:
-      delimiter: ! ' '
+      delimiter: " "
       precision: 3
-      separator: ! ','
+      separator: ","
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: Miliarda
           million: Milión
@@ -176,7 +178,7 @@ sk:
         significant: false
         strip_insignificant_zeros: false
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: B
@@ -188,19 +190,19 @@ sk:
           tb: TB
     percentage:
       format:
-        delimiter: ! ' '
+        delimiter: " "
     precision:
       format:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ' a '
-      two_words_connector: ! ' a '
-      words_connector: ! ', '
+      last_word_connector: " a "
+      two_words_connector: " a "
+      words_connector: ", "
   time:
     am: dopoludnia
     formats:
-      default: ! '%a %d. %B %Y %H:%M %z'
-      long: ! '%A %d. %B %Y %H:%M'
-      short: ! '%d.%m. %H:%M'
+      default: "%a %d. %B %Y %H:%M %z"
+      long: "%A %d. %B %Y %H:%M"
+      short: "%d.%m. %H:%M"
     pm: popoludní

--- a/rails/locale/sl.yml
+++ b/rails/locale/sl.yml
@@ -1,3 +1,4 @@
+---
 sl:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ sl:
     - pet
     - sob
     abbr_month_names:
-    -
+    - 
     - jan
     - feb
     - mar
@@ -31,11 +32,11 @@ sl:
     - petek
     - sobota
     formats:
-      default: ! '%d.%m.%Y'
-      long: ! '%d. %b %Y'
-      short: ! '%d. %b'
+      default: "%d.%m.%Y"
+      long: "%d. %b %Y"
+      short: "%d. %b"
     month_names:
-    -
+    - 
     - januar
     - februar
     - marec
@@ -91,24 +92,24 @@ sl:
         other: več kot %{count} let
         two: več kot 2 leti
       x_days:
-        few: ! '%{count} dnevi'
+        few: "%{count} dnevi"
         one: 1 dan
-        other: ! '%{count} dni'
+        other: "%{count} dni"
         two: 2 dneva
       x_minutes:
-        few: ! '%{count} minute'
+        few: "%{count} minute"
         one: 1 minuta
-        other: ! '%{count} minut'
+        other: "%{count} minut"
         two: 2 minuti
       x_months:
-        few: ! '%{count} mesece'
+        few: "%{count} mesece"
         one: 1 mesec
-        other: ! '%{count} mesecev'
+        other: "%{count} mesecev"
         two: 2 meseca
       x_seconds:
-        few: ! '%{count} sekunde'
+        few: "%{count} sekunde"
         one: 1 sekunda
-        other: ! '%{count} sekund'
+        other: "%{count} sekund"
         two: 2 sekundi
     prompts:
       day: Dan
@@ -118,7 +119,7 @@ sl:
       second: Sekunde
       year: Leto
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: mora biti sprejeto
       blank: ne sme biti prazno
@@ -141,31 +142,31 @@ sl:
       too_short: je prekratko (zahtevano je najmanj %{count} znakov)
       wrong_length: je napačne dolžine (mora biti natančno %{count} znakov)
     template:
-      body: ! 'Napačno izpolnjena polja:'
+      body: 'Napačno izpolnjena polja:'
       header:
-        few: ! '%{count} napake preprečujejo, da bi shranili %{model}'
+        few: "%{count} napake preprečujejo, da bi shranili %{model}"
         one: Ena napaka preprečuje, da bi shranili %{model}
-        other: ! '%{count} napak preprečuje, da bi shranili %{model}'
+        other: "%{count} napak preprečuje, da bi shranili %{model}"
         two: Dve napaki preprečujeta, da bi shranili %{model}
   number:
     currency:
       format:
-        delimiter: .
-        format: ! '%u%n'
+        delimiter: "."
+        format: "%u%n"
         precision: 2
-        separator: ! ','
+        separator: ","
         significant: false
         strip_insignificant_zeros: false
-        unit: €
+        unit: "€"
     format:
-      delimiter: .
+      delimiter: "."
       precision: 2
-      separator: ! ','
+      separator: ","
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           unit: ''
       format:
@@ -174,7 +175,7 @@ sl:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Byte
@@ -193,13 +194,13 @@ sl:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ' in '
-      two_words_connector: ! ' in '
-      words_connector: ! ', '
+      last_word_connector: " in "
+      two_words_connector: " in "
+      words_connector: ", "
   time:
     am: dopoldan
     formats:
-      default: ! '%A, %d %b %Y ob %H:%M:%S'
-      long: ! '%d. %B, %Y ob %H:%M'
-      short: ! '%d. %b ob %H:%M'
+      default: "%A, %d %b %Y ob %H:%M:%S"
+      long: "%d. %B, %Y ob %H:%M"
+      short: "%d. %b ob %H:%M"
     pm: popoldan

--- a/rails/locale/sr.yml
+++ b/rails/locale/sr.yml
@@ -1,3 +1,4 @@
+---
 sr:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ sr:
     - Пет
     - Суб
     abbr_month_names:
-    -
+    - 
     - Јан
     - Феб
     - Мар
@@ -31,11 +32,11 @@ sr:
     - Петак
     - Субота
     formats:
-      default: ! '%d/%m/%Y'
-      long: ! '%B %e, %Y'
-      short: ! '%e %b'
+      default: "%d/%m/%Y"
+      long: "%B %e, %Y"
+      short: "%e %b"
     month_names:
-    -
+    - 
     - Јануар
     - Фабруар
     - Март
@@ -91,25 +92,25 @@ sr:
         many: преко %{count} година
         other: преко %{count} година
       x_days:
-        one: ! '%{count} дан'
-        few: ! '%{count} дана'
-        many: ! '%{count} дана'
-        other: ! '%{count} дана'
+        one: "%{count} дан"
+        few: "%{count} дана"
+        many: "%{count} дана"
+        other: "%{count} дана"
       x_minutes:
-        one: ! '%{count} минут'
-        few: ! '%{count} минута'
-        many: ! '%{count} минута'
-        other: ! '%{count} минута'
+        one: "%{count} минут"
+        few: "%{count} минута"
+        many: "%{count} минута"
+        other: "%{count} минута"
       x_months:
-        one: ! '%{count} месец'
-        few: ! '%{count} месеца'
-        many: ! '%{count} месеци'
-        other: ! '%{count} месеци'
+        one: "%{count} месец"
+        few: "%{count} месеца"
+        many: "%{count} месеци"
+        other: "%{count} месеци"
       x_seconds:
-        one: ! '%{count} секунда'
-        few: ! '%{count} секунде'
-        many: ! '%{count} секунди'
-        other: ! '%{count} секунди'
+        one: "%{count} секунда"
+        few: "%{count} секунде"
+        many: "%{count} секунди"
+        other: "%{count} секунди"
     prompts:
       day: Дан
       hour: Сат
@@ -118,7 +119,7 @@ sr:
       second: Секунд
       year: Година
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: мора бити прихваћено
       blank: не сме бити празан
@@ -137,10 +138,10 @@ sr:
       not_a_number: није број
       not_an_integer: није цео број
       odd: мора бити непаран
-      record_invalid: ! 'Валидација није успела: %{errors}'
+      record_invalid: 'Валидација није успела: %{errors}'
       restrict_dependent_destroy:
-        one: "Није могуће обрисати запис јер постоји зависан %{record}"
-        many: "Није могуће обрисати запис јер постоје зависни %{record}"
+        one: Није могуће обрисати запис јер постоји зависан %{record}
+        many: Није могуће обрисати запис јер постоје зависни %{record}
       taken: је већ заузет
       too_long:
         one: је предугачак (максимум је %{count} знак)
@@ -157,14 +158,14 @@ sr:
         few: није одговарајуће дужине (треба бити %{count} знака)
         many: није одговарајуће дужине (треба бити %{count} знакова)
         other: није одговарајуће дужине (треба бити %{count} знакова)
-      other_than: "мора бити различит од %{count}"
+      other_than: мора бити различит од %{count}
     template:
-      body: ! 'Молим Вас да проверите следећа поља:'
+      body: 'Молим Вас да проверите следећа поља:'
       header:
-        one: ! 'Нисам успео сачувати %{model}: %{count} грешка.'
-        few: ! 'Нисам успео сачувати %{model}: %{count} грешке.'
-        many: ! 'Нисам успео сачувати %{model}: %{count} грешки.'
-        other: ! 'Нисам успео сачувати %{model}: %{count} грешки.'
+        one: 'Нисам успео сачувати %{model}: %{count} грешка.'
+        few: 'Нисам успео сачувати %{model}: %{count} грешке.'
+        many: 'Нисам успео сачувати %{model}: %{count} грешки.'
+        other: 'Нисам успео сачувати %{model}: %{count} грешки.'
   helpers:
     select:
       prompt: Изаберите
@@ -175,22 +176,22 @@ sr:
   number:
     currency:
       format:
-        delimiter: ! ','
-        format: ! '%n %u'
+        delimiter: ","
+        format: "%n %u"
         precision: 2
-        separator: .
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
         unit: ДИН
     format:
-      delimiter: .
+      delimiter: "."
       precision: 3
-      separator: ! ','
+      separator: ","
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           thousand: Хиљаду
           million: Милион
@@ -204,7 +205,7 @@ sr:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: бајт
@@ -224,13 +225,13 @@ sr:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ', и '
-      two_words_connector: ! ' и '
-      words_connector: ! ', '
+      last_word_connector: ", и "
+      two_words_connector: " и "
+      words_connector: ", "
   time:
     am: АМ
     formats:
-      default: ! '%a %b %d %H:%M:%S %Z %Y'
-      long: ! '%B %d, %Y %H:%M'
-      short: ! '%d %b %H:%M'
+      default: "%a %b %d %H:%M:%S %Z %Y"
+      long: "%B %d, %Y %H:%M"
+      short: "%d %b %H:%M"
     pm: ПМ

--- a/rails/locale/sv.yml
+++ b/rails/locale/sv.yml
@@ -1,3 +1,4 @@
+---
 sv:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ sv:
     - fre
     - lör
     abbr_month_names:
-    -
+    - 
     - jan
     - feb
     - mar
@@ -31,11 +32,11 @@ sv:
     - fredag
     - lördag
     formats:
-      default: ! '%Y-%m-%d'
-      long: ! '%e %B %Y'
-      short: ! '%e %b'
+      default: "%Y-%m-%d"
+      long: "%e %B %Y"
+      short: "%e %b"
     month_names:
-    -
+    - 
     - januari
     - februari
     - mars
@@ -78,16 +79,16 @@ sv:
         other: mer än %{count} år
       x_days:
         one: en dag
-        other: ! '%{count} dagar'
+        other: "%{count} dagar"
       x_minutes:
         one: en minut
-        other: ! '%{count} minuter'
+        other: "%{count} minuter"
       x_months:
         one: en månad
-        other: ! '%{count} månader'
+        other: "%{count} månader"
       x_seconds:
         one: en sekund
-        other: ! '%{count} sekunder'
+        other: "%{count} sekunder"
     prompts:
       day: Dag
       hour: Timme
@@ -96,7 +97,7 @@ sv:
       second: Sekund
       year: År
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: måste vara accepterad
       blank: måste anges
@@ -114,16 +115,16 @@ sv:
       not_a_number: är inte ett nummer
       not_an_integer: måste vara ett heltal
       odd: måste vara udda
-      record_invalid: ! 'Ett fel uppstod: %{errors}'
+      record_invalid: 'Ett fel uppstod: %{errors}'
       taken: används redan
       too_long: är för lång (maximum är %{count} tecken)
       too_short: är för kort (minimum är %{count} tecken)
       wrong_length: har fel längd (ska vara %{count} tecken)
     template:
-      body: ! 'Det var problem med följande fält:'
+      body: 'Det var problem med följande fält:'
       header:
         one: Ett fel förhindrade denna %{model} från att sparas
-        other: ! '%{count} fel förhindrade denna %{model} från att sparas'
+        other: "%{count} fel förhindrade denna %{model} från att sparas"
   helpers:
     select:
       prompt: Välj
@@ -135,21 +136,21 @@ sv:
     currency:
       format:
         delimiter: ''
-        format: ! '%n %u'
+        format: "%n %u"
         precision: 2
-        separator: ! ','
+        separator: ","
         significant: false
         strip_insignificant_zeros: false
         unit: kr
     format:
       delimiter: ''
       precision: 2
-      separator: ! ','
+      separator: ","
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: Miljard
           million: Miljon
@@ -163,7 +164,7 @@ sv:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Byte
@@ -180,13 +181,13 @@ sv:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ' och '
-      two_words_connector: ! ' och '
-      words_connector: ! ', '
+      last_word_connector: " och "
+      two_words_connector: " och "
+      words_connector: ", "
   time:
     am: ''
     formats:
-      default: ! '%a, %e %b %Y %H:%M:%S %z'
-      long: ! '%e %B %Y %H:%M'
-      short: ! '%e %b %H:%M'
+      default: "%a, %e %b %Y %H:%M:%S %z"
+      long: "%e %B %Y %H:%M"
+      short: "%e %b %H:%M"
     pm: ''

--- a/rails/locale/sw.yml
+++ b/rails/locale/sw.yml
@@ -1,3 +1,4 @@
+---
 sw:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ sw:
     - Ij
     - J1
     abbr_month_names:
-    -
+    - 
     - Jan
     - Feb
     - Mac
@@ -31,11 +32,11 @@ sw:
     - Ijumaa
     - Jumamosi
     formats:
-      default: ! '%d-%m-%Y'
-      long: ! '%e %B, %Y'
-      short: ! '%e %b'
+      default: "%d-%m-%Y"
+      long: "%e %B, %Y"
+      short: "%e %b"
     month_names:
-    -
+    - 
     - Mwezi wa kwanza
     - Mwezi wa pili
     - Mwezi wa tatu
@@ -96,7 +97,7 @@ sw:
       second: Sekunde
       year: Mwaka
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: lazima ikubaliwe
       blank: haitakiwi kuwa wazi
@@ -114,16 +115,16 @@ sw:
       not_a_number: inaruhusiwa namba tu
       not_an_integer: inaruhusiwa namba tu
       odd: z/iwe witiri
-      record_invalid: ! 'Uhalalishaji umeshindikana: %{errors}'
+      record_invalid: 'Uhalalishaji umeshindikana: %{errors}'
       taken: imesajiliwa
       too_long: ndefu sana (isizidi herufi %{count})
       too_short: fupi mno (isipungue herufi %{count})
       wrong_length: idadi ya herufi hazilingani (inatakiwa %{count})
     template:
-      body: ! 'Tafadhali kagua sehemu zifuatazo:'
+      body: 'Tafadhali kagua sehemu zifuatazo:'
       header:
-        one: ! '%{model} haikuhifadhiwa kwa sababu moja.'
-        other: ! '%{model} haikuhifadhiwa kwa sababu %{count}.'
+        one: "%{model} haikuhifadhiwa kwa sababu moja."
+        other: "%{model} haikuhifadhiwa kwa sababu %{count}."
   helpers:
     select:
       prompt: Tafadhali teua
@@ -134,22 +135,22 @@ sw:
   number:
     currency:
       format:
-        delimiter: .
-        format: ! '%n%u'
+        delimiter: "."
+        format: "%n%u"
         precision: 2
-        separator: ! ','
+        separator: ","
         significant: false
         strip_insignificant_zeros: false
-        unit: /=
+        unit: "/="
     format:
-      delimiter: .
+      delimiter: "."
       precision: 2
-      separator: ! ','
+      separator: ","
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: Bilioni
           million: Milioni
@@ -163,7 +164,7 @@ sw:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte: Baiti
           gb: GB
@@ -178,13 +179,13 @@ sw:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ', na '
-      two_words_connector: ! ' na '
-      words_connector: ! ', '
+      last_word_connector: ", na "
+      two_words_connector: " na "
+      words_connector: ", "
   time:
     am: am
     formats:
-      default: ! '%a, %d %b %Y %H:%M:%S'
-      long: ! '%A, %e. %B %Y, %H:%M:%S'
-      short: ! '%e %b %Y %H:%M'
+      default: "%a, %d %b %Y %H:%M:%S"
+      long: "%A, %e. %B %Y, %H:%M:%S"
+      short: "%e %b %Y %H:%M"
     pm: pm

--- a/rails/locale/ta.yml
+++ b/rails/locale/ta.yml
@@ -1,3 +1,4 @@
+---
 ta:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ ta:
     - வெள்ளி
     - சனி
     abbr_month_names:
-    -
+    - 
     - ஜன
     - பிப்
     - மார்ச்
@@ -31,11 +32,11 @@ ta:
     - வெள்ளிக்கிழமை
     - சனிக்கிழமை
     formats:
-      default: ! '%d-%m-%Y'
-      long: ! '%B %d, %Y'
-      short: ! '%b %d'
+      default: "%d-%m-%Y"
+      long: "%B %d, %Y"
+      short: "%b %d"
     month_names:
-    -
+    - 
     - ஜனவரி
     - பிப்ரவரி
     - மார்ச்
@@ -66,28 +67,28 @@ ta:
       almost_x_years:
         one: கிட்டத்தட்ட 1  ஆண்டு
         other: கிட்டத்தட்ட %{count}  ஆண்டுகள்
-      half_a_minute:   அரை நிமிடம்
+      half_a_minute: அரை நிமிடம்
       less_than_x_minutes:
-        one:   ஒரு நிமிடத்திற்கும் குறைவாக
+        one: ஒரு நிமிடத்திற்கும் குறைவாக
         other: குறைவாக %{count} நிமிடங்கள்
       less_than_x_seconds:
         one: ஒரு வினாடிக்கும் குறைவாக
         other: குறைவாக %{count} வினாடிகள்
       over_x_years:
         one: ஒரு  ஆண்டிற்கு மேலாக
-        other: ! '%{count}  ஆண்டிற்கு மேலாக'
+        other: "%{count}  ஆண்டிற்கு மேலாக"
       x_days:
         one: 1 நாள்
-        other: ! '%{count} நாட்கள்'
+        other: "%{count} நாட்கள்"
       x_minutes:
         one: 1 நிமிடம்
-        other: ! '%{count} நிமிடங்கள்'
+        other: "%{count} நிமிடங்கள்"
       x_months:
         one: 1 மாதம்
-        other: ! '%{count} மாதங்கள்'
+        other: "%{count} மாதங்கள்"
       x_seconds:
         one: 1 வினாடி
-        other: ! '%{count} விநாடிகள்'
+        other: "%{count} விநாடிகள்"
     prompts:
       day: நாள்
       hour: மணி
@@ -96,29 +97,29 @@ ta:
       second: விநாடிகள்
       year: ஆண்டு
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: ஏற்கப்பட வேண்டும்
       blank: காலியாக இருக்க முடியாது
       present: காலியாக இருக்க வேண்டும்
-      confirmation: ! "%{attribute}  பொருந்தவில்லை"
+      confirmation: "%{attribute}  பொருந்தவில்லை"
       empty: வெறுமையாக இருக்க முடியாது
-      equal_to: ! '%{count} சமமாக இருக்க வேண்டும்'
+      equal_to: "%{count} சமமாக இருக்க வேண்டும்"
       even: இரட்டைப்படை இருக்க வேண்டும்
       exclusion: ஒதுக்கப்பட்டுள்ளது
-      greater_than: ! '%{count} ஐ விட அதிகமாக இருக்க வேண்டும்'
-      greater_than_or_equal_to: ! '%{count}  அதிகமாக அல்லது சமமாக இருக்க வேண்டும்'
+      greater_than: "%{count} ஐ விட அதிகமாக இருக்க வேண்டும்"
+      greater_than_or_equal_to: "%{count}  அதிகமாக அல்லது சமமாக இருக்க வேண்டும்"
       inclusion: பட்டியலில் சேர்க்கப்படவில்லை
       invalid: செல்லுபடியானதல்ல
-      less_than: ! '%{count} ஐ விட குறைவாக இருக்க வேண்டும்'
-      less_than_or_equal_to: ! '%{count} குறைவாக அல்லது சமமாக இருக்க வேண்டும்'
+      less_than: "%{count} ஐ விட குறைவாக இருக்க வேண்டும்"
+      less_than_or_equal_to: "%{count} குறைவாக அல்லது சமமாக இருக்க வேண்டும்"
       not_a_number: ஒரு எண் அல்ல
       not_an_integer: ஒரு முழு எண்ணாக இருக்க வேண்டும்
       odd: ஒற்றைப்படை இருக்க வேண்டும்
-      record_invalid: ! 'சரிபார்த்தல் தோல்வியுற்றது: %{errors}'
+      record_invalid: 'சரிபார்த்தல் தோல்வியுற்றது: %{errors}'
       restrict_dependent_destroy:
-        one: "பதிவை நீக்க முடியாது, ஏனெனில் ஒரு சார்பு %{record} உள்ளது"
-        many: "பதிவை நீக்க முடியாது, ஏனெனில் சார்புகள் %{record} உள்ளது"
+        one: பதிவை நீக்க முடியாது, ஏனெனில் ஒரு சார்பு %{record} உள்ளது
+        many: பதிவை நீக்க முடியாது, ஏனெனில் சார்புகள் %{record} உள்ளது
       taken: ஏற்கனவே எடுத்துகொள்ள பட்டது
       too_long:
         one: மிக நீளமாக உள்ளது (அதிகபட்சமாக ஒரு எழுத்து)
@@ -131,41 +132,41 @@ ta:
         other: தவறான நீளம் (%{count} எழுத்துக்கள் இருக்கவேண்டும்)
       other_than: "%{count} தவிர வேறு இருக்க வேண்டும்"
     template:
-      body: ! 'பின்வரும் புலங்களில் பிரச்சினைகள் உள்ளது:'
+      body: 'பின்வரும் புலங்களில் பிரச்சினைகள் உள்ளது:'
       header:
         one: 1 பிழை இந்த %{model} ஐ சேமிக்க தடையாக உள்ளது
-        other: ! '%{count} பிழைகள் இந்த %{model} ஐ சேமிக்க தடையாக உள்ளது'
+        other: "%{count} பிழைகள் இந்த %{model} ஐ சேமிக்க தடையாக உள்ளது"
   helpers:
     select:
       prompt: தேர்வு செய்க
     submit:
-      create: ! '%{model} ஐ  உருவாக்கு'
-      submit: ! '%{model} ஐ சேமி'
-      update: ! '%{model} ஐ புதுப்பி'
+      create: "%{model} ஐ  உருவாக்கு"
+      submit: "%{model} ஐ சேமி"
+      update: "%{model} ஐ புதுப்பி"
   number:
     currency:
       format:
-        delimiter: ! ','
-        format: ! '%u%n'
+        delimiter: ","
+        format: "%u%n"
         precision: 2
-        separator: .
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
-        unit: ₹
+        unit: "₹"
     format:
-      delimiter: ! ','
+      delimiter: ","
       precision: 3
-      separator: .
+      separator: "."
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: பில்லியன்
           million: மில்லியன்
           quadrillion: குவாட்ரில்லியன்
-          thousand:  ஆயிரம்
+          thousand: ஆயிரம்
           trillion: டிரில்லியன்
           unit: ''
       format:
@@ -174,7 +175,7 @@ ta:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Byte
@@ -192,13 +193,13 @@ ta:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ', மற்றும் '
-      two_words_connector: ! ' மற்றும் '
-      words_connector: ! ', '
+      last_word_connector: ", மற்றும் "
+      two_words_connector: " மற்றும் "
+      words_connector: ", "
   time:
     am: மு.ப.
     formats:
-      default: ! '%a, %d %b %Y %H:%M:%S %z'
-      long: ! '%B %d, %Y %H:%M'
-      short: ! '%d %b %H:%M'
+      default: "%a, %d %b %Y %H:%M:%S %z"
+      long: "%B %d, %Y %H:%M"
+      short: "%d %b %H:%M"
     pm: பி.ப.

--- a/rails/locale/th.yml
+++ b/rails/locale/th.yml
@@ -1,3 +1,4 @@
+---
 th:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ th:
     - ศ
     - ส
     abbr_month_names:
-    -
+    - 
     - ม.ค.
     - ก.พ.
     - มี.ค.
@@ -31,11 +32,11 @@ th:
     - ศุกร์
     - เสาร์
     formats:
-      default: ! '%d-%m-%Y'
-      long: ! '%d %B %Y'
-      short: ! '%d %b'
+      default: "%d-%m-%Y"
+      long: "%d %B %Y"
+      short: "%d %b"
     month_names:
-    -
+    - 
     - มกราคม
     - กุมภาพันธ์
     - มีนาคม
@@ -62,10 +63,10 @@ th:
       less_than_x_minutes: น้อยกว่า %{count} นาที
       less_than_x_seconds: น้อยกว่า %{count} วินาที
       over_x_years: มากกว่า %{count} ปี
-      x_days: ! '%{count} วัน'
-      x_minutes: ! '%{count} นาที'
-      x_months: ! '%{count} เดือน'
-      x_seconds: ! '%{count} วินาที'
+      x_days: "%{count} วัน"
+      x_minutes: "%{count} นาที"
+      x_months: "%{count} เดือน"
+      x_seconds: "%{count} วินาที"
     prompts:
       day: วัน
       hour: ชั่วโมง
@@ -74,7 +75,7 @@ th:
       second: วินาที
       year: ปี
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: ต้องถูกยอมรับ
       blank: ต้องไม่เว้นว่างเอาไว้
@@ -92,13 +93,13 @@ th:
       not_a_number: ไม่ใช่ตัวเลข
       not_an_integer: ไม่ใช่จำนวนเต็ม
       odd: ต้องเป็นจำนวนคี่
-      record_invalid: ! 'ไม่ผ่านการตรวจสอบ: %{errors}'
+      record_invalid: 'ไม่ผ่านการตรวจสอบ: %{errors}'
       taken: ถูกใช้ไปแล้ว
       too_long: ยาวเกินไป (ต้องไม่เกิน %{count} ตัวอักษร)
       too_short: สั้นเกินไป (ต้องยาวกว่า %{count} ตัวอักษร)
       wrong_length: มีความยาวไม่ถูกต้อง (ต้องมีความยาว %{count} ตัวอักษร)
     template:
-      body: ! 'โปรดตรวจสอบข้อมูลในช่องต่อไปนี้:'
+      body: 'โปรดตรวจสอบข้อมูลในช่องต่อไปนี้:'
       header: พบข้อผิดพลาด %{count} ประการ ทำให้ไม่สามารถบันทึก%{model}ได้
   helpers:
     select:
@@ -110,22 +111,22 @@ th:
   number:
     currency:
       format:
-        delimiter: ! ','
-        format: ! '%n %u'
+        delimiter: ","
+        format: "%n %u"
         precision: 2
-        separator: .
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
         unit: บาท
     format:
-      delimiter: ! ','
+      delimiter: ","
       precision: 3
-      separator: .
+      separator: "."
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: พันล้าน
           million: ล้าน
@@ -139,7 +140,7 @@ th:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte: ไบต์
           gb: จิกะไบต์
@@ -154,13 +155,13 @@ th:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ', และ '
-      two_words_connector: ! ' และ '
-      words_connector: ! ', '
+      last_word_connector: ", และ "
+      two_words_connector: " และ "
+      words_connector: ", "
   time:
     am: ก่อนเที่ยง
     formats:
-      default: ! '%a %d %b %Y %H:%M:%S %z'
-      long: ! '%d %B %Y %H:%M น.'
-      short: ! '%d %b %H:%M น.'
+      default: "%a %d %b %Y %H:%M:%S %z"
+      long: "%d %B %Y %H:%M น."
+      short: "%d %b %H:%M น."
     pm: หลังเที่ยง

--- a/rails/locale/tl.yml
+++ b/rails/locale/tl.yml
@@ -1,94 +1,77 @@
-# Filipino (Tagalog) translations for Rails
-# by Patrick CHEW (pchew@change.org)
-# contributors:
-#  - Patrick CHEW - https://github.com/pchew-change (pchew@change.org)
-#  - Jose BUSTAMANTE - (josebust@cisco.com)
-# Corrected by Christine Roque : christine@change.org
-# Additional correction by: https://github.com/Lioness8257
-# Additional corrections by: https://github.com/ariesandrada
-
-"tl":
+---
+tl:
   date:
     formats:
       default: "%d/%m/%Y"
       short: ika-%d ng %b
       long: ika-%d ng %B, %Y
-
     day_names:
-      - Linggo
-      - Lunes
-      - Martes
-      - Miyerkules
-      - Huwebes
-      - Biyernes
-      - Sabado
-
+    - Linggo
+    - Lunes
+    - Martes
+    - Miyerkules
+    - Huwebes
+    - Biyernes
+    - Sabado
     abbr_day_names:
-      - Lin
-      - Lun
-      - Mar
-      - Miy
-      - Huw
-      - Biy
-      - Sab
-
+    - Lin
+    - Lun
+    - Mar
+    - Miy
+    - Huw
+    - Biy
+    - Sab
     month_names:
-      - ~
-      - Enero
-      - Pebrero
-      - Marso
-      - Abril
-      - Mayo
-      - Hunyo
-      - Hulyo
-      - Agosto
-      - Setyembre
-      - Oktubre
-      - Nobyembre
-      - Disyembre
-
+    - 
+    - Enero
+    - Pebrero
+    - Marso
+    - Abril
+    - Mayo
+    - Hunyo
+    - Hulyo
+    - Agosto
+    - Setyembre
+    - Oktubre
+    - Nobyembre
+    - Disyembre
     abbr_month_names:
-      - ~
-      - Ene
-      - Peb
-      - Mar
-      - Abr
-      - May
-      - Hun
-      - Hul
-      - Ago
-      - Set
-      - Okt
-      - Nob
-      - Dis
-
+    - 
+    - Ene
+    - Peb
+    - Mar
+    - Abr
+    - May
+    - Hun
+    - Hul
+    - Ago
+    - Set
+    - Okt
+    - Nob
+    - Dis
     order:
-     - :year
-     - :month
-     - :day
-
+    - :year
+    - :month
+    - :day
   time:
     formats:
       default: "%A, ika-%d ng %B ng %Y %H:%M:%S %z"
       short: "%d ng %b %H:%M"
-      long: "ika-%d ng %B ng %Y %H:%M"
+      long: ika-%d ng %B ng %Y %H:%M
     am: AM
     pm: PM
-
   support:
     array:
       words_connector: ","
-      two_words_connector: "at"
+      two_words_connector: at
       last_word_connector: ", at"
-
   number:
     format:
       separator: "."
       delimiter: ","
       precision: 3
-      significant: FALSE
-      strip_insignificant_zeros: FALSE
-
+      significant: false
+      strip_insignificant_zeros: false
     currency:
       format:
         format: "%n %u"
@@ -96,23 +79,20 @@
         separator: "."
         delimiter: ","
         precision: 2
-        significant: FALSE
-        strip_insignificant_zeros: FALSE
-
+        significant: false
+        strip_insignificant_zeros: false
     percentage:
-     format:
-       delimiter: ""
-
+      format:
+        delimiter: ''
     precision:
       format:
-        delimiter: ""
-
+        delimiter: ''
     human:
       format:
-        delimiter: ""
+        delimiter: ''
         precision: 1
-        significant: TRUE
-        strip_insignificant_zeros: TRUE
+        significant: true
+        strip_insignificant_zeros: true
       storage_units:
         format: "%n %u"
         units:
@@ -126,49 +106,48 @@
       decimal_units:
         format: "%n %u"
         units:
-          unit: ""
+          unit: ''
           thousand: libo
           million: milyon
           billion: bilyon
           trillion: trilyon
           quadrillion: kuwadrilyon
-
   datetime:
     distance_in_words:
-      half_a_minute: "kalahating minuto"
+      half_a_minute: kalahating minuto
       less_than_x_seconds:
         one: mas mababa sa isang segundo
-        other: "mas mababa sa %{count} segundo"
+        other: mas mababa sa %{count} segundo
       x_seconds:
         one: isang segundo
         other: "%{count} segundo"
       less_than_x_minutes:
-         one: mas mababa sa isang minuto
-         other: "mas mababa sa %{count} minuto"
+        one: mas mababa sa isang minuto
+        other: mas mababa sa %{count} minuto
       x_minutes:
-         one: isang minuto
-         other: "%{count} minuto"
+        one: isang minuto
+        other: "%{count} minuto"
       about_x_hours:
-         one: humigit-kumulang isang oras
-         other: "humigit-kumulang %{count} oras"
+        one: humigit-kumulang isang oras
+        other: humigit-kumulang %{count} oras
       x_days:
-         one: isang araw
-         other: "%{count} araw"
+        one: isang araw
+        other: "%{count} araw"
       about_x_months:
-         one: humigit-kumulang isang buwan
-         other: "humigit-kumulang %{count} buwan"
+        one: humigit-kumulang isang buwan
+        other: humigit-kumulang %{count} buwan
       x_months:
-         one: isang buwan
-         other: "%{count} buwan"
+        one: isang buwan
+        other: "%{count} buwan"
       about_x_years:
-         one: humigit-kumulang isang taon
-         other: "humigit-kumulang %{count} taon"
+        one: humigit-kumulang isang taon
+        other: humigit-kumulang %{count} taon
       over_x_years:
-         one: higit sa isang taon
-         other: "higit %{count} taon"
+        one: higit sa isang taon
+        other: higit %{count} taon
       almost_x_years:
-         one: halos isang taon
-         other: "halos %{count} taon"
+        one: halos isang taon
+        other: halos %{count} taon
     prompts:
       year: taon
       month: buwan
@@ -176,20 +155,16 @@
       hour: oras
       minute: minuto
       second: segundo
-
   helpers:
     select:
       prompt: Mangyaring pumili
-
     submit:
-      create: "lumikha ng %{model}"
-      update: "i-update ang %{model}"
-      submit: "isumite ang %{model}"
-
+      create: lumikha ng %{model}
+      update: i-update ang %{model}
+      submit: isumite ang %{model}
   errors:
     format: "%{attribute} ay %{message}"
-
-    messages: &errors_messages
+    messages:
       inclusion: hindi kasama sa listahan
       exclusion: nakalaan na
       invalid: hindi wasto
@@ -198,11 +173,11 @@
       empty: hindi maaaring walang laman
       blank: hindi maaaring walang laman
       too_long:
-        one: "masyadong mahaba (pinakamadami ay %{count} character)"
-        other: "masyadong mahaba (pinakamadami ay %{count} character)"
+        one: masyadong mahaba (pinakamadami ay %{count} character)
+        other: masyadong mahaba (pinakamadami ay %{count} character)
       too_short:
-        one: "masyadong maikli (pinakakonti ay %{count} character)"
-        other: "masyadong maikli (pinakakonti ay %{count} character)"
+        one: masyadong maikli (pinakakonti ay %{count} character)
+        other: masyadong maikli (pinakakonti ay %{count} character)
       wrong_length:
         one: ang maling haba (ito ay dapat eksaktong %{count} character)
         other: ang maling haba (ito ay dapat eksaktong %{count} character)
@@ -216,9 +191,9 @@
       odd: dapat maging odd
       even: dapat maging even
       taken: ginagamit na
-      record_invalid: "Nabigo ang pagpapatunay: %{errors}"
+      record_invalid: 'Nabigo ang pagpapatunay: %{errors}'
     template:
       header:
-        one: "hindi maaaring i-save ang %{model} na ito dahil sa isang error"
-        other: "hindi maaaring i-save ang %{model} na ito dahil sa %{count} error"
-      body: "May mga problema sa mga sumusunod na patlang:"
+        one: hindi maaaring i-save ang %{model} na ito dahil sa isang error
+        other: hindi maaaring i-save ang %{model} na ito dahil sa %{count} error
+      body: 'May mga problema sa mga sumusunod na patlang:'

--- a/rails/locale/tr.yml
+++ b/rails/locale/tr.yml
@@ -1,3 +1,4 @@
+---
 tr:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ tr:
     - Cum
     - Cts
     abbr_month_names:
-    -
+    - 
     - Oca
     - Şub
     - Mar
@@ -31,11 +32,11 @@ tr:
     - Cuma
     - Cumartesi
     formats:
-      default: ! '%d.%m.%Y'
-      long: ! '%e %B %Y, %A'
-      short: ! '%e %b'
+      default: "%d.%m.%Y"
+      long: "%e %B %Y, %A"
+      short: "%e %b"
     month_names:
-    -
+    - 
     - Ocak
     - Şubat
     - Mart
@@ -69,25 +70,25 @@ tr:
       half_a_minute: yarım dakika
       less_than_x_minutes:
         one: 1 dakikadan az
-        other: ! '%{count} dakikadan az'
+        other: "%{count} dakikadan az"
       less_than_x_seconds:
         one: 1 saniyeden az
-        other: ! '%{count} saniyeden az'
+        other: "%{count} saniyeden az"
       over_x_years:
         one: 1 yıldan fazla
-        other: ! '%{count} yıldan fazla'
+        other: "%{count} yıldan fazla"
       x_days:
         one: 1 gün
-        other: ! '%{count} gün'
+        other: "%{count} gün"
       x_minutes:
         one: 1 dakika
-        other: ! '%{count} dakika'
+        other: "%{count} dakika"
       x_months:
         one: 1 ay
-        other: ! '%{count} ay'
+        other: "%{count} ay"
       x_seconds:
         one: 1 saniye
-        other: ! '%{count} saniye'
+        other: "%{count} saniye"
     prompts:
       day: Gün
       hour: Saat
@@ -96,29 +97,29 @@ tr:
       second: Saniye
       year: Yıl
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: kabul edilmeli
       blank: doldurulmalı
       present: boş bırakılmalı
-      confirmation: ! "%{attribute} teyidiyle uyuşmuyor"
+      confirmation: "%{attribute} teyidiyle uyuşmuyor"
       empty: doldurulmalı
       equal_to: tam olarak %{count} olmalı
       even: çift olmalı
       exclusion: kullanılamaz
-      greater_than: ! '%{count} sayısından büyük olmalı'
-      greater_than_or_equal_to: ! '%{count} sayısına eşit veya büyük olmalı'
+      greater_than: "%{count} sayısından büyük olmalı"
+      greater_than_or_equal_to: "%{count} sayısına eşit veya büyük olmalı"
       inclusion: kabul edilen bir kelime değil
       invalid: geçersiz
-      less_than: ! '%{count} sayısından küçük olmalı'
-      less_than_or_equal_to: ! '%{count} sayısına eşit veya küçük olmalı'
+      less_than: "%{count} sayısından küçük olmalı"
+      less_than_or_equal_to: "%{count} sayısına eşit veya küçük olmalı"
       not_a_number: geçerli bir sayı değil
       not_an_integer: tam sayı olmalı
       odd: tek olmalı
-      record_invalid: ! 'Doğrulama başarısız oldu: %{errors}'
+      record_invalid: 'Doğrulama başarısız oldu: %{errors}'
       restrict_dependent_destroy:
-        one: "Bağlı bir kayıt %{record} bulunduğu için kayıt silinemedi"
-        many: "Bağlı kayıtlar %{record} bulunduğu için kayıt silinemedi"
+        one: Bağlı bir kayıt %{record} bulunduğu için kayıt silinemedi
+        many: Bağlı kayıtlar %{record} bulunduğu için kayıt silinemedi
       taken: hali hazırda kullanılmakta
       too_long:
         one: çok uzun (en fazla 1 karakter)
@@ -131,36 +132,36 @@ tr:
         other: hatalı uzunlukta (%{count} karakter olmalı)
       other_than: "%{count} karakterden oluşamaz"
     template:
-      body: ! 'Lütfen aşağıdaki hataları düzeltiniz:'
+      body: 'Lütfen aşağıdaki hataları düzeltiniz:'
       header:
         one: 1 hata oluştuğu için %{model} kaydedilemedi
-        other: ! '%{count} hata oluştuğu için %{model} kaydedilemedi'
+        other: "%{count} hata oluştuğu için %{model} kaydedilemedi"
   helpers:
     select:
       prompt: Lütfen seçiniz
     submit:
-      create: '%{model} Ekle'
-      submit: '%{model} Kaydet'
-      update: '%{model} Güncelle'
+      create: "%{model} Ekle"
+      submit: "%{model} Kaydet"
+      update: "%{model} Güncelle"
   number:
     currency:
       format:
-        delimiter: ! '.'
-        format: ! '%n %u'
+        delimiter: "."
+        format: "%n %u"
         precision: 2
-        separator: ! ','
+        separator: ","
         significant: false
         strip_insignificant_zeros: false
         unit: TL
     format:
-      delimiter: .
+      delimiter: "."
       precision: 2
-      separator: ! ','
+      separator: ","
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: Milyar
           million: Milyon
@@ -169,12 +170,12 @@ tr:
           trillion: Trilyon
           unit: ''
       format:
-        delimiter: .
+        delimiter: "."
         precision: 2
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Bayt
@@ -189,16 +190,16 @@ tr:
         format: "%%n"
     precision:
       format:
-        delimiter: .
+        delimiter: "."
   support:
     array:
-      last_word_connector: ! ' ve '
-      two_words_connector: ! ' ve '
-      words_connector: ! ', '
+      last_word_connector: " ve "
+      two_words_connector: " ve "
+      words_connector: ", "
   time:
     am: öğleden önce
     formats:
-      default: ! '%a %d.%b.%y %H:%M'
-      long: ! '%e %B %Y, %A, %H:%M'
-      short: ! '%e %B, %H:%M'
+      default: "%a %d.%b.%y %H:%M"
+      long: "%e %B %Y, %A, %H:%M"
+      short: "%e %B, %H:%M"
     pm: öğleden sonra

--- a/rails/locale/tt.yml
+++ b/rails/locale/tt.yml
@@ -1,3 +1,4 @@
+---
 tt:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ tt:
     - Җом
     - Шим
     abbr_month_names:
-    -
+    - 
     - гыйн.
     - февр.
     - март
@@ -31,11 +32,11 @@ tt:
     - җомга
     - шимбә
     formats:
-      default: ! '%d.%m.%Y'
-      long: ! '%-d %B %Y'
-      short: ! '%-d %b'
+      default: "%d.%m.%Y"
+      long: "%-d %B %Y"
+      short: "%-d %b"
     month_names:
-    -
+    - 
     - гыйнвар
     - февраль
     - март
@@ -56,38 +57,38 @@ tt:
     distance_in_words:
       about_x_hours:
         one: бер сәгать чамасы
-        other: ! '%{count} сәгать чамасы'
+        other: "%{count} сәгать чамасы"
       about_x_months:
         one: бер ай чамасы
-        other: ! '%{count} ай чамасы'
+        other: "%{count} ай чамасы"
       about_x_years:
         one: бер ел чамасы
-        other: ! '%{count} ел чамасы'
+        other: "%{count} ел чамасы"
       almost_x_years:
         one: бер ел диярлек
-        other: ! '%{count} ел диярлек'
+        other: "%{count} ел диярлек"
       half_a_minute: минуттан азрак
       less_than_x_minutes:
         one: бер минуттан азрак
-        other: ! '%{count} минуттан азрак'
+        other: "%{count} минуттан азрак"
       less_than_x_seconds:
         one: бер секундтан азрак
-        other: ! '%{count} секундтан азрак'
+        other: "%{count} секундтан азрак"
       over_x_years:
         one: бер ел артык
-        other: ! '%{count} ел артык'
+        other: "%{count} ел артык"
       x_days:
         one: бер көн
-        other: ! '%{count} көн'
+        other: "%{count} көн"
       x_minutes:
         one: бер минут
-        other: ! '%{count} минут'
+        other: "%{count} минут"
       x_months:
         one: бер ай
-        other: ! '%{count} ай'
+        other: "%{count} ай"
       x_seconds:
         one: бер секунд
-        other: ! '%{count} секунд'
+        other: "%{count} секунд"
     prompts:
       day: Көн
       hour: Сәгать
@@ -96,29 +97,29 @@ tt:
       second: Секунд
       year: Ел
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: раслау кирәк
       blank: буш була алмый
       present: буш булырга тиеш
-      confirmation: ! '%{attribute} читнең мәгнәсе белән тигез түгел'
+      confirmation: "%{attribute} читнең мәгнәсе белән тигез түгел"
       empty: буш була алмый
       equal_to: мәгнәсе %{count} була гына ала
       even: так кына була ала
       exclusion: резервта саклау дигән әһәмияте бар
-      greater_than: ! '%{count} мәгнәсеннән зур була ала'
-      greater_than_or_equal_to: ! '%{count} мәгнәсеннән зур яки тигез була ала'
+      greater_than: "%{count} мәгнәсеннән зур була ала"
+      greater_than_or_equal_to: "%{count} мәгнәсеннән зур яки тигез була ала"
       inclusion: мәгнәсе алдан исәпкә алынган түгел
       invalid: мәгнәсе ялгыш
-      less_than: ! '%{count} мәгнәсеннән азрак була ала'
-      less_than_or_equal_to: ! '%{count} мәгнәсеннән азрак яки тигез була ала'
+      less_than: "%{count} мәгнәсеннән азрак була ала"
+      less_than_or_equal_to: "%{count} мәгнәсеннән азрак яки тигез була ала"
       not_a_number: сан тугел
       not_an_integer: бөтен сан түгел
-      odd: җөп кенә була ала 
-      record_invalid: ! 'Хаталар чыкты: %{errors}'
+      odd: җөп кенә була ала
+      record_invalid: 'Хаталар чыкты: %{errors}'
       restrict_dependent_destroy:
-        one: "Язмышны бетереп булмады, чөнки бәйлелек табылды: %{record}"
-        many: "Язмышны бетереп булмады, чөнки бәйлелекләр табылды: %{record}"
+        one: 'Язмышны бетереп булмады, чөнки бәйлелек табылды: %{record}'
+        many: 'Язмышны бетереп булмады, чөнки бәйлелекләр табылды: %{record}'
       taken: бар инде
       too_long:
         one: бигрәк озын (озынлыгы бердән озынрак була алмый)
@@ -129,38 +130,38 @@ tt:
       wrong_length:
         one: озынлыгы ялгыш (озынлыгы бергә тигез булырга тиеш)
         other: озынлыгы ялгыш (озынлыгы %{count} мәгнәгә тигез булырга тиеш)
-      other_than: ! '%{count} мәгнәсеннән икенче булырга тиеш'
+      other_than: "%{count} мәгнәсеннән икенче булырга тиеш"
     template:
-      body: ! ':'
+      body: ":"
       header:
-        one: ! '%{model}: %{count} хата аркасында саклау чыкмады'
-        other: ! '%{model}: %{count} хата аркасында саклау чыкмады'
+        one: "%{model}: %{count} хата аркасында саклау чыкмады"
+        other: "%{model}: %{count} хата аркасында саклау чыкмады"
   helpers:
     select:
-      prompt: ! 'Сайлагыз: '
+      prompt: 'Сайлагыз: '
     submit:
-      create: ! '%{model} иҗат итергә'
-      submit: ! '%{model} саклап калырга'
-      update: ! '%{model} саклап калырга'
+      create: "%{model} иҗат итергә"
+      submit: "%{model} саклап калырга"
+      update: "%{model} саклап калырга"
   number:
     currency:
       format:
-        delimiter: ! ' '
-        format: ! '%n %u'
+        delimiter: " "
+        format: "%n %u"
         precision: 2
-        separator: ','
+        separator: ","
         significant: false
         strip_insignificant_zeros: false
         unit: сум
     format:
-      delimiter: ! ' '
+      delimiter: " "
       precision: 3
-      separator: ','
+      separator: ","
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion:
             one: миллиард
@@ -184,7 +185,7 @@ tt:
         significant: false
         strip_insignificant_zeros: false
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: байт
@@ -202,13 +203,13 @@ tt:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ' һәм '
-      two_words_connector: ! ' һәм '
-      words_connector: ! ', '
+      last_word_connector: " һәм "
+      two_words_connector: " һәм "
+      words_connector: ", "
   time:
     am: иртәнге
     formats:
-      default: ! '%a, %d %b %Y, %H:%M:%S %z'
-      long: ! '%d %B %Y, %H:%M'
-      short: ! '%d %b, %H:%M'
+      default: "%a, %d %b %Y, %H:%M:%S %z"
+      long: "%d %B %Y, %H:%M"
+      short: "%d %b, %H:%M"
     pm: кичке

--- a/rails/locale/uk.yml
+++ b/rails/locale/uk.yml
@@ -1,3 +1,4 @@
+---
 uk:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ uk:
     - пт.
     - сб.
     abbr_month_names:
-    -
+    - 
     - січ.
     - лют.
     - бер.
@@ -31,11 +32,11 @@ uk:
     - п'ятниця
     - субота
     formats:
-      default: ! '%d.%m.%Y'
-      long: ! '%d %B %Y'
-      short: ! '%d %b'
+      default: "%d.%m.%Y"
+      long: "%d %B %Y"
+      short: "%d %b"
     month_names:
-    -
+    - 
     - Січня
     - Лютого
     - Березня
@@ -91,25 +92,25 @@ uk:
         one: більше %{count} року
         other: більше %{count} року
       x_days:
-        few: ! '%{count} дні'
-        many: ! '%{count} днів'
-        one: ! '%{count} день'
-        other: ! '%{count} дня'
+        few: "%{count} дні"
+        many: "%{count} днів"
+        one: "%{count} день"
+        other: "%{count} дня"
       x_minutes:
-        few: ! '%{count} хвилини'
-        many: ! '%{count} хвилин'
-        one: ! '%{count} хвилина'
-        other: ! '%{count} хвилини'
+        few: "%{count} хвилини"
+        many: "%{count} хвилин"
+        one: "%{count} хвилина"
+        other: "%{count} хвилини"
       x_months:
-        few: ! '%{count} місяці'
-        many: ! '%{count} місяців'
-        one: ! '%{count} місяць'
-        other: ! '%{count} місяця'
+        few: "%{count} місяці"
+        many: "%{count} місяців"
+        one: "%{count} місяць"
+        other: "%{count} місяця"
       x_seconds:
-        few: ! '%{count} секунди'
-        many: ! '%{count} секунд'
-        one: ! '%{count} секунда'
-        other: ! '%{count} секунди'
+        few: "%{count} секунди"
+        many: "%{count} секунд"
+        one: "%{count} секунда"
+        other: "%{count} секунди"
     prompts:
       day: День
       hour: Година
@@ -118,7 +119,7 @@ uk:
       second: Секунда
       year: Рік
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: має бути прийнятий
       blank: не може бути пустим
@@ -136,7 +137,7 @@ uk:
       not_a_number: не число
       not_an_integer: не э цілим числом
       odd: має бути непарним
-      record_invalid: ! 'Виникли помилки: %{errors}'
+      record_invalid: 'Виникли помилки: %{errors}'
       taken: вже зайнятий
       too_long:
         few: занадто довгий (максимум %{count} знаки)
@@ -154,15 +155,15 @@ uk:
         one: неправильна довжина (має бути %{count} знак)
         other: неправильна довжина (має бути %{count} знаку)
     template:
-      body: ! 'Помилки виявлено в таких полях:'
+      body: 'Помилки виявлено в таких полях:'
       header:
-        few: ! '%{model} не збережено через %{count} помилки'
-        many: ! '%{model} не збережено через %{count} помилок'
-        one: ! '%{model} не збережено через %{count} помилку'
-        other: ! '%{model} не збережено через %{count} помилки'
+        few: "%{model} не збережено через %{count} помилки"
+        many: "%{model} не збережено через %{count} помилок"
+        one: "%{model} не збережено через %{count} помилку"
+        other: "%{model} не збережено через %{count} помилки"
   helpers:
     select:
-      prompt: ! 'Оберіть: '
+      prompt: 'Оберіть: '
     submit:
       create: Створити %{model}
       submit: Зберегти %{model}
@@ -170,22 +171,22 @@ uk:
   number:
     currency:
       format:
-        delimiter: ! ' '
-        format: ! '%n %u'
+        delimiter: " "
+        format: "%n %u"
         precision: 2
-        separator: ! ','
+        separator: ","
         significant: false
         strip_insignificant_zeros: false
         unit: грн.
     format:
-      delimiter: ! ' '
+      delimiter: " "
       precision: 3
-      separator: ! ','
+      separator: ","
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion:
             few: Мільярдів
@@ -219,7 +220,7 @@ uk:
         significant: false
         strip_insignificant_zeros: false
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             few: байти
@@ -238,13 +239,13 @@ uk:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ' та '
-      two_words_connector: ! ' і '
-      words_connector: ! ', '
+      last_word_connector: " та "
+      two_words_connector: " і "
+      words_connector: ", "
   time:
     am: до полудня
     formats:
-      default: ! '%a, %d %b %Y, %H:%M:%S %z'
-      long: ! '%d %B %Y, %H:%M'
-      short: ! '%d %b, %H:%M'
+      default: "%a, %d %b %Y, %H:%M:%S %z"
+      long: "%d %B %Y, %H:%M"
+      short: "%d %b, %H:%M"
     pm: по полудні

--- a/rails/locale/ur.yml
+++ b/rails/locale/ur.yml
@@ -1,3 +1,4 @@
+---
 ur:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ ur:
     - جمعہ
     - ہفتہ
     abbr_month_names:
-    -
+    - 
     - جنوری
     - فروری
     - مارچ
@@ -31,11 +32,11 @@ ur:
     - جمعہ
     - ہفتہ
     formats:
-      default: ! '%d %B %Y'
-      long: ! '%B %d، %Y'
-      short: ! '%d %b'
+      default: "%d %B %Y"
+      long: "%B %d، %Y"
+      short: "%d %b"
     month_names:
-    -
+    - 
     - جنوری
     - فروری
     - مارچ
@@ -56,38 +57,38 @@ ur:
     distance_in_words:
       about_x_hours:
         one: تقریبا ایک گھنٹہ
-        other: ! 'تقریبا %{count} گھنٹے'
+        other: تقریبا %{count} گھنٹے
       about_x_months:
         one: تقریبا ایک مہینہ
-        other: ! 'تقریبا %{count} مہینہ'
+        other: تقریبا %{count} مہینہ
       about_x_years:
         one: تقریبا ایک سال
-        other: ! 'تقریبا %{count} سال'
+        other: تقریبا %{count} سال
       almost_x_years:
         one: تقریبا ایک سال
-        other: ! 'تقریبا %{count} سال'
+        other: تقریبا %{count} سال
       half_a_minute: آدھا منٹ
       less_than_x_minutes:
         one: ایک مںٹ سے کم
-        other: ! '%{count} مںٹوں سے کم'
+        other: "%{count} مںٹوں سے کم"
       less_than_x_seconds:
         one: ایک سیکنڈ سے کم
-        other: ! '%{count} سیکنڈوں سے کم'
+        other: "%{count} سیکنڈوں سے کم"
       over_x_years:
         one: ایک سال سے زیادہ
-        other: ! '%{count} سالوں سے زیادہ'
+        other: "%{count} سالوں سے زیادہ"
       x_days:
         one: ایک دن
-        other: ! '%{count} دن'
+        other: "%{count} دن"
       x_minutes:
         one: ایک منٹ
-        other: ! '%{count} منٹ'
+        other: "%{count} منٹ"
       x_months:
         one: ایک ماہ
-        other: ! '%{count} ماہ'
+        other: "%{count} ماہ"
       x_seconds:
-        one:  ایک سیکنڈ
-        other: ! '%{count} سیکنڈ'
+        one: ایک سیکنڈ
+        other: "%{count} سیکنڈ"
     prompts:
       day: دن
       hour: گھنٹہ
@@ -96,29 +97,30 @@ ur:
       second: سیکنڈ
       year: سال
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: قبول ہونا ضروری ہے
       blank: لازم ہے
       present: خالی ہونا ضروری ہے
-      confirmation: ! '%{attribute} میل نہیں رکھتا'
+      confirmation: "%{attribute} میل نہیں رکھتا"
       empty: لازم ہے
-      equal_to: ! '%{count} کے برابر ہونا چاہیے'
+      equal_to: "%{count} کے برابر ہونا چاہیے"
       even: جفت ہونا ضروری ہے
       exclusion: مخصوص ہے
-      greater_than: ! '%{count} سے زیادہ ہونا چاہیے'
-      greater_than_or_equal_to: ! '%{count} سے بڑا یا برابر ہونا چاہیے'
+      greater_than: "%{count} سے زیادہ ہونا چاہیے"
+      greater_than_or_equal_to: "%{count} سے بڑا یا برابر ہونا چاہیے"
       inclusion: فہرست میں شامل نہیں ہے
       invalid: باطل ہے
-      less_than: ! '%{count} سے کم ہونا چاہیے'
-      less_than_or_equal_to: ! '%{count} سے کم یا اس کے برابر ہونا چاہیے'
+      less_than: "%{count} سے کم ہونا چاہیے"
+      less_than_or_equal_to: "%{count} سے کم یا اس کے برابر ہونا چاہیے"
       not_a_number: ایک نمبر نہیں ہے
       not_an_integer: ایک عدد صحیح ہونا ضروری ہے
       odd: طاق ہونا ضروری ہے
-      record_invalid: ! 'توثیق میں نا کا می: %{errors}'
+      record_invalid: 'توثیق میں نا کا می: %{errors}'
       restrict_dependent_destroy:
-        one: "ایک منحصر %{record} کی موجودگی کے باعث اس ریکارڈ کو حذف نہیں کیا جا سکتا"
-        many: "چند منحصر %{record}  کی موجودگی کے باعث اس ریکارڈ کو حذف نہیں کیا جا سکتا"
+        one: ایک منحصر %{record} کی موجودگی کے باعث اس ریکارڈ کو حذف نہیں کیا جا سکتا
+        many: چند منحصر %{record}  کی موجودگی کے باعث اس ریکارڈ کو حذف نہیں کیا جا
+          سکتا
       taken: پہلے سے ہی استعمال میں ہے
       too_long:
         one: بہت طویل ہے (زیادہ سے زیادہ ایک حرف)
@@ -131,36 +133,36 @@ ur:
         other: غلط طوالت (%{count} حروف ہونے چاہئے)
       other_than: "%{count} کے علاوہ کسی اور کا ہونا لازمی ہے"
     template:
-      body: ! 'مندرجہ ذیل متن کے ساتھ مسائل ہیں:'
+      body: 'مندرجہ ذیل متن کے ساتھ مسائل ہیں:'
       header:
         one: ایک خرابی کے باعث یہ %{model} محفوظ نہیں کیا جا سکا
-        other: ! '%{count} خرابیوں کے باعث یہ %{model} محفوظ نہیں کیا جا سکا'
+        other: "%{count} خرابیوں کے باعث یہ %{model} محفوظ نہیں کیا جا سکا"
   helpers:
     select:
       prompt: منتخب کیجیے
     submit:
       create: "%{model} تشکیل دیں"
       submit: "%{model} محفوظ کریں"
-      update: "اپ ڈیٹ %{model}"
+      update: اپ ڈیٹ %{model}
   number:
     currency:
       format:
-        delimiter: ! ','
-        format: ! '%n %u'
+        delimiter: ","
+        format: "%n %u"
         precision: 2
-        separator: .
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
         unit: Rs
     format:
-      delimiter: ! ','
+      delimiter: ","
       precision: 0
-      separator: .
+      separator: "."
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           thousand: ہزار
           million: ملین
@@ -174,7 +176,7 @@ ur:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Byte
@@ -192,13 +194,13 @@ ur:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! '، اور '
-      two_words_connector: ! ' اور '
-      words_connector: ! '، '
+      last_word_connector: "، اور "
+      two_words_connector: " اور "
+      words_connector: "، "
   time:
     am: صبح
     pm: شام
     formats:
-      default: ! '%a، %d %b %Y، %p %l:%M %Z'
-      long: ! '%B %d، %Y %p %H:%M'
-      short: ! '%d %b، %H:%M'
+      default: "%a، %d %b %Y، %p %l:%M %Z"
+      long: "%B %d، %Y %p %H:%M"
+      short: "%d %b، %H:%M"

--- a/rails/locale/uz.yml
+++ b/rails/locale/uz.yml
@@ -1,3 +1,4 @@
+---
 uz:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ uz:
     - Ju
     - Sh
     abbr_month_names:
-    -
+    - 
     - yan.
     - fev.
     - mart
@@ -31,11 +32,11 @@ uz:
     - juma
     - shanba
     formats:
-      default: ! '%d.%m.%Y'
-      long: ! '%d %B %Y'
-      short: ! '%d %b'
+      default: "%d.%m.%Y"
+      long: "%d %B %Y"
+      short: "%d %b"
     month_names:
-    -
+    - 
     - yanvar
     - fevral
     - mart
@@ -76,40 +77,40 @@ uz:
         other: deyarli %{count} yil
       half_a_minute: bir daqiqadan kam
       less_than_x_minutes:
-        few: ! '%{count} daqiqadan kam'
-        many: ! '%{count} daqiqadan kam'
-        one: ! '%{count} daqiqadan kam'
-        other: ! '%{count} daqiqadan kam'
+        few: "%{count} daqiqadan kam"
+        many: "%{count} daqiqadan kam"
+        one: "%{count} daqiqadan kam"
+        other: "%{count} daqiqadan kam"
       less_than_x_seconds:
-        few: ! '%{count} soniyadan kam'
-        many: ! '%{count} soniyadan kam'
-        one: ! '%{count} soniyadan kam'
-        other: ! '%{count} soniyadan kam'
+        few: "%{count} soniyadan kam"
+        many: "%{count} soniyadan kam"
+        one: "%{count} soniyadan kam"
+        other: "%{count} soniyadan kam"
       over_x_years:
-        few: ! '%{count} yildan ziyod'
-        many: ! '%{count} yildan ziyod'
-        one: ! '%{count} yildan ziyod'
-        other: ! '%{count} yildan ziyod'
+        few: "%{count} yildan ziyod"
+        many: "%{count} yildan ziyod"
+        one: "%{count} yildan ziyod"
+        other: "%{count} yildan ziyod"
       x_days:
-        few: ! '%{count} kun'
-        many: ! '%{count} kun'
-        one: ! '%{count} kun'
-        other: ! '%{count} kun'
+        few: "%{count} kun"
+        many: "%{count} kun"
+        one: "%{count} kun"
+        other: "%{count} kun"
       x_minutes:
-        few: ! '%{count} daqiqa'
-        many: ! '%{count} daqiqa'
-        one: ! '%{count} daqiqa'
-        other: ! '%{count} daqiqa'
+        few: "%{count} daqiqa"
+        many: "%{count} daqiqa"
+        one: "%{count} daqiqa"
+        other: "%{count} daqiqa"
       x_months:
-        few: ! '%{count} oy'
-        many: ! '%{count} oy'
-        one: ! '%{count} oy'
-        other: ! '%{count} oy'
+        few: "%{count} oy"
+        many: "%{count} oy"
+        one: "%{count} oy"
+        other: "%{count} oy"
       x_seconds:
-        few: ! '%{count} soniya'
-        many: ! '%{count} soniya'
-        one: ! '%{count} soniyaа'
-        other: ! '%{count} soniya'
+        few: "%{count} soniya"
+        many: "%{count} soniya"
+        one: "%{count} soniyaа"
+        other: "%{count} soniya"
     prompts:
       day: kun
       hour: soat
@@ -118,25 +119,25 @@ uz:
       second: soniya
       year: yil
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: tasdiqlash kerak
       blank: bush bulishi mumkin emas
       confirmation: tasdiq bilan mos emas
       empty: bush bulishi mumkin emas
-      equal_to: ! '%{count} ga teng'
+      equal_to: "%{count} ga teng"
       even: juft sonlar mumkin
       exclusion: mumkin emas
-      greater_than: ! '%{count} dan yuqori'
-      greater_than_or_equal_to: ! '%{count} ga teng yoki yuqori'
+      greater_than: "%{count} dan yuqori"
+      greater_than_or_equal_to: "%{count} ga teng yoki yuqori"
       inclusion: kutilmagan natija
       invalid: notugri
-      less_than: ! '%{count} dan kam'
-      less_than_or_equal_to: ! '%{count} ga teng yoki kam'
+      less_than: "%{count} dan kam"
+      less_than_or_equal_to: "%{count} ga teng yoki kam"
       not_a_number: son emas
       not_an_integer: butun son emas
       odd: toq sonlar mumkin
-      record_invalid: ! '%{errors} ta hato bor.'
+      record_invalid: "%{errors} ta hato bor."
       taken: band
       too_long:
         few: uzunligi yetarligidan ortiq (%{count} ta simvoldan yuqori mumkin emas)
@@ -154,15 +155,15 @@ uz:
         one: uzunligi notugri (uzunligi %{count} simvolga teng bulishi kerak)
         other: uzunligi notugri (uzunligi %{count} simvolga teng bulishi kerak)
     template:
-      body: ! 'Quyidagilarda hatolar mavjud:'
+      body: 'Quyidagilarda hatolar mavjud:'
       header:
-        few: ! '%{count} ta hatolar sababli %{model}:ni saqlab bulmadi'
-        many: ! '%{count} ta hatolar sababli %{model}:ni saqlab bulmadi'
-        one: ! '%{count} ta hato sababli %{model}:ni saqlab bulmadi'
-        other: ! '%{count} ta hatolar sababli %{model}:ni saqlab bulmadi'
+        few: "%{count} ta hatolar sababli %{model}:ni saqlab bulmadi"
+        many: "%{count} ta hatolar sababli %{model}:ni saqlab bulmadi"
+        one: "%{count} ta hato sababli %{model}:ni saqlab bulmadi"
+        other: "%{count} ta hatolar sababli %{model}:ni saqlab bulmadi"
   helpers:
     select:
-      prompt: ! 'Tanlang: '
+      prompt: 'Tanlang: '
     submit:
       create: Yarat %{model}
       submit: Saqla %{model}
@@ -170,22 +171,22 @@ uz:
   number:
     currency:
       format:
-        delimiter: ! ' '
-        format: ! '%n %u'
+        delimiter: " "
+        format: "%n %u"
         precision: 2
-        separator: .
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
         unit: sum.
     format:
-      delimiter: ! ' '
+      delimiter: " "
       precision: 3
-      separator: .
+      separator: "."
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion:
             few: milliard
@@ -219,7 +220,7 @@ uz:
         significant: false
         strip_insignificant_zeros: false
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             few: bayt
@@ -238,13 +239,13 @@ uz:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ' va '
-      two_words_connector: ! ' va '
-      words_connector: ! ', '
+      last_word_connector: " va "
+      two_words_connector: " va "
+      words_connector: ", "
   time:
     am: ertalab
     formats:
-      default: ! '%a, %d %b %Y, %H:%M:%S %z'
-      long: ! '%d %B %Y, %H:%M'
-      short: ! '%d %b, %H:%M'
+      default: "%a, %d %b %Y, %H:%M:%S %z"
+      long: "%d %B %Y, %H:%M"
+      short: "%d %b, %H:%M"
     pm: kechasi

--- a/rails/locale/vi.yml
+++ b/rails/locale/vi.yml
@@ -1,3 +1,4 @@
+---
 vi:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ vi:
     - Thứ sáu
     - Thứ bảy
     abbr_month_names:
-    -
+    - 
     - Tháng một
     - Tháng hai
     - Tháng ba
@@ -31,11 +32,11 @@ vi:
     - Thứ sáu
     - Thứ bảy
     formats:
-      default: ! '%d-%m-%Y'
-      long: ! '%d %B, %Y'
-      short: ! '%d %b'
+      default: "%d-%m-%Y"
+      long: "%d %B, %Y"
+      short: "%d %b"
     month_names:
-    -
+    - 
     - Tháng một
     - Tháng hai
     - Tháng ba
@@ -78,16 +79,16 @@ vi:
         other: hơn %{count} năm
       x_days:
         one: 1 ngày
-        other: ! '%{count} ngày'
+        other: "%{count} ngày"
       x_minutes:
         one: 1 phút
-        other: ! '%{count} phút'
+        other: "%{count} phút"
       x_months:
         one: 1 tháng
-        other: ! '%{count} tháng'
+        other: "%{count} tháng"
       x_seconds:
         one: 1 giây
-        other: ! '%{count} giây'
+        other: "%{count} giây"
     prompts:
       day: Ngày
       hour: Giờ
@@ -96,7 +97,7 @@ vi:
       second: Giây
       year: Năm
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: phải được đồng ý
       blank: không thể để trắng
@@ -115,20 +116,20 @@ vi:
       not_a_number: không phải là số
       not_an_integer: phải là một số nguyên
       odd: phải là số lẻ
-      record_invalid: ! 'Có các lỗi sau: %{errors}'
+      record_invalid: 'Có các lỗi sau: %{errors}'
       restrict_dependent_destroy:
-        one: "Không thể xóa do tồn tại đối tượng phụ thuộc %{record}"
-        many: "Không thể xóa do tồn tại một số đối tượng phụ thuộc %{record}"
+        one: Không thể xóa do tồn tại đối tượng phụ thuộc %{record}
+        many: Không thể xóa do tồn tại một số đối tượng phụ thuộc %{record}
       taken: đã có
       too_long: quá dài (tối đa %{count} ký tự)
       too_short: quá ngắn (tối thiểu %{count} ký tự)
       wrong_length: độ dài không đúng (phải là %{count} ký tự)
-      other_than: "cần phải khác %{count}"
+      other_than: cần phải khác %{count}
     template:
-      body: ! 'Có lỗi với các mục sau:'
+      body: 'Có lỗi với các mục sau:'
       header:
         one: 1 lỗi ngăn không cho lưu %{model} này
-        other: ! '%{count} lỗi ngăn không cho lưu %{model} này'
+        other: "%{count} lỗi ngăn không cho lưu %{model} này"
   helpers:
     select:
       prompt: Vui lòng chọn
@@ -139,22 +140,22 @@ vi:
   number:
     currency:
       format:
-        delimiter: .
-        format: ! '%n %u'
+        delimiter: "."
+        format: "%n %u"
         precision: 2
-        separator: ! ','
+        separator: ","
         significant: false
         strip_insignificant_zeros: false
         unit: đồng
     format:
-      delimiter: .
+      delimiter: "."
       precision: 3
-      separator: ! ','
+      separator: ","
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           unit: ''
           billion: Tỷ
@@ -168,7 +169,7 @@ vi:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Byte
@@ -186,13 +187,13 @@ vi:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ', và '
-      two_words_connector: ! ' và '
-      words_connector: ! ', '
+      last_word_connector: ", và "
+      two_words_connector: " và "
+      words_connector: ", "
   time:
     am: sáng
     formats:
-      default: ! '%a, %d %b %Y %H:%M:%S %z'
-      long: ! '%d %B, %Y %H:%M'
-      short: ! '%d %b %H:%M'
+      default: "%a, %d %b %Y %H:%M:%S %z"
+      long: "%d %B, %Y %H:%M"
+      short: "%d %b %H:%M"
     pm: chiều

--- a/rails/locale/wo.yml
+++ b/rails/locale/wo.yml
@@ -1,3 +1,4 @@
+---
 wo:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ wo:
     - Ajj
     - Gaw
     abbr_month_names:
-    -
+    - 
     - Jan
     - Feb
     - Mar
@@ -31,11 +32,11 @@ wo:
     - Ajjouma
     - Gaawu
     formats:
-      default: ! '%Y-%m-%d'
-      long: ! '%B %d, %Y'
-      short: ! '%b %d'
+      default: "%Y-%m-%d"
+      long: "%B %d, %Y"
+      short: "%b %d"
     month_names:
-    -
+    - 
     - Tamkharit
     - Digui Gamou
     - Gamou
@@ -78,16 +79,16 @@ wo:
         other: over %{count} years
       x_days:
         one: 1 day
-        other: ! '%{count} days'
+        other: "%{count} days"
       x_minutes:
         one: 1 minute
-        other: ! '%{count} minutes'
+        other: "%{count} minutes"
       x_months:
         one: 1 month
-        other: ! '%{count} months'
+        other: "%{count} months"
       x_seconds:
         one: 1 second
-        other: ! '%{count} seconds'
+        other: "%{count} seconds"
     prompts:
       day: Day
       hour: Hour
@@ -96,11 +97,11 @@ wo:
       second: Seconds
       year: Year
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: must be accepted
       blank: can't be blank
-      confirmation: ! "doesn't match %{attribute}"
+      confirmation: doesn't match %{attribute}
       empty: can't be empty
       equal_to: must be equal to %{count}
       even: must be even
@@ -114,7 +115,7 @@ wo:
       not_a_number: is not a number
       not_an_integer: must be an integer
       odd: must be odd
-      record_invalid: ! 'Validation failed: %{errors}'
+      record_invalid: 'Validation failed: %{errors}'
       taken: has already been taken
       too_long:
         one: is too long (maximum is 1 character)
@@ -126,10 +127,10 @@ wo:
         one: is the wrong length (should be 1 character)
         other: is the wrong length (should be %{count} characters)
     template:
-      body: ! 'There were problems with the following fields:'
+      body: 'There were problems with the following fields:'
       header:
         one: 1 error prohibited this %{model} from being saved
-        other: ! '%{count} errors prohibited this %{model} from being saved'
+        other: "%{count} errors prohibited this %{model} from being saved"
   helpers:
     select:
       prompt: Please select
@@ -140,22 +141,22 @@ wo:
   number:
     currency:
       format:
-        delimiter: ! ','
-        format: ! '%u%n'
+        delimiter: ","
+        format: "%u%n"
         precision: 2
-        separator: .
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
-        unit: $
+        unit: "$"
     format:
-      delimiter: ! ','
+      delimiter: ","
       precision: 3
-      separator: .
+      separator: "."
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: Billion
           million: Million
@@ -169,7 +170,7 @@ wo:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Byte
@@ -186,13 +187,13 @@ wo:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ', and '
-      two_words_connector: ! ' and '
-      words_connector: ! ', '
+      last_word_connector: ", and "
+      two_words_connector: " and "
+      words_connector: ", "
   time:
     am: am
     formats:
-      default: ! '%a, %d %b %Y %H:%M:%S %z'
-      long: ! '%B %d, %Y %H:%M'
-      short: ! '%d %b %H:%M'
+      default: "%a, %d %b %Y %H:%M:%S %z"
+      long: "%B %d, %Y %H:%M"
+      short: "%d %b %H:%M"
     pm: pm

--- a/rails/locale/zh-CN.yml
+++ b/rails/locale/zh-CN.yml
@@ -1,3 +1,4 @@
+---
 zh-CN:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ zh-CN:
     - 周五
     - 周六
     abbr_month_names:
-    -
+    - 
     - 1月
     - 2月
     - 3月
@@ -31,11 +32,11 @@ zh-CN:
     - 星期五
     - 星期六
     formats:
-      default: ! '%Y-%m-%d'
-      long: ! '%Y年%b%d日'
-      short: ! '%b%d日'
+      default: "%Y-%m-%d"
+      long: "%Y年%b%d日"
+      short: "%b%d日"
     month_names:
-    -
+    - 
     - 一月
     - 二月
     - 三月
@@ -75,19 +76,19 @@ zh-CN:
         other: 不到 %{count} 秒
       over_x_years:
         one: 一年多
-        other: ! '%{count} 年多'
+        other: "%{count} 年多"
       x_days:
         one: 一天
-        other: ! '%{count} 天'
+        other: "%{count} 天"
       x_minutes:
         one: 一分钟
-        other: ! '%{count} 分钟'
+        other: "%{count} 分钟"
       x_months:
         one: 一个月
-        other: ! '%{count} 个月'
+        other: "%{count} 个月"
       x_seconds:
         one: 一秒
-        other: ! '%{count} 秒'
+        other: "%{count} 秒"
     prompts:
       day: 日
       hour: 时
@@ -96,7 +97,7 @@ zh-CN:
       second: 秒
       year: 年
   errors:
-    format: ! '%{attribute}%{message}'
+    format: "%{attribute}%{message}"
     messages:
       accepted: 必须是可被接受的
       blank: 不能为空字符
@@ -115,7 +116,7 @@ zh-CN:
       not_a_number: 不是数字
       not_an_integer: 必须是整数
       odd: 必须为单数
-      record_invalid: ! '验证失败: %{errors}'
+      record_invalid: '验证失败: %{errors}'
       restrict_dependent_destroy:
         one: 由于 %{record} 需要此记录，所以无法移除记录
         many: 由于 %{record} 需要此记录，所以无法移除记录
@@ -145,22 +146,22 @@ zh-CN:
   number:
     currency:
       format:
-        delimiter: ! ','
-        format: ! '%u %n'
+        delimiter: ","
+        format: "%u %n"
         precision: 2
-        separator: .
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
         unit: CN¥
     format:
-      delimiter: ! ','
+      delimiter: ","
       precision: 3
-      separator: .
+      separator: "."
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: 十亿
           million: 百万
@@ -174,7 +175,7 @@ zh-CN:
         significant: false
         strip_insignificant_zeros: false
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Byte
@@ -191,13 +192,13 @@ zh-CN:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ', 和 '
-      two_words_connector: ! ' 和 '
-      words_connector: ! ', '
+      last_word_connector: ", 和 "
+      two_words_connector: " 和 "
+      words_connector: ", "
   time:
     am: 上午
     formats:
-      default: ! '%Y年%b%d日 %A %H:%M:%S %Z'
-      long: ! '%Y年%b%d日 %H:%M'
-      short: ! '%b%d日 %H:%M'
+      default: "%Y年%b%d日 %A %H:%M:%S %Z"
+      long: "%Y年%b%d日 %H:%M"
+      short: "%b%d日 %H:%M"
     pm: 下午

--- a/rails/locale/zh-HK.yml
+++ b/rails/locale/zh-HK.yml
@@ -1,3 +1,4 @@
+---
 zh-HK:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ zh-HK:
     - 周五
     - 周六
     abbr_month_names:
-    -
+    - 
     - 1月
     - 2月
     - 3月
@@ -31,11 +32,11 @@ zh-HK:
     - 星期五
     - 星期六
     formats:
-      default: ! '%Y-%m-%d'
-      long: ! '%Y年%b%d日'
-      short: ! '%b%d日'
+      default: "%Y-%m-%d"
+      long: "%Y年%b%d日"
+      short: "%b%d日"
     month_names:
-    -
+    - 
     - 一月
     - 二月
     - 三月
@@ -78,16 +79,16 @@ zh-HK:
         other: 超過%{count}年
       x_days:
         one: 一天
-        other: ! '%{count}天'
+        other: "%{count}天"
       x_minutes:
         one: 一分鐘
-        other: ! '%{count}分鐘'
+        other: "%{count}分鐘"
       x_months:
         one: 一個月
-        other: ! '%{count}個月'
+        other: "%{count}個月"
       x_seconds:
         one: 一秒
-        other: ! '%{count}秒'
+        other: "%{count}秒"
     prompts:
       day: 日
       hour: 時
@@ -96,30 +97,30 @@ zh-HK:
       second: 秒
       year: 年
   errors:
-    format: ! '%{message}'
+    format: "%{message}"
     messages:
       accepted: 必定要接受%{attribute}
-      blank: ! '%{attribute}不可以是空白'
-      present: ! '%{attribute}必定要是空白'
-      confirmation: ! '不符合%{attribute}'
-      empty: ! '%{attribute}不可以留空'
-      equal_to: ! '%{attribute}必須等於%{count}'
-      even: ! '%{attribute}必須要是雙數'
-      exclusion: ! '%{attribute}是被保留的關鍵字'
-      greater_than: ! '%{attribute}必須大於%{count}'
-      greater_than_or_equal_to: ! '%{attribute}必須大於或等於%{count}'
-      inclusion: ! '%{attribute}沒有包含在列表中'
-      invalid: ! '%{attribute}是無效的'
-      less_than: ! '%{attribute}必須小於%{count}'
-      less_than_or_equal_to: ! '%{attribute}必須小於或等於%{count}'
-      not_a_number: ! '%{attribute}不是數字'
-      not_an_integer: ! '%{attribute}必須是整數'
-      odd: ! '%{attribute}必須是單數'
-      record_invalid: ! '%{attribute}驗證失敗︰%{errors}'
+      blank: "%{attribute}不可以是空白"
+      present: "%{attribute}必定要是空白"
+      confirmation: 不符合%{attribute}
+      empty: "%{attribute}不可以留空"
+      equal_to: "%{attribute}必須等於%{count}"
+      even: "%{attribute}必須要是雙數"
+      exclusion: "%{attribute}是被保留的關鍵字"
+      greater_than: "%{attribute}必須大於%{count}"
+      greater_than_or_equal_to: "%{attribute}必須大於或等於%{count}"
+      inclusion: "%{attribute}沒有包含在列表中"
+      invalid: "%{attribute}是無效的"
+      less_than: "%{attribute}必須小於%{count}"
+      less_than_or_equal_to: "%{attribute}必須小於或等於%{count}"
+      not_a_number: "%{attribute}不是數字"
+      not_an_integer: "%{attribute}必須是整數"
+      odd: "%{attribute}必須是單數"
+      record_invalid: "%{attribute}驗證失敗︰%{errors}"
       restrict_dependent_destroy:
         one: 由於%{record}依賴此記錄，無法移除
         many: 由於%{record}依賴此記錄，無法移除
-      taken: ! '%{attribute}已被使用'
+      taken: "%{attribute}已被使用"
       too_long:
         one: 太長（最長為一個字元）
         other: 太長（最長為%{count}個字元）
@@ -129,7 +130,7 @@ zh-HK:
       wrong_length:
         one: 字數錯誤 (應為一個字元)
         other: 字數錯誤 (應為%{count}個字元)
-      other_than: ! '%{attribute}唔可以係%{count}'
+      other_than: "%{attribute}唔可以係%{count}"
     template:
       body: 以下欄位發生問題︰
       header:
@@ -145,22 +146,22 @@ zh-HK:
   number:
     currency:
       format:
-        delimiter: ! ','
-        format: ! '%u %n'
+        delimiter: ","
+        format: "%u %n"
         precision: 2
-        separator: .
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
         unit: HK$
     format:
-      delimiter: ! ','
+      delimiter: ","
       precision: 3
-      separator: .
+      separator: "."
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: 十億
           million: 百萬
@@ -174,7 +175,7 @@ zh-HK:
         significant: false
         strip_insignificant_zeros: false
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Byte
@@ -186,19 +187,19 @@ zh-HK:
     percentage:
       format:
         delimiter: ''
-        format: '%n%'
+        format: "%n%"
     precision:
       format:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! '和'
-      two_words_connector: ! '和'
-      words_connector: 、
+      last_word_connector: 和
+      two_words_connector: 和
+      words_connector: "、"
   time:
     am: 上午
     formats:
-      default: ! '%Y年%b%d日 %A %H:%M:%S %Z'
-      long: ! '%Y年%b%d日 %H:%M'
-      short: ! '%b%d日 %H:%M'
+      default: "%Y年%b%d日 %A %H:%M:%S %Z"
+      long: "%Y年%b%d日 %H:%M"
+      short: "%b%d日 %H:%M"
     pm: 下午

--- a/rails/locale/zh-TW.yml
+++ b/rails/locale/zh-TW.yml
@@ -1,3 +1,4 @@
+---
 zh-TW:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ zh-TW:
     - 周五
     - 周六
     abbr_month_names:
-    -
+    - 
     - 1月
     - 2月
     - 3月
@@ -31,11 +32,11 @@ zh-TW:
     - 星期五
     - 星期六
     formats:
-      default: ! '%Y-%m-%d'
-      long: ! '%Y年%b%d日'
-      short: ! '%b%d日'
+      default: "%Y-%m-%d"
+      long: "%Y年%b%d日"
+      short: "%b%d日"
     month_names:
-    -
+    - 
     - 一月
     - 二月
     - 三月
@@ -75,19 +76,19 @@ zh-TW:
         other: 不到 %{count} 秒
       over_x_years:
         one: 一年多
-        other: ! '%{count} 年多'
+        other: "%{count} 年多"
       x_days:
         one: 一天
-        other: ! '%{count} 天'
+        other: "%{count} 天"
       x_minutes:
         one: 一分鐘
-        other: ! '%{count} 分鐘'
+        other: "%{count} 分鐘"
       x_months:
         one: 一個月
-        other: ! '%{count} 個月'
+        other: "%{count} 個月"
       x_seconds:
         one: 一秒
-        other: ! '%{count} 秒'
+        other: "%{count} 秒"
     prompts:
       day: 日
       hour: 時
@@ -96,7 +97,7 @@ zh-TW:
       second: 秒
       year: 年
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: 必須是可被接受的
       blank: 不能是空白字元
@@ -115,7 +116,7 @@ zh-TW:
       not_a_number: 不是數字
       not_an_integer: 必須是整數
       odd: 必須是奇數
-      record_invalid: ! '校驗失敗: %{errors}'
+      record_invalid: '校驗失敗: %{errors}'
       restrict_dependent_destroy:
         one: 由於 %{record} 需要此記錄，所以無法移除記錄
         many: 由於 %{record} 需要此記錄，所以無法移除記錄
@@ -145,22 +146,22 @@ zh-TW:
   number:
     currency:
       format:
-        delimiter: ! ','
-        format: ! '%u %n'
+        delimiter: ","
+        format: "%u %n"
         precision: 2
-        separator: .
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
         unit: NT$
     format:
-      delimiter: ! ','
+      delimiter: ","
       precision: 3
-      separator: .
+      separator: "."
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: 十億
           million: 百萬
@@ -174,7 +175,7 @@ zh-TW:
         significant: false
         strip_insignificant_zeros: false
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: 位元組
@@ -191,13 +192,13 @@ zh-TW:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ', 和 '
-      two_words_connector: ! ' 和 '
-      words_connector: ! ', '
+      last_word_connector: ", 和 "
+      two_words_connector: " 和 "
+      words_connector: ", "
   time:
     am: 上午
     formats:
-      default: ! '%Y年%b%d日 %A %H:%M:%S %Z'
-      long: ! '%Y年%b%d日 %H:%M'
-      short: ! '%b%d日 %H:%M'
+      default: "%Y年%b%d日 %A %H:%M:%S %Z"
+      long: "%Y年%b%d日 %H:%M"
+      short: "%b%d日 %H:%M"
     pm: 下午

--- a/rails/locale/zh-YUE.yml
+++ b/rails/locale/zh-YUE.yml
@@ -1,3 +1,4 @@
+---
 zh-YUE:
   date:
     abbr_day_names:
@@ -9,7 +10,7 @@ zh-YUE:
     - 周五
     - 周六
     abbr_month_names:
-    -
+    - 
     - 1月
     - 2月
     - 3月
@@ -31,11 +32,11 @@ zh-YUE:
     - 星期五
     - 星期六
     formats:
-      default: ! '%Y-%m-%d'
-      long: ! '%Y年%b%d日'
-      short: ! '%b%d日'
+      default: "%Y-%m-%d"
+      long: "%Y年%b%d日"
+      short: "%b%d日"
     month_names:
-    -
+    - 
     - 一月
     - 二月
     - 三月
@@ -78,16 +79,16 @@ zh-YUE:
         other: 超過%{count}年
       x_days:
         one: 一日
-        other: ! '%{count}日'
+        other: "%{count}日"
       x_minutes:
         one: 一分鐘
-        other: ! '%{count}分鐘'
+        other: "%{count}分鐘"
       x_months:
         one: 一個月
-        other: ! '%{count}個月'
+        other: "%{count}個月"
       x_seconds:
         one: 一秒
-        other: ! '%{count}秒'
+        other: "%{count}秒"
     prompts:
       day: 日
       hour: 點
@@ -96,30 +97,30 @@ zh-YUE:
       second: 秒
       year: 年
   errors:
-    format: ! '%{message}'
+    format: "%{message}"
     messages:
       accepted: 一定要接受%{attribute}
-      blank: ! '%{attribute}唔可以空白'
-      present: ! '%{attribute}要空白'
-      confirmation: ! '%{attribute}唔夾'
-      empty: ! '%{attribute}唔可以漏空'
-      equal_to: ! '%{attribute}要係%{count}'
-      even: ! '%{attribute}要係雙數'
-      exclusion: ! '%{attribute}唔用得'
-      greater_than: ! '%{attribute}要大過%{count}'
-      greater_than_or_equal_to: ! '%{attribute}要大過或者等於%{count}'
-      inclusion: ! '%{attribute}唔喺表入面'
-      invalid: ! '%{attribute}無效'
-      less_than: ! '%{attribute}要細過%{count}'
-      less_than_or_equal_to: ! '%{attribute}要細過或者等於%{count}'
-      not_a_number: ! '%{attribute}唔係一個數'
-      not_an_integer: ! '%{attribute}要係整數'
-      odd: ! '%{attribute}要係單數'
-      record_invalid: ! '%{attribute}有問題︰%{errors}'
+      blank: "%{attribute}唔可以空白"
+      present: "%{attribute}要空白"
+      confirmation: "%{attribute}唔夾"
+      empty: "%{attribute}唔可以漏空"
+      equal_to: "%{attribute}要係%{count}"
+      even: "%{attribute}要係雙數"
+      exclusion: "%{attribute}唔用得"
+      greater_than: "%{attribute}要大過%{count}"
+      greater_than_or_equal_to: "%{attribute}要大過或者等於%{count}"
+      inclusion: "%{attribute}唔喺表入面"
+      invalid: "%{attribute}無效"
+      less_than: "%{attribute}要細過%{count}"
+      less_than_or_equal_to: "%{attribute}要細過或者等於%{count}"
+      not_a_number: "%{attribute}唔係一個數"
+      not_an_integer: "%{attribute}要係整數"
+      odd: "%{attribute}要係單數"
+      record_invalid: "%{attribute}有問題︰%{errors}"
       restrict_dependent_destroy:
         one: 唔可以刪除，因為%{record}要用佢
         many: 唔可以刪除，因為%{record}要用佢
-      taken: ! '%{attribute}已經用過'
+      taken: "%{attribute}已經用過"
       too_long:
         one: 太長（最多1個字）
         other: 太長（最多%{count}個字）
@@ -129,7 +130,7 @@ zh-YUE:
       wrong_length:
         one: 唔啱字數 (要係1個字)
         other: 唔啱字數 (要係%{count}個字)
-      other_than: ! '%{attribute}唔可以係%{count}'
+      other_than: "%{attribute}唔可以係%{count}"
     template:
       body: 呢啲有問題︰
       header:
@@ -145,22 +146,22 @@ zh-YUE:
   number:
     currency:
       format:
-        delimiter: ! ','
-        format: ! '%u %n'
+        delimiter: ","
+        format: "%u %n"
         precision: 2
-        separator: .
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
         unit: HK$
     format:
-      delimiter: ! ','
+      delimiter: ","
       precision: 3
-      separator: .
+      separator: "."
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: 十億
           million: 百萬
@@ -174,7 +175,7 @@ zh-YUE:
         significant: false
         strip_insignificant_zeros: false
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Byte
@@ -186,7 +187,7 @@ zh-YUE:
     percentage:
       format:
         delimiter: ''
-        format: '%n%'
+        format: "%n%"
     precision:
       format:
         delimiter: ''
@@ -194,11 +195,11 @@ zh-YUE:
     array:
       last_word_connector: 同
       two_words_connector: 同
-      words_connector: 、
+      words_connector: "、"
   time:
     am: 上晝
     formats:
-      default: ! '%Y年%b%d號 %A %H:%M:%S %Z'
-      long: ! '%Y年%b%d號 %H:%M'
-      short: ! '%b%d號 %H:%M'
+      default: "%Y年%b%d號 %A %H:%M:%S %Z"
+      long: "%Y年%b%d號 %H:%M"
+      short: "%b%d號 %H:%M"
     pm: 下晝


### PR DESCRIPTION
This changes are done by [Psych](https://rubygems.org/gems/psych) (version 2.0.13).

List of changes:
- add `---` mark (to signal the start of a document if no directives are present)
- comments are removed
- replace single quotation marks with double quotation marks
- add space to empty keys. I don't know if this is necessary, but I'll leave it as a part of automated Psych parsing