### PR TITLE
Add space before "%" percentage sign

### DIFF
--- a/rails/locale/de.yml
+++ b/rails/locale/de.yml
@@ -186,7 +186,7 @@ de:
     percentage:
       format:
         delimiter: ''
-        format: "%n%"
+        format: "%n %"
     precision:
       format:
         delimiter: ''


### PR DESCRIPTION
In German, the rule is to have a space before the percentage sign.

Reference a: http://www.duden.de/rechtschreibung/Prozent `Beispiel: 5 Prozent oder 5 %`
Reference b: http://de.wikipedia.org/wiki/Prozentzeichen `Wie bei Maßeinheiten wird zwischen die Zahl und das Prozentzeichen ein geschütztes Leerzeichen gesetzt (siehe Schreibweise von Zahlen).[7] Der Duden empfiehlt hier, einen kleineren, festen Zwischenraum zu verwenden.[8]`

Even better would be to use a non breaking space but that would break a lot of views, so I changed it to a simple space here.