### PR TITLE
es.yml was missing the key x_years

### DIFF
--- a/rails/locale/es.yml
+++ b/rails/locale/es.yml
@@ -93,6 +93,9 @@ es:
       x_months:
         one: 1 mes
         other: "%{count} meses"
+      x_years:
+        one: 1 year
+        other: "%{count} years"
       x_seconds:
         one: 1 segundo
         other: "%{count} segundos"


### PR DESCRIPTION
The key is present in the :en locale, but not in the :es locale, causing line count to be different.