### PR TITLE
Fix broken and add missing translations to et.yml

### DIFF
--- a/rails/locale/et.yml
+++ b/rails/locale/et.yml
@@ -110,7 +110,7 @@ et:
       equal_to: peab olema võrdne arvuga %{count}
       even: peab olema paarisarv
       exclusion: on reserveeritud
-      greater_than: ei tohi olla suurem kui %{count}
+      greater_than: peab olema suurem kui %{count}
       greater_than_or_equal_to: peab olema suurem või võrdne arvuga %{count}
       inclusion: ei leidu nimekirjas
       invalid: ei ole korrektne

--- a/rails/locale/et.yml
+++ b/rails/locale/et.yml
@@ -4,6 +4,9 @@ et:
     errors:
       messages:
         record_invalid: 'Valideerimine ebaõnnestus: %{errors}'
+        restrict_dependent_destroy:
+          has_one: "Ei saa kirjet kustutada kuna sõltuv %{record} on olemas"
+          has_many: "Ei saa kirjet kustutada kuna sõltuvad %{record} on olemas"
   date:
     abbr_day_names:
     - P
@@ -90,6 +93,9 @@ et:
       x_months:
         one: "%{count} kuu"
         other: "%{count} kuud"
+      x_years:
+        one: "%{count} aasta"
+        other: "%{count} aastat"
       x_seconds:
         one: "%{count} sekund"
         other: "%{count} sekundit"
@@ -105,6 +111,7 @@ et:
     messages:
       accepted: peab olema heaks kiidetud
       blank: on täitmata
+      present: peab olema täitmata
       confirmation: ei vasta kinnitusele
       empty: on tühi
       equal_to: peab olema võrdne arvuga %{count}
@@ -116,13 +123,16 @@ et:
       invalid: ei ole korrektne
       less_than: peab olema vähem kui %{count}
       less_than_or_equal_to: peab olema vähem või võrdne arvuga %{count}
+      model_invalid: "Valideerimine ebaõnnestus: %{errors}"
       not_a_number: ei ole number
       not_an_integer: peab olema täisarv
       odd: peab olema paaritu arv
+      required: peab olemas olema
       taken: on juba võetud
       too_long: on liiga pikk (maksimum on %{count} tähemärki)
       too_short: on liiga lühike (miinimum on %{count} tähemärki)
       wrong_length: on vale pikkusega (peab olema %{count} tähemärki)
+      other_than: peab olema midagi muud kui %{count}
     template:
       body: 'Probleeme ilmnes järgmiste väljadega:'
       header:
@@ -179,6 +189,7 @@ et:
     percentage:
       format:
         delimiter: ''
+        format: "%n%"
     precision:
       format:
         delimiter: ''


### PR DESCRIPTION
During some work with Validations, figured out `et.yml` translation for `greater_than` was completely incorrect, it was vice versa, saying basically that "cannot be greater than X".

After reading Contribution notes, validates `et.yml` against `en.yml` and figured out some newer translations are missing, so added these as well.