### PR TITLE
Fix missing translations for Dutch (nl) locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Available locales are:
 Complete locales are:
 
 > en-US, es, es-419, es-AR, es-CL, es-CO, es-CR, es-EC, es-MX, es-PA, es-PE,
-> es-US, es-VE, ja, pt-BR
+> es-US, es-VE, ja, nl, pt-BR
 
 Currently, most locales are incomplete. Typically they lack the following keys:
 

--- a/rails/locale/nl.yml
+++ b/rails/locale/nl.yml
@@ -120,9 +120,11 @@ nl:
       invalid: is ongeldig
       less_than: moet minder zijn dan %{count}
       less_than_or_equal_to: moet minder dan of gelijk zijn aan %{count}
+      model_invalid: "Validatie mislukt: %{errors}"
       not_a_number: is geen getal
       not_an_integer: moet een geheel getal zijn
       odd: moet oneven zijn
+      required: moet bestaan
       taken: is al in gebruik
       too_long:
         one: is te lang (maximaal %{count} teken)


### PR DESCRIPTION
This commit adds missing translations for `nl.yml` as reported by `bundle exec rake i18n-spec:completeness`.