### PR TITLE
Improve 'required' translation (pt-BR)

### DIFF
--- a/rails/locale/pt-BR.yml
+++ b/rails/locale/pt-BR.yml
@@ -124,7 +124,7 @@ pt-BR:
       not_a_number: não é um número
       not_an_integer: não é um número inteiro
       odd: deve ser ímpar
-      required: deve existir
+      required: é obrigatório(a)
       taken: já está em uso
       too_long:
         one: 'é muito longo (máximo: 1 caracter)'


### PR DESCRIPTION
`errors.messages.required` is used when a `belongs_to` relationship isn't `optional` (Rails 5+), so it'd make more sense to change this translation:

## Before

> Categoria deve existir
> Conta deve existir
> Usuário deve existir

## After

> Categoria é obrigatório(a)
> Conta é obrigatório(a)
> Usuário é obrigatório(a)