### PR TITLE
Spanish does not have Serial comma

### DIFF
--- a/rails/locale/es-CL.yml
+++ b/rails/locale/es-CL.yml
@@ -181,7 +181,7 @@ es-CL:
         delimiter: ''
   support:
     array:
-      last_word_connector: ", y "
+      last_word_connector: " y "
       two_words_connector: " y "
       words_connector: ", "
   time:

--- a/rails/locale/es-VE.yml
+++ b/rails/locale/es-VE.yml
@@ -187,7 +187,7 @@ es-VE:
         delimiter: ","
   support:
     array:
-      last_word_connector: ", y "
+      last_word_connector: " y "
       two_words_connector: " y "
       words_connector: ", "
   time:

--- a/rails/locale/es.yml
+++ b/rails/locale/es.yml
@@ -181,7 +181,7 @@ es:
         delimiter: ''
   support:
     array:
-      last_word_connector: ", y "
+      last_word_connector: " y "
       two_words_connector: " y "
       words_connector: ", "
   time:


### PR DESCRIPTION
Hi,

Spanish does not have [Serial comma](http://en.wikipedia.org/wiki/Serial_comma). You can take a look to [RAE](http://lema.rae.es/dpd/?key=coma2&lema=coma2) (note: is in Spanish)