### PR TITLE
Use ideographic comma for words_connector of ja

### DIFF
--- a/rails/locale/ja.yml
+++ b/rails/locale/ja.yml
@@ -193,9 +193,9 @@ ja:
         delimiter: ''
   support:
     array:
-      last_word_connector: と
-      two_words_connector: と
-      words_connector: と
+      last_word_connector: 、
+      two_words_connector: 、
+      words_connector: 、
   time:
     am: 午前
     formats:


### PR DESCRIPTION
"と" is similar to "and" in English, and locale of latin-based languages seems to use `, ` for words_connector. It is safer to use "、" for words_connector of ja because of its grammar.

### Grammar background

- Japanese does not have something like last_word_connector, so "red, green and blue"  is "赤と緑と青" or "赤、緑、青" in Japanese.
- "と" is more sensitive to readability
  - (below Japanese sentences means "red, green and blue")
  - "赤と緑と青" is readable, because they are Kanji.
  - "あかとみどりとあお" less readable: "と" does not work well as word separator.
  - "あか、みどり、あお" is good, because words are separated by comma.
- If target of to_sentence is not noun, using "と" causes really ugly grammar.