### PR TITLE
Added Albanian Translation for the rails-4-x branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Available locales are:
 > es-419, es-AR, es-CL, es-CO, es-CR, es-EC, es-ES, es-MX, es-PA, es-PE, es-US, es-VE,
 > et, eu, fa, fi, fr, fr-CA, fr-CH, fr-FR, gl, he, hi, hi-IN, hr, hu, id, is, it,
 > it-CH, ja, km, kn, ko, lb, lo, lt, lv, mk, mn, mr-IN, ms, nb, ne, nl, nn, or,
-> pa, pl, pt, pt-BR, rm, ro, ru, sk, sl, sr, sv, sw, ta, th, tl, tr, tt, ug, uk,
+> pa, pl, pt, pt-BR, rm, ro, ru, sk, sl, sq, sr, sv, sw, ta, th, tl, tr, tt, ug, uk,
 > ur, uz, vi, wo, zh-CN, zh-HK, zh-TW, zh-YUE
 
 Currently, no locales are complete. Typically they lack the following keys:

--- a/rails/locale/sq.yml
+++ b/rails/locale/sq.yml
@@ -1,0 +1,205 @@
+---
+sq:
+  date:
+    abbr_day_names:
+    - E Diel
+    - E Hënë
+    - E Martë
+    - E Mërkurë
+    - E Enjte
+    - E Premte
+    - E Shtunë
+    abbr_month_names:
+    -
+    - Janar
+    - Shkurt
+    - Mars
+    - Prill
+    - Maj
+    - Qershor
+    - Korrik
+    - Gusht
+    - Shtator
+    - Tetor
+    - Nëntor
+    - Dhjetor
+    day_names:
+    - E Diel
+    - E Hënë
+    - E Martë
+    - E Mërkurë
+    - E Enjte
+    - E Premte
+    - E Shtunë
+    formats:
+      default: "%m-%d-%Y"
+      long: "%B %d, %Y"
+      short: "%b %d"
+    month_names:
+    -
+    - Janar
+    - Shkurt
+    - Mars
+    - Prill
+    - Maj
+    - Qershor
+    - Korrik
+    - Gusht
+    - Shtator
+    - Tetor
+    - Nëntor
+    - Dhjetor
+    order:
+    - :month
+    - :day
+    - :year
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: rreth 1 orë
+        other: rreth %{count} orë
+      about_x_months:
+        one: rreth 1 muaj
+        other: rreth %{count} muaj
+      about_x_years:
+        one: rreth 1 vit
+        other: rreth %{count} vite
+      almost_x_years:
+        one: gati 1 vit
+        other: gati %{count} vite
+      half_a_minute: gjysëm minute
+      less_than_x_minutes:
+        one: më pak se një minutë
+        other: më pak se %{count} minuta
+      less_than_x_seconds:
+        one: më pak se 1 sekond
+        other: më pak se %{count} sekonda
+      over_x_years:
+        one: mbi 1 vit
+        other: mbi %{count} vite
+      x_days:
+        one: 1 ditë
+        other: "%{count} ditë"
+      x_minutes:
+        one: 1 minutë
+        other: "%{count} minuta"
+      x_months:
+        one: 1 muaj
+        other: "%{count} muaj"
+      x_seconds:
+        one: 1 sekond
+        other: "%{count} sekonda"
+    prompts:
+      day: Ditë
+      hour: Orë
+      minute: Minutë
+      month: Muaj
+      second: Sekond
+      year: Vit
+  errors:
+    format: "%{attribute} %{message}"
+    messages:
+      accepted: duhet të pranohet
+      blank: nuk mund të jetë bosh
+      present: duhet të jetë bosh
+      confirmation: nuk përputhet me %{attribute}
+      empty: nuk mund të jetë bosh
+      equal_to: duhet të përputhet me %{count}
+      even: duhet të jetë i barabartë
+      exclusion: është i rezervuar
+      greater_than: duhet të jetë më shumë se %{count}
+      greater_than_or_equal_to: duhet të jetë më shumë ose i barabartë me %{count}
+      inclusion: nuk është i përfshirë në list
+      invalid: është e palejuar
+      less_than: duhet të jetë më pak se %{count}
+      less_than_or_equal_to: duhet të jetë më pak ose i barabartë me %{count}
+      not_a_number: nuk është numër
+      not_an_integer: duhet të jetë numër
+      odd: duhet të jetë tek
+      record_invalid: 'Validimi dështoi: %{errors}'
+      restrict_dependent_destroy:
+        one: Nuk mund të fshini rekordin për shkak se një %{record} i varur ekziston
+        many: Nuk mund të fshini rekordin për shkak se %{record} të varura ekzistojnë
+      taken: është marrë tashmë
+      too_long:
+        one: është shumë i gjatë (maksimumi është 1 shkronjë)
+        other: është shumë i gjatë (maksimumi është %{count} shkronja)
+      too_short:
+        one: është shumë i shkurtër (minimumi është 1 shkronjë)
+        other: është shumë i shkurtër (minimumi është %{count} shkronja)
+      wrong_length:
+        one: është gjatësia e gabuar (duhet të jetë 1 shkronjë)
+        other: është gjatësia e gabuar (duhet të jetë %{count} shkronja)
+      other_than: duhet të jetë më shumë se %{count}
+    template:
+      body: 'Kishte probleme me formën e mëposhtme:'
+      header:
+        one: 1 veprim i gabuar e ndaloi këtë %{model} për t'u ruajtur
+        other: "%{count} veprime të gabuara e ndaluan këtë %{model} për t'u ruajtur"
+  helpers:
+    select:
+      prompt: Ju lutem zgjidhni
+    submit:
+      create: Krijo %{model}
+      submit: Ruaj %{model}
+      update: Ndrysho %{model}
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u%n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "LEK"
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: Bilion
+          million: Milion
+          quadrillion: Kuatrilion
+          thousand: Mijë
+          trillion: Trilion
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: ", dhe "
+      two_words_connector: " dhe "
+      words_connector: ", "
+  time:
+    am: në mëngjes
+    formats:
+      default: "%a, %d %b %Y %I:%M:%S %p %Z"
+      long: "%B %d, %Y %I:%M %p"
+      short: "%d %b %I:%M %p"
+    pm: mbasdite


### PR DESCRIPTION
I've completed the hole translation for my mother tongue Albanian for the rails 4 branch. Also i updated the Readme.md just like the instructions said.
Note that if you might have noticed that abbreviations are the same as the full words this is because in Albanian abbreviations of week days and months don't exist.
