### PR TITLE
Don't translate most of storage units in ja locale

### DIFF
--- a/rails/locale/ja.yml
+++ b/rails/locale/ja.yml
@@ -177,10 +177,10 @@ ja:
         format: "%n%u"
         units:
           byte: バイト
-          gb: ギガバイト
-          kb: キロバイト
-          mb: メガバイト
-          tb: テラバイト
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
     percentage:
       format:
         delimiter: ''


### PR DESCRIPTION
In my personal experience, Japanese people are familiar with untranslated units like *GB*,  *MB* and so on.  OSX's Finder is an example.

 
![storage_units](https://cloud.githubusercontent.com/assets/10973/15599616/5678b6fe-241f-11e6-9184-e5e4c4d5d273.png)

This PR leaves these units untranslated except single letter *B* for *byte* (バイト).

EDIT: minor English grammar
