### PR TITLE
Reordering distance_in_words for en locale to be smallest to biggest

### DIFF
--- a/rails/locale/en.yml
+++ b/rails/locale/en.yml
@@ -62,43 +62,43 @@ en:
     - :day
   datetime:
     distance_in_words:
+      x_seconds:
+        one: 1 second
+        other: "%{count} seconds"
+      less_than_x_seconds:
+        one: less than 1 second
+        other: less than %{count} seconds
+      half_a_minute: half a minute
+      less_than_x_minutes:
+        one: less than a minute
+        other: less than %{count} minutes
+      x_minutes:
+        one: 1 minute
+        other: "%{count} minutes"
+      x_days:
+        one: 1 day
+        other: "%{count} days"
       about_x_hours:
         one: about 1 hour
         other: about %{count} hours
+      x_months:
+        one: 1 month
+        other: "%{count} months"
       about_x_months:
         one: about 1 month
         other: about %{count} months
+      x_years:
+        one: 1 year
+        other: "%{count} years"  
       about_x_years:
         one: about 1 year
         other: about %{count} years
       almost_x_years:
         one: almost 1 year
         other: almost %{count} years
-      half_a_minute: half a minute
-      less_than_x_minutes:
-        one: less than a minute
-        other: less than %{count} minutes
-      less_than_x_seconds:
-        one: less than 1 second
-        other: less than %{count} seconds
       over_x_years:
         one: over 1 year
         other: over %{count} years
-      x_days:
-        one: 1 day
-        other: "%{count} days"
-      x_minutes:
-        one: 1 minute
-        other: "%{count} minutes"
-      x_months:
-        one: 1 month
-        other: "%{count} months"
-      x_years:
-        one: 1 year
-        other: "%{count} years"  
-      x_seconds:
-        one: 1 second
-        other: "%{count} seconds"
     prompts:
       day: Day
       hour: Hour


### PR DESCRIPTION
So starting from the smallest unit of time to the largest.