### PR TITLE
remove full stop from ja

### DIFF
--- a/rails/locale/ja.yml
+++ b/rails/locale/ja.yml
@@ -127,7 +127,7 @@ ja:
       body: 次の項目を確認してください
       header:
         one: "%{model}にエラーが発生しました。"
-        other: "%{model}に%{count}個のエラーが発生しました。"
+        other: "%{model}に%{count}個のエラーが発生しました"
   helpers:
     select:
       prompt: 選択してください


### PR DESCRIPTION
「errors: template: header: other: 」only include full stop in japanese translation.
I removed it.