### PR TITLE
Fixed thousands separator and decimal mark for Greek.

### DIFF
--- a/rails/locale/el.yml
+++ b/rails/locale/el.yml
@@ -141,17 +141,17 @@ el:
   number:
     currency:
       format:
-        delimiter: ","
+        delimiter: "."
         format: ! '%n %u'
         precision: 2
-        separator: ! '.'
+        separator: ! ','
         significant: false
         strip_insignificant_zeros: false
         unit: €
     format:
-      delimiter: ","
+      delimiter: "."
       precision: 3
-      separator: ! '.'
+      separator: ! ','
       significant: false
       strip_insignificant_zeros: false
     human:


### PR DESCRIPTION
Fixed thousands separator and decimal mark for Greek.

In Greece this is correct: "10.000,50 €"
This isn't: "10,000.50 €"
https://en.wikipedia.org/wiki/Decimal_mark#Hindu.E2.80.93Arabic_numeral_system