### PR TITLE
Update nb and nn locales

### DIFF
--- a/rails/locale/nb.yml
+++ b/rails/locale/nb.yml
@@ -109,7 +109,7 @@ nb:
       accepted: må være akseptert
       blank: kan ikke være blank
       present: må være blank
-      confirmation: passer ikke bekreftelsen
+      confirmation: er ikke lik %{attribute}
       empty: kan ikke være tom
       equal_to: må være lik %{count}
       even: må være partall
@@ -120,9 +120,11 @@ nb:
       invalid: er ugyldig
       less_than: må være mindre enn %{count}
       less_than_or_equal_to: må være mindre enn eller lik %{count}
+      model_invalid: 'Det oppstod feil: %{errors}'
       not_a_number: er ikke et tall
       not_an_integer: er ikke et heltall
       odd: må være oddetall
+      required: må eksistere
       taken: er allerede i bruk
       too_long: er for lang (maksimum %{count} tegn)
       too_short: er for kort (minimum %{count} tegn)
@@ -192,6 +194,7 @@ nb:
     percentage:
       format:
         delimiter: ''
+        format: "%n%"
     precision:
       format:
         delimiter: ''

--- a/rails/locale/nn.yml
+++ b/rails/locale/nn.yml
@@ -107,7 +107,7 @@ nn:
       accepted: må vera akseptert
       blank: kan ikkje vera blank
       present: må vera blank
-      confirmation: er ikkje stadfesta
+      confirmation: er ikkje lik %{attribute}
       empty: kan ikkje vera tom
       equal_to: må vera lik %{count}
       even: må vera partal
@@ -118,9 +118,11 @@ nn:
       invalid: er ugyldig
       less_than: må vera mindre enn %{count}
       less_than_or_equal_to: må vera mindre enn eller lik %{count}
+      model_invalid: 'Valideringa mislukka: %{errors}'
       not_a_number: er ikkje eit tal
       not_an_integer: er ikkje eit heiltal
       odd: må vera oddetal
+      required: må eksistera
       taken: er allereie i bruk
       too_long: er for lang (maksimum %{count} teikn)
       too_short: er for kort (minimum %{count} teikn)
@@ -134,7 +136,7 @@ nn:
       prompt: Gjer eit val
     submit:
       create: Lag %{model}
-      submit: Lagr %{model}
+      submit: Lagre %{model}
       update: Oppdater %{model}
   number:
     currency:
@@ -188,6 +190,7 @@ nn:
     percentage:
       format:
         delimiter: ''
+        format: "%n%"
     precision:
       format:
         delimiter: ''


### PR DESCRIPTION
Fixes confirmation in both nb and nn from the equivalent of:
"{confirmation} does not match confirmation" to
"{confirmation} does not match {attribute}"

Adds three missing fields in nb and nn.

Fixes a typo in nn for submit.