### PR TITLE
remove outdated instructions regarding &errors_messages anchoring/merging

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,6 @@ If you are not,
 ### Create or edit your locale file
 
 * Have a look in `rails/locale/en.yml`, which should be used as the base of your translation.
-  Note that we use `&errors_messages` and `<<: *errors_messages` to anchor and merge a part of translation data.
 * Create or edit your locale file.
   Please pay attention to save your files as UTF-8.
 


### PR DESCRIPTION
From what I can tell, this anchoring/merging stopped when 655e9c1355082ac100e8ea546fd5eaee5e417468 removed the activemodel and activerecord namespaces, so we can safely remove this comment from readme.