### PR TITLE
Added Polish errors.messages.required translation

### DIFF
--- a/rails/locale/pl.yml
+++ b/rails/locale/pl.yml
@@ -145,6 +145,7 @@ pl:
       not_an_integer: musi być liczbą całkowitą
       odd: musi być nieparzyste
       present: musi być puste
+      required: musi istnieć
       taken: zostało już zajęte
       too_long:
         few: jest za długie (maksymalnie %{count} znaki)


### PR DESCRIPTION
Hi, I've just added the missing `errors.messages.required` key.

Thank you for merging.

Regards.