### PR TITLE
fix SI byte values, especially 'kB' with lowercase 'k'

### DIFF
--- a/rails/locale/af.yml
+++ b/rails/locale/af.yml
@@ -10,7 +10,7 @@ af:
     - Vry
     - Sat
     abbr_month_names:
-    - 
+    -
     - Jan
     - Feb
     - Mar
@@ -36,7 +36,7 @@ af:
       long: "%B %d, %Y"
       short: "%b %d"
     month_names:
-    - 
+    -
     - Januarie
     - Februarie
     - Maart
@@ -176,7 +176,7 @@ af:
             one: Byte
             other: Bytes
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/ar.yml
+++ b/rails/locale/ar.yml
@@ -10,7 +10,7 @@ ar:
     - الجمعة
     - السبت
     abbr_month_names:
-    - 
+    -
     - يناير
     - فبراير
     - مارس
@@ -36,7 +36,7 @@ ar:
       long: "%B %e, %Y"
       short: "%e %b"
     month_names:
-    - 
+    -
     - يناير
     - فبراير
     - مارس
@@ -251,7 +251,7 @@ ar:
             many: Bytes
             other: Bytes
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/az.yml
+++ b/rails/locale/az.yml
@@ -10,7 +10,7 @@ az:
     - C.
     - Ş.
     abbr_month_names:
-    - 
+    -
     - Yan
     - Fev
     - Mar
@@ -36,7 +36,7 @@ az:
       long: "%d %B %Y"
       short: "%d %b"
     month_names:
-    - 
+    -
     - Yanvar
     - Fevral
     - Mart
@@ -170,7 +170,7 @@ az:
             one: Bayt
             other: Bayt
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/bn.yml
+++ b/rails/locale/bn.yml
@@ -10,7 +10,7 @@ bn:
     - শুক্রবার
     - শনিবার
     abbr_month_names:
-    - 
+    -
     - জানুয়ারি
     - ফেব্রুয়ারি
     - মার্চ
@@ -36,7 +36,7 @@ bn:
       long: "%e de %B de %Y"
       short: "%e de %b"
     month_names:
-    - 
+    -
     - জানুয়ারি
     - ফেব্রুয়ারি
     - মার্চ
@@ -153,7 +153,7 @@ bn:
             one: Byte
             other: Bytes
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/bs.yml
+++ b/rails/locale/bs.yml
@@ -10,7 +10,7 @@ bs:
     - pet
     - sub
     abbr_month_names:
-    - 
+    -
     - jan
     - feb
     - mar
@@ -35,7 +35,7 @@ bs:
       long: "%e. %B %Y."
       short: "%e. %b. %Y."
     month_names:
-    - 
+    -
     - januar
     - februar
     - mart
@@ -220,7 +220,7 @@ bs:
             one: bajt
             other: bajtova
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/ca.yml
+++ b/rails/locale/ca.yml
@@ -10,7 +10,7 @@ ca:
     - Dv
     - Ds
     abbr_month_names:
-    - 
+    -
     - Gen
     - Feb
     - Mar
@@ -36,7 +36,7 @@ ca:
       long: "%d de %B de %Y"
       short: "%d de %b"
     month_names:
-    - 
+    -
     - Gener
     - Febrer
     - Març
@@ -170,7 +170,7 @@ ca:
             one: Byte
             other: Bytes
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/cs.yml
+++ b/rails/locale/cs.yml
@@ -10,7 +10,7 @@ cs:
     - Pá
     - So
     abbr_month_names:
-    - 
+    -
     - led
     - úno
     - bře
@@ -36,7 +36,7 @@ cs:
       long: "%d. %B %Y"
       short: "%d %b"
     month_names:
-    - 
+    -
     - leden
     - únor
     - březen
@@ -187,7 +187,7 @@ cs:
         units:
           byte: B
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/cy.yml
+++ b/rails/locale/cy.yml
@@ -10,7 +10,7 @@ cy:
     - Gwe
     - Sad
     abbr_month_names:
-    - 
+    -
     - Ion
     - Chw
     - Maw
@@ -36,7 +36,7 @@ cy:
       long: "%B %d, %Y"
       short: "%b %d"
     month_names:
-    - 
+    -
     - Ionawr
     - Chwefror
     - Mawrth
@@ -220,7 +220,7 @@ cy:
             many: Bytes
             other: Bytes
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/da.yml
+++ b/rails/locale/da.yml
@@ -10,7 +10,7 @@ da:
     - fre
     - lør
     abbr_month_names:
-    - 
+    -
     - jan
     - feb
     - mar
@@ -36,7 +36,7 @@ da:
       long: "%e. %B %Y"
       short: "%e. %b %Y"
     month_names:
-    - 
+    -
     - januar
     - februar
     - marts
@@ -175,7 +175,7 @@ da:
             one: Byte
             other: Bytes
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/de-AT.yml
+++ b/rails/locale/de-AT.yml
@@ -10,7 +10,7 @@ de-AT:
     - Fr
     - Sa
     abbr_month_names:
-    - 
+    -
     - Jän
     - Feb
     - Mär
@@ -36,7 +36,7 @@ de-AT:
       long: "%e. %B %Y"
       short: "%e. %b"
     month_names:
-    - 
+    -
     - Jänner
     - Februar
     - März
@@ -186,7 +186,7 @@ de-AT:
             one: Byte
             other: Bytes
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/de-CH.yml
+++ b/rails/locale/de-CH.yml
@@ -10,7 +10,7 @@ de-CH:
     - Fr
     - Sa
     abbr_month_names:
-    - 
+    -
     - Jan
     - Feb
     - Mär
@@ -36,7 +36,7 @@ de-CH:
       long: "%e. %B %Y"
       short: "%e. %b"
     month_names:
-    - 
+    -
     - Januar
     - Februar
     - März
@@ -190,7 +190,7 @@ de-CH:
             one: Byte
             other: Bytes
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/de.yml
+++ b/rails/locale/de.yml
@@ -10,7 +10,7 @@ de:
     - Fr
     - Sa
     abbr_month_names:
-    - 
+    -
     - Jan
     - Feb
     - Mär
@@ -36,7 +36,7 @@ de:
       long: "%e. %B %Y"
       short: "%e. %b"
     month_names:
-    - 
+    -
     - Januar
     - Februar
     - März
@@ -186,7 +186,7 @@ de:
             one: Byte
             other: Bytes
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/el.yml
+++ b/rails/locale/el.yml
@@ -10,7 +10,7 @@ el:
     - Παρ
     - Σάβ
     abbr_month_names:
-    - 
+    -
     - Ιαν
     - Φεβ
     - Μαρ
@@ -36,7 +36,7 @@ el:
       long: "%e %B %Y"
       short: "%d %b"
     month_names:
-    - 
+    -
     - Ιανουάριος
     - Φεβρουάριος
     - Μάρτιος
@@ -176,7 +176,7 @@ el:
             one: byte
             other: bytes
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/en-AU.yml
+++ b/rails/locale/en-AU.yml
@@ -10,7 +10,7 @@ en-AU:
     - Fri
     - Sat
     abbr_month_names:
-    - 
+    -
     - Jan
     - Feb
     - Mar
@@ -36,7 +36,7 @@ en-AU:
       long: "%d %B, %Y"
       short: "%d %b"
     month_names:
-    - 
+    -
     - January
     - February
     - March
@@ -176,7 +176,7 @@ en-AU:
             one: Byte
             other: Bytes
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/en-CA.yml
+++ b/rails/locale/en-CA.yml
@@ -10,7 +10,7 @@ en-CA:
     - Fri
     - Sat
     abbr_month_names:
-    - 
+    -
     - Jan
     - Feb
     - Mar
@@ -36,7 +36,7 @@ en-CA:
       long: "%B %d, %Y"
       short: "%d %b"
     month_names:
-    - 
+    -
     - January
     - February
     - March
@@ -176,7 +176,7 @@ en-CA:
             one: Byte
             other: Bytes
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/en-GB.yml
+++ b/rails/locale/en-GB.yml
@@ -10,7 +10,7 @@ en-GB:
     - Fri
     - Sat
     abbr_month_names:
-    - 
+    -
     - Jan
     - Feb
     - Mar
@@ -36,7 +36,7 @@ en-GB:
       long: "%d %B, %Y"
       short: "%d %b"
     month_names:
-    - 
+    -
     - January
     - February
     - March
@@ -176,7 +176,7 @@ en-GB:
             one: Byte
             other: Bytes
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/en-IE.yml
+++ b/rails/locale/en-IE.yml
@@ -10,7 +10,7 @@ en-IE:
     - Fri
     - Sat
     abbr_month_names:
-    - 
+    -
     - Jan
     - Feb
     - Mar
@@ -36,7 +36,7 @@ en-IE:
       long: "%d %B, %Y"
       short: "%d %b"
     month_names:
-    - 
+    -
     - January
     - February
     - March
@@ -176,7 +176,7 @@ en-IE:
             one: Byte
             other: Bytes
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/en-IN.yml
+++ b/rails/locale/en-IN.yml
@@ -10,7 +10,7 @@ en-IN:
     - Fri
     - Sat
     abbr_month_names:
-    - 
+    -
     - Jan
     - Feb
     - Mar
@@ -36,7 +36,7 @@ en-IN:
       long: "%B %d, %Y"
       short: "%b %d"
     month_names:
-    - 
+    -
     - January
     - February
     - March
@@ -176,7 +176,7 @@ en-IN:
             one: Byte
             other: Bytes
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/en-NZ.yml
+++ b/rails/locale/en-NZ.yml
@@ -10,7 +10,7 @@ en-NZ:
     - Fri
     - Sat
     abbr_month_names:
-    - 
+    -
     - Jan
     - Feb
     - Mar
@@ -36,7 +36,7 @@ en-NZ:
       long: "%d %B, %Y"
       short: "%d %b"
     month_names:
-    - 
+    -
     - January
     - February
     - March
@@ -176,7 +176,7 @@ en-NZ:
             one: Byte
             other: Bytes
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/en-US.yml
+++ b/rails/locale/en-US.yml
@@ -10,7 +10,7 @@ en-US:
     - Fri
     - Sat
     abbr_month_names:
-    - 
+    -
     - Jan
     - Feb
     - Mar
@@ -36,7 +36,7 @@ en-US:
       long: "%B %d, %Y"
       short: "%b %d"
     month_names:
-    - 
+    -
     - January
     - February
     - March
@@ -181,7 +181,7 @@ en-US:
             one: Byte
             other: Bytes
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/en-ZA.yml
+++ b/rails/locale/en-ZA.yml
@@ -10,7 +10,7 @@ en-ZA:
     - Fri
     - Sat
     abbr_month_names:
-    - 
+    -
     - Jan
     - Feb
     - Mar
@@ -36,7 +36,7 @@ en-ZA:
       long: "%B %d, %Y"
       short: "%b %d"
     month_names:
-    - 
+    -
     - January
     - February
     - March
@@ -181,7 +181,7 @@ en-ZA:
             one: Byte
             other: Bytes
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/en.yml
+++ b/rails/locale/en.yml
@@ -10,7 +10,7 @@ en:
     - Fri
     - Sat
     abbr_month_names:
-    - 
+    -
     - Jan
     - Feb
     - Mar
@@ -36,7 +36,7 @@ en:
       long: "%B %d, %Y"
       short: "%b %d"
     month_names:
-    - 
+    -
     - January
     - February
     - March
@@ -181,7 +181,7 @@ en:
             one: Byte
             other: Bytes
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/eo.yml
+++ b/rails/locale/eo.yml
@@ -10,7 +10,7 @@ eo:
     - ven
     - sam
     abbr_month_names:
-    - 
+    -
     - jan.
     - feb.
     - mar.
@@ -36,7 +36,7 @@ eo:
       long: "%e %B %Y"
       short: "%e %b"
     month_names:
-    - 
+    -
     - januaro
     - februaro
     - marto

--- a/rails/locale/es-419.yml
+++ b/rails/locale/es-419.yml
@@ -10,7 +10,7 @@ es-419:
     - vie
     - sáb
     abbr_month_names:
-    - 
+    -
     - ene
     - feb
     - mar
@@ -36,7 +36,7 @@ es-419:
       long: "%A, %d de %B de %Y"
       short: "%d de %b"
     month_names:
-    - 
+    -
     - enero
     - febrero
     - marzo
@@ -176,7 +176,7 @@ es-419:
             one: Byte
             other: Bytes
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/es-AR.yml
+++ b/rails/locale/es-AR.yml
@@ -10,7 +10,7 @@ es-AR:
     - vie
     - sáb
     abbr_month_names:
-    - 
+    -
     - ene
     - feb
     - mar
@@ -36,7 +36,7 @@ es-AR:
       long: "%A, %d de %B de %Y"
       short: "%d de %b"
     month_names:
-    - 
+    -
     - enero
     - febrero
     - marzo
@@ -176,7 +176,7 @@ es-AR:
             one: Byte
             other: Bytes
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/es-CL.yml
+++ b/rails/locale/es-CL.yml
@@ -10,7 +10,7 @@ es-CL:
     - vie
     - sáb
     abbr_month_names:
-    - 
+    -
     - ene
     - feb
     - mar
@@ -36,7 +36,7 @@ es-CL:
       long: "%A %d de %B de %Y"
       short: "%d de %b"
     month_names:
-    - 
+    -
     - enero
     - febrero
     - marzo
@@ -170,7 +170,7 @@ es-CL:
             one: Byte
             other: Bytes
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/es-CO.yml
+++ b/rails/locale/es-CO.yml
@@ -10,7 +10,7 @@ es-CO:
     - vie
     - sáb
     abbr_month_names:
-    - 
+    -
     - ene
     - feb
     - mar
@@ -36,7 +36,7 @@ es-CO:
       long: "%A, %d de %B de %Y"
       short: "%d de %b"
     month_names:
-    - 
+    -
     - enero
     - febrero
     - marzo
@@ -176,7 +176,7 @@ es-CO:
             one: Byte
             other: Bytes
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/es-CR.yml
+++ b/rails/locale/es-CR.yml
@@ -10,7 +10,7 @@ es-CR:
     - vie
     - sáb
     abbr_month_names:
-    - 
+    -
     - ene
     - feb
     - mar
@@ -36,7 +36,7 @@ es-CR:
       long: "%A, %d de %B de %Y"
       short: "%d de %b"
     month_names:
-    - 
+    -
     - enero
     - febrero
     - marzo
@@ -176,7 +176,7 @@ es-CR:
             one: Byte
             other: Bytes
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/es-EC.yml
+++ b/rails/locale/es-EC.yml
@@ -10,7 +10,7 @@ es-EC:
     - vie
     - sáb
     abbr_month_names:
-    - 
+    -
     - ene
     - feb
     - mar
@@ -36,7 +36,7 @@ es-EC:
       long: "%A, %-d de %B de %Y"
       short: "%-d de %b"
     month_names:
-    - 
+    -
     - enero
     - febrero
     - marzo
@@ -181,7 +181,7 @@ es-EC:
             one: Byte
             other: Bytes
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/es-MX.yml
+++ b/rails/locale/es-MX.yml
@@ -10,7 +10,7 @@ es-MX:
     - vie
     - sáb
     abbr_month_names:
-    - 
+    -
     - ene
     - feb
     - mar
@@ -36,7 +36,7 @@ es-MX:
       long: "%A, %d de %B de %Y"
       short: "%d de %b"
     month_names:
-    - 
+    -
     - enero
     - febrero
     - marzo
@@ -181,7 +181,7 @@ es-MX:
             one: Byte
             other: Bytes
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/es-PA.yml
+++ b/rails/locale/es-PA.yml
@@ -10,7 +10,7 @@ es-PA:
     - vie
     - sáb
     abbr_month_names:
-    - 
+    -
     - ene
     - feb
     - mar
@@ -36,7 +36,7 @@ es-PA:
       long: "%A, %-d de %B de %Y"
       short: "%-d de %b"
     month_names:
-    - 
+    -
     - enero
     - febrero
     - marzo
@@ -181,7 +181,7 @@ es-PA:
             one: Byte
             other: Bytes
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/es-PE.yml
+++ b/rails/locale/es-PE.yml
@@ -10,7 +10,7 @@ es-PE:
     - vie
     - sáb
     abbr_month_names:
-    - 
+    -
     - ene
     - feb
     - mar
@@ -36,7 +36,7 @@ es-PE:
       long: "%A, %d de %B del %Y"
       short: "%d de %b"
     month_names:
-    - 
+    -
     - enero
     - febrero
     - marzo
@@ -160,7 +160,7 @@ es-PE:
             one: Byte
             other: Bytes
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/es-US.yml
+++ b/rails/locale/es-US.yml
@@ -10,7 +10,7 @@ es-US:
     - vie
     - sáb
     abbr_month_names:
-    - 
+    -
     - ene
     - feb
     - mar
@@ -36,7 +36,7 @@ es-US:
       long: "%A, %d de %B de %Y"
       short: "%d de %b"
     month_names:
-    - 
+    -
     - enero
     - febrero
     - marzo
@@ -176,7 +176,7 @@ es-US:
             one: Byte
             other: Bytes
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/es-VE.yml
+++ b/rails/locale/es-VE.yml
@@ -10,7 +10,7 @@ es-VE:
     - vie
     - sáb
     abbr_month_names:
-    - 
+    -
     - ene
     - feb
     - mar
@@ -36,7 +36,7 @@ es-VE:
       long: "%A, %d de %B de %Y"
       short: "%d de %b"
     month_names:
-    - 
+    -
     - enero
     - febrero
     - marzo
@@ -176,7 +176,7 @@ es-VE:
             one: Byte
             other: Bytes
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/es.yml
+++ b/rails/locale/es.yml
@@ -10,7 +10,7 @@ es:
     - vie
     - sáb
     abbr_month_names:
-    - 
+    -
     - ene
     - feb
     - mar
@@ -36,7 +36,7 @@ es:
       long: "%d de %B de %Y"
       short: "%d de %b"
     month_names:
-    - 
+    -
     - enero
     - febrero
     - marzo
@@ -170,7 +170,7 @@ es:
             one: Byte
             other: Bytes
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/et.yml
+++ b/rails/locale/et.yml
@@ -10,7 +10,7 @@ et:
     - R
     - L
     abbr_month_names:
-    - 
+    -
     - jaan.
     - veebr.
     - märts
@@ -36,7 +36,7 @@ et:
       long: "%d. %B %Y"
       short: "%d.%m.%y"
     month_names:
-    - 
+    -
     - jaanuar
     - veebruar
     - märts
@@ -170,7 +170,7 @@ et:
             one: bait
             other: baiti
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/eu.yml
+++ b/rails/locale/eu.yml
@@ -10,7 +10,7 @@ eu:
     - Osti
     - Lar
     abbr_month_names:
-    - 
+    -
     - Urt
     - Ots
     - Mar
@@ -36,7 +36,7 @@ eu:
       long: "%Y(e)ko %Bk %e"
       short: "%b %e"
     month_names:
-    - 
+    -
     - Urtarrila
     - Otsaila
     - Martxoa
@@ -170,7 +170,7 @@ eu:
             one: Byte
             other: Byte
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/gl.yml
+++ b/rails/locale/gl.yml
@@ -10,7 +10,7 @@ gl:
     - Ven
     - Sab
     abbr_month_names:
-    - 
+    -
     - Xan
     - Feb
     - Mar
@@ -36,7 +36,7 @@ gl:
       long: "%A %e de %B de %Y"
       short: "%e %b"
     month_names:
-    - 
+    -
     - Xaneiro
     - Febreiro
     - Marzo
@@ -149,7 +149,7 @@ gl:
             one: Byte
             other: Bytes
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/hi-IN.yml
+++ b/rails/locale/hi-IN.yml
@@ -10,7 +10,7 @@ hi-IN:
     - शुक्र
     - शनि
     abbr_month_names:
-    - 
+    -
     - Jan
     - Feb
     - Mar
@@ -36,7 +36,7 @@ hi-IN:
       long: "%B %d, %Y"
       short: "%b %d"
     month_names:
-    - 
+    -
     - जनवरी
     - फरवरी
     - मार्च
@@ -170,7 +170,7 @@ hi-IN:
             one: Byte
             other: Bytes
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/hi.yml
+++ b/rails/locale/hi.yml
@@ -10,7 +10,7 @@ hi:
     - शुक्र
     - शनि
     abbr_month_names:
-    - 
+    -
     - जन
     - फर
     - मार्च
@@ -36,7 +36,7 @@ hi:
       long: "%B %d, %Y"
       short: "%b %d"
     month_names:
-    - 
+    -
     - जनवरी
     - फरवरी
     - मार्च
@@ -170,7 +170,7 @@ hi:
             one: Byte
             other: Bytes
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/hr.yml
+++ b/rails/locale/hr.yml
@@ -10,7 +10,7 @@ hr:
     - Pet
     - Sub
     abbr_month_names:
-    - 
+    -
     - Sij
     - Veǉ
     - Ožu
@@ -36,7 +36,7 @@ hr:
       long: "%e. %B %Y."
       short: "%e.%-m."
     month_names:
-    - 
+    -
     - Siječanj
     - Veljača
     - Ožujak
@@ -213,7 +213,7 @@ hr:
             many: bajtova
             other: bajtova
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/hu.yml
+++ b/rails/locale/hu.yml
@@ -10,7 +10,7 @@ hu:
     - p.
     - szo.
     abbr_month_names:
-    - 
+    -
     - jan.
     - febr.
     - márc.
@@ -36,7 +36,7 @@ hu:
       long: "%Y. %B %e."
       short: "%b %e."
     month_names:
-    - 
+    -
     - január
     - február
     - március
@@ -170,7 +170,7 @@ hu:
             one: bájt
             other: bájt
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/id.yml
+++ b/rails/locale/id.yml
@@ -10,7 +10,7 @@ id:
     - Jum
     - Sab
     abbr_month_names:
-    - 
+    -
     - Jan
     - Feb
     - Mar
@@ -36,7 +36,7 @@ id:
       long: "%A, %d %B %Y"
       short: "%d.%m.%Y"
     month_names:
-    - 
+    -
     - Januari
     - Februari
     - Maret
@@ -171,7 +171,7 @@ id:
             one: Byte
             other: Byte
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/is.yml
+++ b/rails/locale/is.yml
@@ -10,7 +10,7 @@ is:
     - fös
     - lau
     abbr_month_names:
-    - 
+    -
     - jan
     - feb
     - mar
@@ -36,7 +36,7 @@ is:
       long: "%e. %B %Y"
       short: "%e. %b"
     month_names:
-    - 
+    -
     - janúar
     - febrúar
     - mars
@@ -189,7 +189,7 @@ is:
             one: bæti
             other: bæti
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/iso-639-2/csb.yml
+++ b/rails/locale/iso-639-2/csb.yml
@@ -9,7 +9,7 @@ csb:
     - pią
     - sob
     abbr_month_names:
-    - 
+    -
     - stë
     - gro
     - str
@@ -35,7 +35,7 @@ csb:
       long: ! '%B %d, %Y'
       short: ! '%d %b'
     month_names:
-    - 
+    -
     - stëcznik
     - gromicznik
     - strëmiannik
@@ -180,7 +180,7 @@ csb:
             one: bajt
             other: bajtë
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/iso-639-2/dsb.yml
+++ b/rails/locale/iso-639-2/dsb.yml
@@ -9,7 +9,7 @@ dsb:
     - Pě
     - So
     abbr_month_names:
-    - 
+    -
     - jan
     - feb
     - měr
@@ -35,7 +35,7 @@ dsb:
       long: ! '%d. %B %Y'
       short: ! '%d %b'
     month_names:
-    - 
+    -
     - Januar
     - Februar
     - Měrc
@@ -185,7 +185,7 @@ dsb:
             other: bajtow
             two: bajta
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/iso-639-2/fur.yml
+++ b/rails/locale/iso-639-2/fur.yml
@@ -9,7 +9,7 @@ fur:
     - vin
     - sab
     abbr_month_names:
-    - 
+    -
     - Zen
     - Fev
     - Mar
@@ -35,7 +35,7 @@ fur:
       long: ! '%d di %B dal %Y'
       short: ! '%d di %b'
     month_names:
-    - 
+    -
     - Zenâr
     - Fevrâr
     - Març
@@ -168,10 +168,10 @@ fur:
           byte:
             one: Byte
             other: Byte
-          gb: Gb
-          kb: Kb
-          mb: Mb
-          tb: Tb
+          gb: GB
+          kb: kB
+          mb: MB
+          tb: TB
     percentage:
       format:
         delimiter: ''

--- a/rails/locale/iso-639-2/gsw-CH.yml
+++ b/rails/locale/iso-639-2/gsw-CH.yml
@@ -9,7 +9,7 @@
     - Fr
     - Sa
     abbr_month_names:
-    - 
+    -
     - Jan
     - Feb
     - Mär
@@ -35,7 +35,7 @@
       long: ! '%e. %B %Y'
       short: ! '%e. %b'
     month_names:
-    - 
+    -
     - Januar
     - Februar
     - März
@@ -173,7 +173,7 @@
             one: Byte
             other: Bytes
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/iso-639-2/hsb.yml
+++ b/rails/locale/iso-639-2/hsb.yml
@@ -9,7 +9,7 @@ hsb:
     - Pj
     - So
     abbr_month_names:
-    - 
+    -
     - jan
     - feb
     - měr
@@ -35,7 +35,7 @@ hsb:
       long: ! '%d. %B %Y'
       short: ! '%d %b'
     month_names:
-    - 
+    -
     - Januar
     - Februar
     - Měrc
@@ -184,7 +184,7 @@ hsb:
             other: bajtow
             two: bajtaj
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/iso-639-2/pap-AW.yml
+++ b/rails/locale/iso-639-2/pap-AW.yml
@@ -181,7 +181,7 @@ pap-AW:
             one: Byte
             other: Bytes
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/iso-639-2/pap-CW.yml
+++ b/rails/locale/iso-639-2/pap-CW.yml
@@ -181,7 +181,7 @@ pap-CW:
             one: Byte
             other: Bytes
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/iso-639-2/scr.yml
+++ b/rails/locale/iso-639-2/scr.yml
@@ -9,7 +9,7 @@ scr:
     - Pet
     - Sub
     abbr_month_names:
-    - 
+    -
     - Jan
     - Feb
     - Mar
@@ -35,7 +35,7 @@ scr:
       long: ! '%B %e, %Y'
       short: ! '%e %b'
     month_names:
-    - 
+    -
     - Januar
     - Februar
     - Mart
@@ -212,7 +212,7 @@ scr:
             many: bajtova
             other: bajtova
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/it-CH.yml
+++ b/rails/locale/it-CH.yml
@@ -10,7 +10,7 @@ it-CH:
     - Ven
     - Sab
     abbr_month_names:
-    - 
+    -
     - Gen
     - Feb
     - Mar
@@ -36,7 +36,7 @@ it-CH:
       long: "%d %B %Y"
       short: "%d %b"
     month_names:
-    - 
+    -
     - Gennaio
     - Febbraio
     - Marzo
@@ -176,7 +176,7 @@ it-CH:
             one: Byte
             other: Byte
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/it.yml
+++ b/rails/locale/it.yml
@@ -10,7 +10,7 @@ it:
     - ven
     - sab
     abbr_month_names:
-    - 
+    -
     - gen
     - feb
     - mar
@@ -36,7 +36,7 @@ it:
       long: "%d %B %Y"
       short: "%d %b"
     month_names:
-    - 
+    -
     - gennaio
     - febbraio
     - marzo
@@ -181,7 +181,7 @@ it:
             one: Byte
             other: Byte
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/kn.yml
+++ b/rails/locale/kn.yml
@@ -10,7 +10,7 @@ kn:
     - ಶುಕ್ರ
     - ಶನಿ
     abbr_month_names:
-    - 
+    -
     - Jan
     - Feb
     - Mar
@@ -36,7 +36,7 @@ kn:
       long: "%B %d, %Y"
       short: "%b %d"
     month_names:
-    - 
+    -
     - ಜನವರಿ
     - ಫೆಬ್ರವರಿ
     - ಮಾರ್ಚ್
@@ -170,7 +170,7 @@ kn:
             one: Byte
             other: Bytes
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/lb.yml
+++ b/rails/locale/lb.yml
@@ -182,7 +182,7 @@ lb:
             one: Byte
             other: Byten
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/lo.yml
+++ b/rails/locale/lo.yml
@@ -10,7 +10,7 @@ lo:
     - ''
     - ''
     abbr_month_names:
-    - 
+    -
     - ''
     - ''
     - ''
@@ -36,7 +36,7 @@ lo:
       long: "%e %B %Y"
       short: "%e %b"
     month_names:
-    - 
+    -
     - ມັງກອນ
     - ກຸມພາ
     - ມີນາ
@@ -205,7 +205,7 @@ lo:
             many: Bytes
             other: Bytes
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/lt.yml
+++ b/rails/locale/lt.yml
@@ -10,7 +10,7 @@ lt:
     - Pen
     - Šeš
     abbr_month_names:
-    - 
+    -
     - Sau
     - Vas
     - Kov
@@ -36,7 +36,7 @@ lt:
       long: "%B %d, %Y"
       short: "%b %d"
     month_names:
-    - 
+    -
     - sausio
     - vasario
     - kovo
@@ -194,7 +194,7 @@ lt:
             few: Baitai
             other: Baitų
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/lv.yml
+++ b/rails/locale/lv.yml
@@ -10,7 +10,7 @@ lv:
     - Pk.
     - S.
     abbr_month_names:
-    - 
+    -
     - Janv
     - Febr
     - Marts
@@ -36,7 +36,7 @@ lv:
       long: "%Y. gada %e. %B"
       short: "%e. %B"
     month_names:
-    - 
+    -
     - Janvāris
     - Februāris
     - Marts
@@ -207,7 +207,7 @@ lv:
             one: baits
             other: baiti
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/mk.yml
+++ b/rails/locale/mk.yml
@@ -10,7 +10,7 @@ mk:
     - Пет
     - Саб
     abbr_month_names:
-    - 
+    -
     - Јан
     - Фев
     - Мар
@@ -36,7 +36,7 @@ mk:
       long: "%B %e, %Y"
       short: "%e %b"
     month_names:
-    - 
+    -
     - Јануари
     - Февруари
     - Март
@@ -176,7 +176,7 @@ mk:
             one: бајт
             other: бајти
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/mr-IN.yml
+++ b/rails/locale/mr-IN.yml
@@ -181,7 +181,7 @@ mr-IN:
             one: Byte
             other: Bytes
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/ms.yml
+++ b/rails/locale/ms.yml
@@ -10,7 +10,7 @@ ms:
     - Jum
     - Sab
     abbr_month_names:
-    - 
+    -
     - Jan
     - Feb
     - Mac
@@ -36,7 +36,7 @@ ms:
       long: "%d %B, %Y"
       short: "%d %b"
     month_names:
-    - 
+    -
     - Januari
     - Febuari
     - Mac
@@ -176,7 +176,7 @@ ms:
             one: Bait
             other: Bait
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/or.yml
+++ b/rails/locale/or.yml
@@ -10,7 +10,7 @@ or:
     - ଶୁକ୍ର
     - ଶନି
     abbr_month_names:
-    - 
+    -
     - ଜାନୁ
     - ଫେବରୁ
     - ମାର
@@ -36,7 +36,7 @@ or:
       long: "%B %d, %Y"
       short: "%b %d"
     month_names:
-    - 
+    -
     - ଜାନୁୟାରୀ
     - ଫେବୃୟାରୀ
     - ମାର୍ଚ଼
@@ -170,7 +170,7 @@ or:
             one: Byte
             other: Bytes
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/pl.yml
+++ b/rails/locale/pl.yml
@@ -10,7 +10,7 @@ pl:
     - pią
     - sob
     abbr_month_names:
-    - 
+    -
     - sty
     - lut
     - mar
@@ -36,7 +36,7 @@ pl:
       long: "%B %d, %Y"
       short: "%d %b"
     month_names:
-    - 
+    -
     - styczeń
     - luty
     - marzec
@@ -213,7 +213,7 @@ pl:
             one: bajt
             other: bajty
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/pt-BR.yml
+++ b/rails/locale/pt-BR.yml
@@ -10,7 +10,7 @@ pt-BR:
     - Sex
     - Sáb
     abbr_month_names:
-    - 
+    -
     - Jan
     - Fev
     - Mar
@@ -36,7 +36,7 @@ pt-BR:
       long: "%d de %B de %Y"
       short: "%d de %B"
     month_names:
-    - 
+    -
     - Janeiro
     - Fevereiro
     - Março
@@ -183,7 +183,7 @@ pt-BR:
             one: Byte
             other: Bytes
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/pt.yml
+++ b/rails/locale/pt.yml
@@ -10,7 +10,7 @@ pt:
     - Sex
     - Sáb
     abbr_month_names:
-    - 
+    -
     - Jan
     - Fev
     - Mar
@@ -36,7 +36,7 @@ pt:
       long: "%d de %B de %Y"
       short: "%d de %B"
     month_names:
-    - 
+    -
     - Janeiro
     - Fevereiro
     - Março
@@ -178,7 +178,7 @@ pt:
             one: Byte
             other: Bytes
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/rm.yml
+++ b/rails/locale/rm.yml
@@ -10,7 +10,7 @@ rm:
     - ve
     - so
     abbr_month_names:
-    - 
+    -
     - schan
     - favr
     - mars
@@ -36,7 +36,7 @@ rm:
       long: "%e. %B %Y"
       short: "%e. %b"
     month_names:
-    - 
+    -
     - schaner
     - favrer
     - mars
@@ -201,7 +201,7 @@ rm:
             many: bytes
             other: bytes
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/ro.yml
+++ b/rails/locale/ro.yml
@@ -10,7 +10,7 @@ ro:
     - Vin
     - Sâm
     abbr_month_names:
-    - 
+    -
     - Ian
     - Feb
     - Mar
@@ -36,7 +36,7 @@ ro:
       long: "%d %B %Y"
       short: "%d %b"
     month_names:
-    - 
+    -
     - Ianuarie
     - Februarie
     - Martie
@@ -183,7 +183,7 @@ ro:
             few: Bytes
             other: Bytes
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/sk.yml
+++ b/rails/locale/sk.yml
@@ -10,7 +10,7 @@ sk:
     - Pi
     - So
     abbr_month_names:
-    - 
+    -
     - Jan
     - Feb
     - Mar
@@ -36,7 +36,7 @@ sk:
       long: "%d. %B %Y"
       short: "%d %b"
     month_names:
-    - 
+    -
     - Január
     - Február
     - Marec
@@ -185,7 +185,7 @@ sk:
             few: B
             other: B
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/sl.yml
+++ b/rails/locale/sl.yml
@@ -10,7 +10,7 @@ sl:
     - pet
     - sob
     abbr_month_names:
-    - 
+    -
     - jan
     - feb
     - mar
@@ -36,7 +36,7 @@ sl:
       long: "%d. %b %Y"
       short: "%d. %b"
     month_names:
-    - 
+    -
     - januar
     - februar
     - marec
@@ -183,7 +183,7 @@ sl:
             few: Bytes
             other: Bytes
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/sv.yml
+++ b/rails/locale/sv.yml
@@ -10,7 +10,7 @@ sv:
     - fre
     - lör
     abbr_month_names:
-    - 
+    -
     - jan
     - feb
     - mar
@@ -36,7 +36,7 @@ sv:
       long: "%e %B %Y"
       short: "%e %b"
     month_names:
-    - 
+    -
     - januari
     - februari
     - mars
@@ -175,7 +175,7 @@ sv:
             one: Byte
             other: Bytes
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/sw.yml
+++ b/rails/locale/sw.yml
@@ -10,7 +10,7 @@ sw:
     - Ij
     - J1
     abbr_month_names:
-    - 
+    -
     - Jan
     - Feb
     - Mac
@@ -36,7 +36,7 @@ sw:
       long: "%e %B, %Y"
       short: "%e %b"
     month_names:
-    - 
+    -
     - Mwezi wa kwanza
     - Mwezi wa pili
     - Mwezi wa tatu
@@ -168,7 +168,7 @@ sw:
         units:
           byte: Baiti
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/ta.yml
+++ b/rails/locale/ta.yml
@@ -10,7 +10,7 @@ ta:
     - வெள்ளி
     - சனி
     abbr_month_names:
-    - 
+    -
     - ஜன
     - பிப்
     - மார்ச்
@@ -36,7 +36,7 @@ ta:
       long: "%B %d, %Y"
       short: "%b %d"
     month_names:
-    - 
+    -
     - ஜனவரி
     - பிப்ரவரி
     - மார்ச்
@@ -181,7 +181,7 @@ ta:
             one: Byte
             other: Bytes
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/tl.yml
+++ b/rails/locale/tl.yml
@@ -22,7 +22,7 @@ tl:
     - Biy
     - Sab
     month_names:
-    - 
+    -
     - Enero
     - Pebrero
     - Marso
@@ -36,7 +36,7 @@ tl:
     - Nobyembre
     - Disyembre
     abbr_month_names:
-    - 
+    -
     - Ene
     - Peb
     - Mar
@@ -99,7 +99,7 @@ tl:
           byte:
             one: Byte
             other: Bytes
-          kb: KB
+          kb: kB
           mb: MB
           gb: GB
           tb: TB

--- a/rails/locale/tr.yml
+++ b/rails/locale/tr.yml
@@ -10,7 +10,7 @@ tr:
     - Cum
     - Cts
     abbr_month_names:
-    - 
+    -
     - Oca
     - Şub
     - Mar
@@ -36,7 +36,7 @@ tr:
       long: "%e %B %Y, %A"
       short: "%e %b"
     month_names:
-    - 
+    -
     - Ocak
     - Şubat
     - Mart
@@ -181,7 +181,7 @@ tr:
             one: Bayt
             other: Bayt
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/ur.yml
+++ b/rails/locale/ur.yml
@@ -10,7 +10,7 @@ ur:
     - جمعہ
     - ہفتہ
     abbr_month_names:
-    - 
+    -
     - جنوری
     - فروری
     - مارچ
@@ -36,7 +36,7 @@ ur:
       long: "%B %d، %Y"
       short: "%d %b"
     month_names:
-    - 
+    -
     - جنوری
     - فروری
     - مارچ
@@ -182,7 +182,7 @@ ur:
             one: Byte
             other: Bytes
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/uz.yml
+++ b/rails/locale/uz.yml
@@ -10,7 +10,7 @@ uz:
     - Ju
     - Sh
     abbr_month_names:
-    - 
+    -
     - yan.
     - fev.
     - mart
@@ -36,7 +36,7 @@ uz:
       long: "%d %B %Y"
       short: "%d %b"
     month_names:
-    - 
+    -
     - yanvar
     - fevral
     - mart
@@ -228,7 +228,7 @@ uz:
             one: bayt
             other: bayt
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/vi.yml
+++ b/rails/locale/vi.yml
@@ -10,7 +10,7 @@ vi:
     - Thứ sáu
     - Thứ bảy
     abbr_month_names:
-    - 
+    -
     - Tháng một
     - Tháng hai
     - Tháng ba
@@ -36,7 +36,7 @@ vi:
       long: "%d %B, %Y"
       short: "%d %b"
     month_names:
-    - 
+    -
     - Tháng một
     - Tháng hai
     - Tháng ba
@@ -175,7 +175,7 @@ vi:
             one: Byte
             other: Byte
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/wo.yml
+++ b/rails/locale/wo.yml
@@ -10,7 +10,7 @@ wo:
     - Ajj
     - Gaw
     abbr_month_names:
-    - 
+    -
     - Jan
     - Feb
     - Mar
@@ -36,7 +36,7 @@ wo:
       long: "%B %d, %Y"
       short: "%b %d"
     month_names:
-    - 
+    -
     - Tamkharit
     - Digui Gamou
     - Gamou
@@ -176,7 +176,7 @@ wo:
             one: Byte
             other: Bytes
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/zh-CN.yml
+++ b/rails/locale/zh-CN.yml
@@ -10,7 +10,7 @@ zh-CN:
     - 周五
     - 周六
     abbr_month_names:
-    - 
+    -
     - 1月
     - 2月
     - 3月
@@ -36,7 +36,7 @@ zh-CN:
       long: "%Y年%b%d日"
       short: "%b%d日"
     month_names:
-    - 
+    -
     - 一月
     - 二月
     - 三月
@@ -181,7 +181,7 @@ zh-CN:
             one: Byte
             other: Bytes
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/zh-HK.yml
+++ b/rails/locale/zh-HK.yml
@@ -10,7 +10,7 @@ zh-HK:
     - 周五
     - 周六
     abbr_month_names:
-    - 
+    -
     - 1月
     - 2月
     - 3月
@@ -36,7 +36,7 @@ zh-HK:
       long: "%Y年%b%d日"
       short: "%b%d日"
     month_names:
-    - 
+    -
     - 一月
     - 二月
     - 三月
@@ -181,7 +181,7 @@ zh-HK:
             one: Byte
             other: Bytes
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/zh-TW.yml
+++ b/rails/locale/zh-TW.yml
@@ -10,7 +10,7 @@ zh-TW:
     - 周五
     - 周六
     abbr_month_names:
-    - 
+    -
     - 1月
     - 2月
     - 3月
@@ -36,7 +36,7 @@ zh-TW:
       long: "%Y年%b%d日"
       short: "%b%d日"
     month_names:
-    - 
+    -
     - 一月
     - 二月
     - 三月
@@ -181,7 +181,7 @@ zh-TW:
             one: 位元組
             other: 位元組
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/locale/zh-YUE.yml
+++ b/rails/locale/zh-YUE.yml
@@ -10,7 +10,7 @@ zh-YUE:
     - 周五
     - 周六
     abbr_month_names:
-    - 
+    -
     - 1月
     - 2月
     - 3月
@@ -36,7 +36,7 @@ zh-YUE:
       long: "%Y年%b%d日"
       short: "%b%d日"
     month_names:
-    - 
+    -
     - 一月
     - 二月
     - 三月
@@ -181,7 +181,7 @@ zh-YUE:
             one: Byte
             other: Bytes
           gb: GB
-          kb: KB
+          kb: kB
           mb: MB
           tb: TB
     percentage:

--- a/rails/rails4/active_support.yml
+++ b/rails/rails4/active_support.yml
@@ -102,7 +102,7 @@ default:
           byte:
             one:   "Byte"
             other: "Bytes"
-          kb: "KB"
+          kb: "kB"
           mb: "MB"
           gb: "GB"
           tb: "TB"


### PR DESCRIPTION
This PR replaces non-standard conform Byte-values with those standardized by SI, see: https://en.wikipedia.org/wiki/Byte#Unit_symbol
This will allow standard conform parsing of those values.