### PR TITLE
Add support for Panjabi/Punjabi language, ISO code - pa

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rails-i18n (4.0.6)
+    rails-i18n (4.0.7)
       i18n (~> 0.7)
       railties (~> 4.0)
 
@@ -90,3 +90,6 @@ DEPENDENCIES
   rails-i18n!
   rspec-rails (= 2.14.2)
   spork (= 1.0.0rc3)
+
+BUNDLED WITH
+   1.10.6

--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ Available locales are:
 > es-419, es-AR, es-CL, es-CO, es-CR, es-EC, es-MX, es-PA, es-PE, es-US, es-VE,
 > et, eu, fa, fi, fr, fr-CA, fr-CH, gl, he, hi, hi-IN, hr, hu, id, is, it,
 > it-CH, ja, km, kn, ko, lb, lo, lt, lv, mk, mn, mr-IN, ms, nb, ne, nl, nn, or,
-> pl, pt, pt-BR, rm, ro, ru, sk, sl, sr, sv, sw, ta, th, tl, tr, tt, ug, uk, ur,
-> uz, vi, wo, zh-CN, zh-HK, zh-TW, zh-YUE
+> pa, pl, pt, pt-BR, rm, ro, ru, sk, sl, sr, sv, sw, ta, th, tl, tr, tt, ug, uk,
+> ur, uz, vi, wo, zh-CN, zh-HK, zh-TW, zh-YUE
 
 Currently, no locales are complete. Typically they lack the following keys:
 

--- a/rails/locale/pa.yml
+++ b/rails/locale/pa.yml
@@ -1,0 +1,205 @@
+---
+pa:
+  date:
+    abbr_day_names:
+    - ਅੈਤ
+    - ਸੋਮ
+    - ਮੰਗਲ
+    - ਬੱੁਧ
+    - ਵੀਰ
+    - ਸ਼ੁੱਕਰ
+    - ਸ਼ਨਿੱਚਰ
+    abbr_month_names:
+    - 
+    - ਜਨ
+    - ਫ਼ਰ
+    - ਮਾਰਚ
+    - ਅਪ੍ਰੈ
+    - ਮਈ
+    - ਜੂਨ
+    - ਜੁਲਾ
+    - ਅਗ
+    - ਸਤੰ
+    - ਅਕਤੂ
+    - ਨਵੰ
+    - ਦਸੰ
+    day_names:
+    - ਐਤਵਾਰ
+    - ਸੋਮਵਾਰ
+    - ਮੰਗਲਵਾਰ
+    - ਬੁੱਧਵਾਰ
+    - ਵੀਰਵਾਰ
+    - ਸ਼ੁੱਕਰਵਾਰ
+    - ਸ਼ਨਿੱਚਰਵਾਰ
+    formats:
+      default: "%Y-%m-%d"
+      long: "%B %d, %Y"
+      short: "%b %d"
+    month_names:
+    - 
+    - ਜਨਵਰੀ
+    - ਫ਼ਰਵਰੀ
+    - ਮਾਰਚ
+    - ਅਪ੍ੈਲ
+    - ਮਈ
+    - ਜੂਨ
+    - ਜੁਲਾਈ
+    - ਅਗਸਤ
+    - ਸਤੰਬਰ
+    - ਅਕਤੂਬਰ
+    - ਨਵੰਬਰ
+    - ਦਸੰਬਰ
+    order:
+    - :year
+    - :month
+    - :day
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: ਲਗਭਗ 1 ਘੰਟਾ
+        other: ਲਗਭਗ %{count} ਘੰਟੇ
+      about_x_months:
+        one: ਲਗਭਗ 1 ਮਹੀਨਾ
+        other: ਲਗਭਗ %{count} ਮਹੀਨੇ
+      about_x_years:
+        one: ਲਗਭਗ 1 ਸਾਲ
+        other: ਲਗਭਗ %{count} ਸਾਲ
+      almost_x_years:
+        one: ਤਕਰੀਬਨ 1 ਸਾਲ
+        other: ਤਕਰੀਬਨ %{count} ਸਾਲ
+      half_a_minute: ਅੱਧਾ ਮਿੰਟ
+      less_than_x_minutes:
+        one: 1 ਮਿੰਟ ਤੋਂ ਘੱਟ
+        other: "%{count} ਮਿੰਟਾਂ ਤੋਂ ਘੱਟ"
+      less_than_x_seconds:
+        one: 1 ਸਕਿੰਟ ਤੋਂ ਘੱਟ
+        other: "%{count} ਸਕਿੰਟਾਂ ਤੋਂ ਘੱਟ"
+      over_x_years:
+        one: 1 ਸਾਲ ਤੋਂ ਵੱਧ
+        other: "%{count} ਸਾਲਾਂ ਤੋਂ ਵੱਧ"
+      x_days:
+        one: 1 ਦਿਨ
+        other: "%{count} ਦਿਨ"
+      x_minutes:
+        one: 1 ਮਿੰਟ
+        other: "%{count} ਮਿੰਟ"
+      x_months:
+        one: 1 ਮਹੀਨਾ
+        other: "%{count} ਮਹੀਨੇ"
+      x_seconds:
+        one: 1 ਸਕਿੰਟ
+        other: "%{count} ਸਕਿੰਟ"
+    prompts:
+      day: ਦਿਨ
+      hour: ਘੰਟਾ
+      minute: ਮਿੰਟ
+      month: ਮਹੀਨਾ
+      second: ਸਕਿੰਟ
+      year: ਸਾਲ
+  errors:
+    format: "%{attribute} %{message}"
+    messages:
+      accepted: ਜਰੂਰੀ ਮੰਜੂਰ ਹੋਵੇ
+      blank: ਖਾਲੀ ਨਹੀਂ ਹੋ ਸਕਦਾ
+      present: ਜਰੂਰੀ ਖਾਲੀ ਹੋਵੇ
+      confirmation: "%{attribute} ਨਹੀਂ ਰਲਦੇ"
+      empty: ਖਾਲੀ ਨਹੀਂ ਹੋ ਸਕਦਾ
+      equal_to: "%{count} ਦੇ ਬਰਾਬਰ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ"
+      even: ਜਰੂਰੀ ਹੈ ਕੇ ਜੋਟਾ ਹੋਵੇ
+      exclusion: ਮੱਲਿਆ ਹੋਇਆ ਹੈ
+      greater_than: "%{count} ਤੋਂ ਵਧੇਰੇ ਹੋਣਾ ਜਰੂਰੀ ਹੈ"
+      greater_than_or_equal_to: "%{count} ਤੋਂ ਵਧੇਰੇ ਜਾਂ ਬਰਾਬਰ ਹੋਣਾ ਜਰੂਰੀ ਹੈ"
+      inclusion: ਇਸ ਲਿਸਟ ਵਿੱਚ ਸ਼ਾਮਿਲ ਨਹੀਂ ਹੈ
+      invalid: ਨਾ-ਮੰਜੂਰਸ਼ੁਦਾ ਹੈ
+      less_than: "%{count} ਤੋਂ ਘੱਟ ਹੋਣਾ ਜਰੂਰੀ ਹੈ"
+      less_than_or_equal_to: "%{count} ਤੋਂ ਘੱਟ ਜਾਂ ਬਰਾਬਰ ਹੋਣਾ ਜਰੂਰੀ ਹੈ"
+      not_a_number: ਸੰਖਿਆ ਨਹੀਂ ਹੈ
+      not_an_integer: ਜਰੂਰੀ ਹੈ ਕੇ ਪੂਰਨ ਅੰਕ ਹੋਵੇ
+      odd: ਜਰੂਰੀ ਹੈ ਕੇ ਕਲ੍ਲੀ ਹੋਵੇ
+      record_invalid: 'ਪਰਮਾਣ ਫ਼ੇਲ ਹੋਇਆ: %{errors}'
+      restrict_dependent_destroy:
+        one: ਮਿਟਾ ਨਹੀਂ ਸਕਦੇ ਕਿਉਂਕਿ ਇੱਕ ਨਿਰਭਰ %{record} ਮੌਜੂਦ ਹੈ
+        many: ਮਿਟਾ ਨਹੀਂ ਸਕਦੇ ਕਿਉਂਕਿ ਨਿਰਭਰ %{record} ਮੌਜੂਦ ਹਨ
+      taken: ਪਹਿਲਾਂ ਹੀ ਮੱਲਿਆ ਹੋਇਆ ਹੈ
+      too_long:
+        one: ਲੰਬਾਈ ਜ਼ਿਆਦਾ ਹੈ (ਵੱਧ ਤੋਂ ਵੱਧ 1 ਅੱਖਰ)
+        other: ਲੰਬਾਈ ਜ਼ਿਆਦਾ ਹੈ (ਵੱਧ ਤੋਂ ਵੱਧ %{count} ਅੱਖਰ)
+      too_short:
+        one: ਲੰਬਾਈ ਘੱਟ ਹੈ (ਘੱਟ ਤੋਂ ਘੱਟ 1 ਅੱਖਰ)
+        other: ਲੰਬਾਈ ਘੱਟ ਹੈ (ਘੱਟ ਤੋਂ ਘੱਟ %{count} ਅੱਖਰ)
+      wrong_length:
+        one: ਲੰਬਾਈ ਗਲਤ ਹੈ (1 ਅੱਖਰ ਹੋਣੀ ਚਾਹੀਦੀ ਹੈ)
+        other: ਲੰਬਾਈ ਗਲਤ ਹੈ (%{count} ਅੱਖਰ ਹੋਣੀ ਚਾਹੀਦੀ ਹੈ)
+      other_than: "%{count} ਦੀ ਜਗਾਹ ਹੋਰ ਹੋਣੀ ਚਾਹੀਦੀ ਹੈ"
+    template:
+      body: 'ਹੇਠਲੇ ਖੇਤਰਾਂ ਵਿੱਚ ਗਲਤੀਆਂ ਹਨ:'
+      header:
+        one: 1 ਗਲਤੀ ਕਰਕੇ ਇਹ %{model} ਬਚਾਇਆ ਨਹੀਂ ਗਿਆ
+        other: "%{count} ਗਲਤੀਆਂ ਕਰਕੇ ਇਹ %{model} ਬਚਾਇਆ ਨਹੀਂ ਗਿਆ"
+  helpers:
+    select:
+      prompt: ਕਿਰਪਾ ਕਰਕੇ ਚੁਣੋ
+    submit:
+      create: "%{model} ਬਣਾਓ"
+      submit: "%{model} ਬਚਾਓ"
+      update: "%{model} ਬਦਲੋ"
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u%n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "$"
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: ਅਰਬ
+          million: ਮਿਲੀਅਨ
+          quadrillion: ਕ੍ਵਾਡਰਿਲੀਅਨ
+          thousand: ਹਜਾਰ
+          trillion: ਟ੍ਰਿਲੀਅਨ
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: ਬਾਈਟ
+            other: ਬਾਈਟ
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: ", ਅਤੇ "
+      two_words_connector: " ਅਤੇ "
+      words_connector: ", "
+  time:
+    am: ਪੂ.ਦੁ.
+    formats:
+      default: "%a, %d %b %Y %H:%M:%S %z"
+      long: "%B %d, %Y %H:%M"
+      short: "%d %b %H:%M"
+    pm: ਬਾ.ਦੁ.

--- a/rails/pluralization/pa.rb
+++ b/rails/pluralization/pa.rb
@@ -1,0 +1,3 @@
+require 'rails_i18n/common_pluralizations/one_with_zero_other'
+
+::RailsI18n::Pluralization::OneWithZeroOther.with_locale(:pa)


### PR DESCRIPTION
Added support for Panjabi - 10th most widely spoken language in the world. ISO code for Gurmukhi Script of Panjabi (also called Punjabi) is pa. The test specs and completeness rake task against en.yml are both passing.