### PR TITLE
change katrilyon (in turkish) to kvadrilyon

### DIFF
--- a/rails/locale/az.yml
+++ b/rails/locale/az.yml
@@ -157,7 +157,7 @@ az:
         units:
           billion: Milyard
           million: Milyon
-          quadrillion: Katrilyon
+          quadrillion: Kvadrilyon
           thousand: Min
           trillion: Trilyon
           unit: ''


### PR DESCRIPTION
source: https://azerdict.com/english/quadrillion