### PR TITLE
[Update]Removed preposition in short format

### DIFF
--- a/rails/locale/oc.yml
+++ b/rails/locale/oc.yml
@@ -208,5 +208,5 @@ oc:
     formats:
       default: "Lo %d %b de %Y a %Ho%M %Ss"
       long: "Lo %d %b de %Y a %Ho%M"
-      short: "%d de %b %Ho%M"
+      short: "%d %b %Ho%M"
     pm: pm


### PR DESCRIPTION
Noticed in diaspora* that the short format was showing "_lo 18 de d’abrial_"* because of the little arrangement we had to do because of **DE** becoming **D'** before vowel.
Should be okay now.

* instead of "_lo 18 d’abrial_"