### PR TITLE
french locales confirmation error now takes %{attribute} into account

### DIFF
--- a/rails/locale/fr-CA.yml
+++ b/rails/locale/fr-CA.yml
@@ -103,7 +103,7 @@ fr-CA:
     messages:
       accepted: doit être accepté(e)
       blank: doit être rempli(e)
-      confirmation: ne concorde pas avec la confirmation
+      confirmation: ne concorde pas avec %{attribute}
       empty: doit être rempli(e)
       equal_to: doit être égal à %{count}
       even: doit être pair

--- a/rails/locale/fr-CH.yml
+++ b/rails/locale/fr-CH.yml
@@ -103,7 +103,7 @@ fr-CH:
     messages:
       accepted: doit être accepté(e)
       blank: doit être rempli(e)
-      confirmation: ne concorde pas avec la confirmation
+      confirmation: ne concorde pas avec %{attribute}
       empty: doit être rempli(e)
       equal_to: doit être égal à %{count}
       even: doit être pair

--- a/rails/locale/fr.yml
+++ b/rails/locale/fr.yml
@@ -104,7 +104,7 @@ fr:
       accepted: doit être accepté(e)
       blank: doit être rempli(e)
       present: doit être vide
-      confirmation: ne concorde pas avec la confirmation
+      confirmation: ne concorde pas avec %{attribute}
       empty: doit être rempli(e)
       equal_to: doit être égal à %{count}
       even: doit être pair


### PR DESCRIPTION
Current translation create weird message like "password_confirmation does not match with confirmation" all other locales (en de ...) rely on %{attribute} to have "password_confirmation does not match %{attribute}" but not the fr version.

This is not perfect due to capitalization or type (la, le, un, une) but not weirder than the rest of the translated errors anyway. This is a better default.