### PR TITLE
In Spanish, do not prepend leading zero before day and month

### DIFF
--- a/rails/locale/es.yml
+++ b/rails/locale/es.yml
@@ -39,9 +39,9 @@ es:
     - viernes
     - sábado
     formats:
-      default: "%d/%m/%Y"
-      long: "%d de %B de %Y"
-      short: "%d de %b"
+      default: "%-d/%-m/%Y"
+      long: "%-d de %B de %Y"
+      short: "%-d de %b"
     month_names:
     -
     - enero
@@ -211,7 +211,7 @@ es:
   time:
     am: am
     formats:
-      default: "%A, %d de %B de %Y %H:%M:%S %z"
-      long: "%d de %B de %Y %H:%M"
-      short: "%d de %b %H:%M"
+      default: "%A, %-d de %B de %Y %H:%M:%S %z"
+      long: "%-d de %B de %Y %H:%M"
+      short: "%-d de %b %H:%M"
     pm: pm


### PR DESCRIPTION
Some time ago I contributed PR #618 to the `rails-4-x` branch. Now I'd like to do the same change on the `master` (Rails 5) branch.