### PR TITLE
In Spanish, day and month numbers are not preceded by zero

### DIFF
--- a/rails/locale/es.yml
+++ b/rails/locale/es.yml
@@ -32,9 +32,9 @@ es:
     - viernes
     - sábado
     formats:
-      default: "%d/%m/%Y"
-      long: "%d de %B de %Y"
-      short: "%d de %b"
+      default: "%-d/%-m/%Y"
+      long: "%-d de %B de %Y"
+      short: "%-d de %b"
     month_names:
     - 
     - enero
@@ -198,7 +198,7 @@ es:
   time:
     am: am
     formats:
-      default: "%A, %d de %B de %Y %H:%M:%S %z"
-      long: "%d de %B de %Y %H:%M"
-      short: "%d de %b %H:%M"
+      default: "%A, %-d de %B de %Y %H:%M:%S %z"
+      long: "%-d de %B de %Y %H:%M"
+      short: "%-d de %b %H:%M"
     pm: pm


### PR DESCRIPTION
[RAE](https://en.wikipedia.org/wiki/Real_Academia_Espa%C3%B1ola) recommends not to prepend, except for imperative technical reasons, a zero before the day when this figure is less than 10 (better "4/2/2016" than "04/02/2016")

Source (in Spanish): http://www.fundeu.es/escribireninternet/como-se-escriben-las-fechas/

Note that this can be different in other countries, that's why I only changed the main (Spain) `es.yml` file