### PR TITLE
Add x_years translation for ja.

### DIFF
--- a/rails/locale/ja.yml
+++ b/rails/locale/ja.yml
@@ -93,6 +93,9 @@ ja:
       x_months:
         one: 1ヶ月
         other: "%{count}ヶ月"
+      x_years:
+        one: 1年
+        other: "%{count}年"
       x_seconds:
         one: 1秒
         other: "%{count}秒"


### PR DESCRIPTION
I imported `en` and `ja` translation to my rails project, and noticed an missing key. So added it.

before

```bash
bundle exec rake i18n-spec:completeness rails/locale/en.yml rails/locale/ja.yml
### rails/locale/ja.yml

- *MISSING* datetime.distance_in_words.x_years
```

after

```bash
bundle exec rake i18n-spec:completeness rails/locale/en.yml rails/locale/ja.yml
### rails/locale/ja.yml

- *COMPLETE* 
```

Thank you for useful template:)