### PR TITLE
Use turkish lira symbol instead of TL for TR locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,26 @@ Following locales have some missing translations or pluralizations:
 
 We always welcome your contributions!
 
+## Currency symbols
+
+Some locales have the symbol of the currency (e.g. `€`) under the key `number.currency.format.unit`,
+while others have the code (e.g. `CHF`). The value of the key depends on the widespread adoption of
+the unicode currency symbols by fonts.
+
+For example the Turkish Lira sign (`₺`) was recently added in Unicode 6.2 and while most popular
+fonts have a glyph, there are still many fonts that will not render the character correctly.
+
+If you want to provide a different value, in a Rails app, you can create your own locale file under
+`config/locales/tr.yml` and override the respective key:
+
+```YAML
+tr:
+  number:
+    currency:
+      format:
+        unit: TL
+```
+
 ## How to contribute
 
 ### Quick contribution

--- a/rails/locale/tr.yml
+++ b/rails/locale/tr.yml
@@ -142,7 +142,7 @@ tr:
         separator: ! ','
         significant: false
         strip_insignificant_zeros: false
-        unit: TL
+        unit: ₺
     format:
       delimiter: .
       precision: 2


### PR DESCRIPTION
Since 2012 there is a symbol (`₺`) for the [Turkish Lira](https://en.wikipedia.org/wiki/Turkish_lira_sign), introduced in Unicode 6.2. Most locales have a symbol in `number.currency.format.unit` and I think the turkish locale should follow suit.