### PR TITLE
Correct long format in localized ES date

### DIFF
--- a/rails/locale/es.yml
+++ b/rails/locale/es.yml
@@ -40,7 +40,7 @@ es:
     - sábado
     formats:
       default: "%d/%m/%Y"
-      long: "%d de %B de %Y"
+      long: "%d de %B del %Y"
       short: "%d de %b"
     month_names:
     -


### PR DESCRIPTION
In spanish, a year is referenced as "del" not "de".
Ex. "23 de Octubre del 2017"