### PR TITLE
Changed Norwegian time separator from colon to dot.

### DIFF
--- a/rails/locale/nb.yml
+++ b/rails/locale/nb.yml
@@ -203,7 +203,7 @@ nb:
   time:
     am: ''
     formats:
-      default: "%A, %e. %B %Y, %H:%M"
-      long: "%A, %e. %B %Y, %H:%M"
-      short: "%e. %B, %H:%M"
+      default: "%A, %e. %B %Y, %H.%M"
+      long: "%A, %e. %B %Y, %H.%M"
+      short: "%e. %B, %H.%M"
     pm: ''


### PR DESCRIPTION
Both are allowed since new changes in 2014 but dot is preferred and has been the standard.

Source (Norwegian): http://www.korrekturavdelingen.no/K4Klokkeslett.htm