### PR TITLE
Change pluralization rule for zh-*

### DIFF
--- a/rails/pluralization/zh-CN.rb
+++ b/rails/pluralization/zh-CN.rb
@@ -1,3 +1,3 @@
-require 'rails_i18n/common_pluralizations/other'
+require 'rails_i18n/common_pluralizations/one_other'
 
 ::RailsI18n::Pluralization::OneOther.with_locale(:'zh-CN')

--- a/rails/pluralization/zh-CN.rb
+++ b/rails/pluralization/zh-CN.rb
@@ -1,3 +1,3 @@
 require 'rails_i18n/common_pluralizations/other'
 
-::RailsI18n::Pluralization::Other.with_locale(:'zh-CN')
+::RailsI18n::Pluralization::OneOther.with_locale(:'zh-CN')

--- a/rails/pluralization/zh-HK.rb
+++ b/rails/pluralization/zh-HK.rb
@@ -1,3 +1,3 @@
 require 'rails_i18n/common_pluralizations/other'
 
-::RailsI18n::Pluralization::Other.with_locale(:'zh-HK')
+::RailsI18n::Pluralization::OneOther.with_locale(:'zh-HK')

--- a/rails/pluralization/zh-HK.rb
+++ b/rails/pluralization/zh-HK.rb
@@ -1,3 +1,3 @@
-require 'rails_i18n/common_pluralizations/other'
+require 'rails_i18n/common_pluralizations/one_other'
 
 ::RailsI18n::Pluralization::OneOther.with_locale(:'zh-HK')

--- a/rails/pluralization/zh-TW.rb
+++ b/rails/pluralization/zh-TW.rb
@@ -1,3 +1,3 @@
 require 'rails_i18n/common_pluralizations/other'
 
-::RailsI18n::Pluralization::Other.with_locale(:'zh-TW')
+::RailsI18n::Pluralization::OneOther.with_locale(:'zh-TW')

--- a/rails/pluralization/zh-TW.rb
+++ b/rails/pluralization/zh-TW.rb
@@ -1,3 +1,3 @@
-require 'rails_i18n/common_pluralizations/other'
+require 'rails_i18n/common_pluralizations/one_other'
 
 ::RailsI18n::Pluralization::OneOther.with_locale(:'zh-TW')

--- a/rails/pluralization/zh-YUE.rb
+++ b/rails/pluralization/zh-YUE.rb
@@ -1,3 +1,3 @@
-require 'rails_i18n/common_pluralizations/other'
+require 'rails_i18n/common_pluralizations/one_other'
 
 ::RailsI18n::Pluralization::OneOther.with_locale(:'zh-YUE')

--- a/rails/pluralization/zh-YUE.rb
+++ b/rails/pluralization/zh-YUE.rb
@@ -1,3 +1,3 @@
 require 'rails_i18n/common_pluralizations/other'
 
-::RailsI18n::Pluralization::Other.with_locale(:'zh-YUE')
+::RailsI18n::Pluralization::OneOther.with_locale(:'zh-YUE')

--- a/rails/pluralization/zh.rb
+++ b/rails/pluralization/zh.rb
@@ -1,3 +1,3 @@
 require 'rails_i18n/common_pluralizations/other'
 
-::RailsI18n::Pluralization::Other.with_locale(:zh)
+::RailsI18n::Pluralization::OneOther.with_locale(:zh)

--- a/rails/pluralization/zh.rb
+++ b/rails/pluralization/zh.rb
@@ -1,3 +1,3 @@
-require 'rails_i18n/common_pluralizations/other'
+require 'rails_i18n/common_pluralizations/one_other'
 
 ::RailsI18n::Pluralization::OneOther.with_locale(:zh)

--- a/spec/unit/pluralization/one_other.rb
+++ b/spec/unit/pluralization/one_other.rb
@@ -1,0 +1,16 @@
+shared_examples 'one-other forms language' do
+  it 'has "one" and "other" plural keys' do
+    plural_keys.size.should == 2
+    plural_keys.should include(:one, :other)
+  end
+
+  it "detects that 1 in category 'one'" do
+    rule.call(1).should == :one
+  end
+
+  [0, 0.3, 1.2, 2, 3, 5, 10, 11, 21, 23, 31, 50, 81, 99, 100].each do |count|
+    it "detects that #{count} in category 'other'" do
+      rule.call(count).should == :other
+    end
+  end
+end

--- a/spec/unit/pluralization_spec.rb
+++ b/spec/unit/pluralization_spec.rb
@@ -9,6 +9,7 @@ require 'support/pluralization_file'
 
 require 'unit/pluralization/ordinary'
 require 'unit/pluralization/other'
+require 'unit/pluralization/one_other'
 require 'unit/pluralization/one_with_zero_other'
 require 'unit/pluralization/one_upto_two_other'
 require 'unit/pluralization/one_two_other'
@@ -175,7 +176,7 @@ describe 'Pluralization rule for' do
 
   describe 'Chinese', :locale => :zh do
     it_behaves_like 'an ordinary pluralization rule'
-    it_behaves_like 'other form language'
+    it_behaves_like 'one-other forms language'
   end
 
   describe 'Colognian', :locale => :ksh do


### PR DESCRIPTION
In zh-*.yml, there are `one` and `other` options for many keys like:
```yml
    distance_in_words:
      about_x_hours:
        one: 大约一小时
        other: 大约 %{count} 小时
 ...
      storage_units:
        format: "%n %u"
        units:
          byte:
            one: Byte
            other: Bytes
``` 
But the `Pluralization::Other` pluralization rule was used for them, we should change to `Pluralization::OneOther` pluralization rule.

On the other hand, if we use `Pluralization::Other` pluralization rule for them, we will got the wrong answer in some rails helpers:
```ruby
Loading development environment (Rails 5.1.4)
irb(main):001:0> I18n.default_locale = :"zh-CN"
=> :"zh-CN"
irb(main):002:0> 1.to_s(:human_size)
=> "1 Bytes"
irb(main):003:0> helper.number_to_human_size(1)
=> "1 Bytes"
```
`"1 Byte"` should be more anticipated here, and `Pluralization::OneOther` pluralization rule did it.