### PR TITLE
Use EN comma as thousand delimiter in AR currency

### DIFF
--- a/rails/locale/ar.yml
+++ b/rails/locale/ar.yml
@@ -223,7 +223,7 @@ ar:
         strip_insignificant_zeros: false
         unit: "$"
     format:
-      delimiter: "،"
+      delimiter: ","
       precision: 3
       separator: "."
       significant: false

--- a/rails/locale/ar.yml
+++ b/rails/locale/ar.yml
@@ -215,7 +215,7 @@ ar:
   number:
     currency:
       format:
-        delimiter: "،"
+        delimiter: ","
         format: "%u%n"
         precision: 2
         separator: "."


### PR DESCRIPTION
Our AR translator informed that

> In the numbers, English commas should be used even within Arabic text.