### PR TITLE
Fix a semantic error in da.yml

### DIFF
--- a/rails/locale/da.yml
+++ b/rails/locale/da.yml
@@ -126,7 +126,7 @@ da:
       odd: skal være et ulige tal
       required: skal eksistere
       taken: er allerede brugt
-      too_long: er for lang (højest %{count} tegn)
+      too_long: er for lang (højst %{count} tegn)
       too_short: er for kort (mindst %{count} tegn)
       wrong_length: har forkert længde (skulle være %{count} tegn)
       other_than: skal være forskellig fra %{count}


### PR DESCRIPTION
'Højst' means 'no more than'. 'Højest' means 'The highest' (as in 'she is the highest of the two of them')

Source: http://syntaksis.dk/hoejst-eller-hoejest/