### PR TITLE
Change data storage units' suffix in fi

### DIFF
--- a/rails/locale/fi.yml
+++ b/rails/locale/fi.yml
@@ -169,10 +169,10 @@ fi:
           byte:
             one: tavu
             other: tavua
-          gb: GB
-          kb: kB
-          mb: MB
-          tb: TB
+          gb: Gt
+          kb: kt
+          mb: Mt
+          tb: Tt
     percentage:
       format:
         delimiter: ''


### PR DESCRIPTION
In finnish, `tavu` means `byte`. The data storage units in the fi-locale use an incorrect suffix, `B`. I have changed it to `t`, to reflect `tavu`, `byte`.

#### Example:

| English | Finnish | Meaning (en)  | Meaning (fi) |
| ------- | ------- | ------------- | ------------ |
| `GB`    | `Gt`    | Gigabyte      | Gigatavu     |
| `Gb`    | `Gb`    | Gigabit       | Gigabitti    |