### PR TITLE
add 12 hour format to locale files

### DIFF
--- a/rails/locale/en.yml
+++ b/rails/locale/en.yml
@@ -210,4 +210,6 @@ en:
       default: "%a, %d %b %Y %H:%M:%S %z"
       long: "%B %d, %Y %H:%M"
       short: "%d %b %H:%M"
+      long_meridiem: "%B %d, %Y %I:%M %p"
+      short_meridiem: "%d %b %I:%M %p"
     pm: pm


### PR DESCRIPTION
Add 12 hour format in our locale files, as many countries use 12 hour format example  US, UK, PH, CA (https://travel.stackexchange.com/questions/34950/which-large-countries-use-12-hour-time-format-am-pm). 
Instead of providing full format whenever calling I18n.l method we can then easily use 12 hour format. If you like this idea, I can make changes in all other locale files. 