### PR TITLE
Fix Croatian currency format

### DIFF
--- a/rails/locale/hr.yml
+++ b/rails/locale/hr.yml
@@ -175,10 +175,10 @@ hr:
   number:
     currency:
       format:
-        delimiter: ! ','
+        delimiter: ! '.'
         format: ! '%n %u'
         precision: 2
-        separator: .
+        separator: ,
         significant: false
         strip_insignificant_zeros: false
         unit: kn

--- a/rails/locale/hr.yml
+++ b/rails/locale/hr.yml
@@ -178,7 +178,7 @@ hr:
         delimiter: ! '.'
         format: ! '%n %u'
         precision: 2
-        separator: ,
+        separator: ','
         significant: false
         strip_insignificant_zeros: false
         unit: kn


### PR DESCRIPTION
It was invalid: it used decimal point instead of comma.