### PR TITLE
Change Bosnian locale Time format

### DIFF
--- a/rails/locale/bs.yml
+++ b/rails/locale/bs.yml
@@ -238,7 +238,7 @@ bs:
   time:
     am: ''
     formats:
-      default: "%H:%M:%S"
+      default: "%d.%m.%Y. %H:%M:%S"
       long: "%d. %B %Y. - %H:%M:%S"
       short: "%d. %b %Y. %H:%M"
     pm: ''


### PR DESCRIPTION
Time should return Date&Time not only Time. 
```
before: Time.current returnes => 10:51:15
afte: Time.current returnes => 09.12.2015 10:51:15
```

This is very useful when working with localization and time zones, because usually people use Time.current (for everything that has date or time), also it is consistent with other locales such as English, Croatian, etc ...