### PR TITLE
Include 'million' pluralisation option for fr and fr-FR

### DIFF
--- a/rails/locale/fr-FR.yml
+++ b/rails/locale/fr-FR.yml
@@ -171,7 +171,9 @@ fr-FR:
         format: "%n %u"
         units:
           billion: milliard
-          million: million
+          million:
+            one: million
+            other: millions
           quadrillion: million de milliards
           thousand: millier
           trillion: billion

--- a/rails/locale/fr.yml
+++ b/rails/locale/fr.yml
@@ -174,7 +174,9 @@ fr:
         format: "%n %u"
         units:
           billion: milliard
-          million: million
+          million:
+            one: million
+            other: millions
           quadrillion: million de milliards
           thousand: millier
           trillion: billion


### PR DESCRIPTION
We're maintaining an app with several languages, and our French team have suggested that the default behaviour for the plural of `million` to be `millions`. 
This proposed change follows the examples provided in `rails/locale/es.yml`.
