### PR TITLE
Fix typo and correct some translations for Khmer(.km)

### DIFF
--- a/rails/locale/km.yml
+++ b/rails/locale/km.yml
@@ -136,11 +136,11 @@ km:
       decimal_units:
         format: "%n %u"
         units:
-          billion: ប៊ីលាន
+          billion: ពាន់លាន
           million: លាន
           quadrillion: ក្វាឌ្រីលាន
           thousand: ពាន់
-          trillion: ទ្រីលាន
+          trillion: ពាន់ពាន់លាន
           unit: ''
       format:
         delimiter: ''
@@ -159,7 +159,7 @@ km:
       two_words_connector: " និង "
       words_connector: ", "
   time:
-    am: ព្រិក
+    am: ព្រឹក
     formats:
       default: "%a %d %b %Y %H:%M:%S %z"
       long: "%d %B %Y %H:%M"


### PR DESCRIPTION
Some words are literally wrong translated, eg:

Billion: should be(ពាន់លាន)
https://translate.google.com/#auto/km/billion

Trillion: should be(ពាន់ពាន់លាន)
https://translate.google.com/#auto/km/trillion

Actually, google translated correctly.

Quadrillion: is also wrong translated, google translate is also wrong. But I also never seen this large number in Khmer language, so I also don't know how to call it too :)