### PR TITLE
Fix common mistake in this word

### DIFF
--- a/rails/locale/az.yml
+++ b/rails/locale/az.yml
@@ -113,7 +113,7 @@ az:
       greater_than: "%{count}-dən böyük olmalıdır"
       greater_than_or_equal_to: böyük və ya %{count}-ə bərabər olmalıdır
       inclusion: siyahiyə daxil deyil
-      invalid: yalnışdır
+      invalid: yanlışdır
       less_than: "%{count}-dən kiçik olmalıdır"
       less_than_or_equal_to: kiçik və ya %{count}-ə bərabər olmalıdır
       not_a_number: rəqəm deyil


### PR DESCRIPTION
Hello,

This PR is to fix common mistake, when letters are placed in a row as pronounced which is wrong.

Refer to: https://azerdict.com/az/izahli-luget/yanl%C4%B1%C5%9F

Thanks