### PR TITLE
[hr.yml] Update currency format

### DIFF
--- a/rails/locale/hr.yml
+++ b/rails/locale/hr.yml
@@ -176,10 +176,10 @@ hr:
   number:
     currency:
       format:
-        delimiter: ","
+        delimiter: "."
         format: "%n %u"
         precision: 2
-        separator: "."
+        separator: ","
         significant: false
         strip_insignificant_zeros: false
         unit: kn


### PR DESCRIPTION
The Croatian locale did not provide the correct currency format (decimal comma and period as the thousands' delimiter).