### PR TITLE
Add `required` translation to de.yml

### DIFF
--- a/rails/locale/de.yml
+++ b/rails/locale/de.yml
@@ -124,6 +124,7 @@ de:
       not_a_number: ist keine Zahl
       not_an_integer: muss ganzzahlig sein
       odd: muss ungerade sein
+      required: muss ausgefüllt werden
       taken: ist bereits vergeben
       too_long:
         one: ist zu lang (mehr als 1 Zeichen)


### PR DESCRIPTION
This makes it work on Rails 5. See also https://github.com/svenfuchs/rails-i18n/pull/631

I'll add more translations if I find out more are missing.