### PR TITLE
The currency format and delimiter for PT locale (Portugal) is WRONG.

### DIFF
--- a/rails/locale/pt.yml
+++ b/rails/locale/pt.yml
@@ -135,8 +135,8 @@ pt:
   number:
     currency:
       format:
-        delimiter: "."
-        format: "%u%n"
+        delimiter: " "
+        format: "%n %u"
         precision: 2
         separator: ","
         significant: false


### PR DESCRIPTION
The typographic guide for Portugal is for example '1 000,00 €' and not '€1.000.00'. You can verify this by consulting the official EU guide for Portugal:
http://publications.europa.eu/code/pt/pt-370303.htm

Attention: If you change the locale on the page http://publications.europa.eu/code/pt/pt-370303.htm to English (en), they will change the convention for UK convention which it's different that the Portugal convention (I don't know why they do that...).

Another simple way to verify this, if you have Mac OS X, go to Settings, Language and Region and change the region to Portugal or add Portuguese (Portugal) language. See the example that is returned. 

Please correct this. Thank you.