### PR TITLE
Add correct translations for Khmer numerals

### DIFF
--- a/rails/locale/km.yml
+++ b/rails/locale/km.yml
@@ -136,11 +136,11 @@ km:
       decimal_units:
         format: "%n %u"
         units:
-          billion: ពាន់លាន
+          billion: ប៊ីលាន
           million: លាន
-          quadrillion: ក្វាឌ្រីលាន
+          quadrillion: ក្វាទ្រីលាន
           thousand: ពាន់
-          trillion: ពាន់ពាន់លាន
+          trillion: ទ្រីលាន
           unit: ''
       format:
         delimiter: ''


### PR DESCRIPTION
Official document from the Royal Government of Cambodia with the correct words for billion, trillion and quadrillion

http://www.moeys.gov.kh/kh/laws-and-legislations/decision/1651.html#.Wu13aNOFPUI

