### PR TITLE
removing dead code, :other is never returned

### DIFF
--- a/rails/pluralization/pl.rb
+++ b/rails/pluralization/pl.rb
@@ -11,10 +11,8 @@ module RailsI18n
             :one
           elsif [2, 3, 4].include?(mod10) && ![12, 13, 14].include?(mod100)
             :few
-          elsif ([0, 1] + (5..9).to_a).include?(mod10) || [12, 13, 14].include?(mod100)
-            :many
           else
-            :other
+            :many
           end
         end
       end


### PR DESCRIPTION
the negation of:
    [2, 3, 4].include?(mod10) && ![12, 13, 14].include?(mod100)
is:
    ([0, 1] + (5..9).to_a).include?(mod10) || [12, 13, 14].include?(mod100)
so there is no need to check that and we can just use `else` keyword.
The implication of that is that the `:other` is never returned.