### PR TITLE
Add missing datetime translations

### DIFF
--- a/rails/locale/da.yml
+++ b/rails/locale/da.yml
@@ -93,6 +93,9 @@ da:
       x_months:
         one: en måned
         other: "%{count} måneder"
+      x_years:
+        one: en år
+        other: "%{count} år"
       x_seconds:
         one: et sekund
         other: "%{count} sekunder"

--- a/rails/locale/de.yml
+++ b/rails/locale/de.yml
@@ -94,6 +94,9 @@ de:
       x_months:
         one: ein Monat
         other: "%{count} Monate"
+      x_years:
+        one: ein Jahr
+        other: "%{count} Jahr"
       x_seconds:
         one: eine Sekunde
         other: "%{count} Sekunden"

--- a/rails/locale/en.yml
+++ b/rails/locale/en.yml
@@ -95,7 +95,7 @@ en:
         other: "%{count} months"
       x_years:
         one: 1 year
-        other: "%{count} years"  
+        other: "%{count} years"
       x_seconds:
         one: 1 second
         other: "%{count} seconds"

--- a/rails/locale/fr.yml
+++ b/rails/locale/fr.yml
@@ -95,6 +95,9 @@ fr:
       x_months:
         one: 1 mois
         other: "%{count} mois"
+      x_years:
+        one: un an
+        other: "%{count} ans"
       x_seconds:
         one: 1 seconde
         other: "%{count} secondes"

--- a/rails/locale/it.yml
+++ b/rails/locale/it.yml
@@ -93,6 +93,9 @@ it:
       x_months:
         one: 1 mese
         other: "%{count} mesi"
+      x_years:
+        one: 1 anno
+        other: "%{count} anni"
       x_seconds:
         one: 1 secondo
         other: "%{count} secondi"

--- a/rails/locale/nl.yml
+++ b/rails/locale/nl.yml
@@ -93,6 +93,9 @@ nl:
       x_months:
         one: 1 maand
         other: "%{count} maanden"
+      x_years:
+        one: 1 jaar
+        other: "%{count} jaar"
       x_seconds:
         one: 1 seconde
         other: "%{count} seconden"


### PR DESCRIPTION
According to the README, all of the locales changed here are already considered complete. However, I figured I'd suggest a few missing translations, based off the existing ones. With these missing translations added, the changed locales now all have the exact same keys within `datetime`, key parity. Note, I'm perfectly fine with closing it if we're not interested/don't think it's a good idea.

EDIT: As I reverted my removal of two French translations, this is no longer a "synchronize translations" PR. Rather, I'm simply proposing we add a few missing translations and remove some trailing space from `en.yml`.