### PR TITLE
comment rails 4.0 in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ Add to your Gemfile:
     gem 'rails-i18n', '~> 5.0.0.beta1' # For 5.0.0.beta1
     gem 'rails-i18n', '~> 4.0.0' # For 4.0.x
     gem 'rails-i18n', '~> 3.0.0' # For 3.x
-    gem 'rails-i18n', github: 'svenfuchs/rails-i18n', branch: 'master' # For 4.x
+    gem 'rails-i18n', github: 'svenfuchs/rails-i18n', branch: 'master' # For 5.x
+    gem 'rails-i18n', github: 'svenfuchs/rails-i18n', branch: 'rails-4-x' # For 4.x
     gem 'rails-i18n', github: 'svenfuchs/rails-i18n', branch: 'rails-3-x' # For 3.x
 
 or run this command:


### PR DESCRIPTION
[skip ci]

Looks like some commits that went in now have master pegged to rails 5.x

Updated the readme to reflect

