### PR TITLE
fixing arabic word connector

### DIFF
--- a/rails/locale/ar.yml
+++ b/rails/locale/ar.yml
@@ -267,8 +267,8 @@ ar:
   support:
     array:
       last_word_connector: " و "
-      two_words_connector: " ،"
-      words_connector: " و "
+      two_words_connector: " و "
+      words_connector: " ، "
   time:
     am: صباحًا
     formats:


### PR DESCRIPTION
in my previous change i updated the ar.yml error messages to fit all arabic attribute but i misplaced the two_words_connector and words_connector...