### PR TITLE
Use correct long scale names for large numbers

### DIFF
--- a/rails/locale/nl.yml
+++ b/rails/locale/nl.yml
@@ -168,9 +168,9 @@ nl:
         units:
           billion: miljard
           million: miljoen
-          quadrillion: quadriljoen
+          quadrillion: biljard
           thousand: duizend
-          trillion: triljoen
+          trillion: biljoen
           unit: ''
       format:
         delimiter: ''


### PR DESCRIPTION
This fixes a bug introduced in PR #589 