### PR TITLE
Improve french locales

### DIFF
--- a/rails/locale/fr-CA.yml
+++ b/rails/locale/fr-CA.yml
@@ -64,40 +64,40 @@ fr-CA:
     distance_in_words:
       about_x_hours:
         one: environ une heure
-        other: environ %{count} heures
+        other: environ %{count} heures
       about_x_months:
         one: environ un mois
-        other: environ %{count} mois
+        other: environ %{count} mois
       about_x_years:
         one: environ un an
-        other: environ %{count} ans
+        other: environ %{count} ans
       almost_x_years:
         one: presqu'un an
         other: presque %{count} ans
       half_a_minute: une demi-minute
       less_than_x_minutes:
-        one: moins d'une minute
-        other: moins de %{count} minutes
-        zero: moins d'une minute
+        one: moins d'une minute
+        other: moins de %{count} minutes
+        zero: moins d'une minute
       less_than_x_seconds:
-        one: moins d'une seconde
-        other: moins de %{count} secondes
+        one: moins d'une seconde
+        other: moins de %{count} secondes
         zero: moins d'une seconde
       over_x_years:
         one: plus d'un an
-        other: plus de %{count} ans
+        other: plus de %{count} ans
       x_days:
-        one: 1 jour
-        other: "%{count} jours"
+        one: 1 jour
+        other: "%{count} jours"
       x_minutes:
-        one: 1 minute
-        other: "%{count} minutes"
+        one: 1 minute
+        other: "%{count} minutes"
       x_months:
-        one: 1 mois
-        other: "%{count} mois"
+        one: 1 mois
+        other: "%{count} mois"
       x_seconds:
-        one: 1 seconde
-        other: "%{count} secondes"
+        one: 1 seconde
+        other: "%{count} secondes"
     prompts:
       day: Jour
       hour: Heure
@@ -139,7 +139,7 @@ fr-CA:
         other: ne fait pas la bonne longueur (doit comporter %{count} caractères)
       other_than: doit être différent de %{count}
     template:
-      body: 'Veuillez vérifier les champs suivants : '
+      body: 'Veuillez vérifier les champs suivants : '
       header:
         one: 'Impossible d''enregistrer ce %{model} : 1 erreur'
         other: 'Impossible d''enregistrer ce %{model} : %{count} erreurs'

--- a/rails/locale/fr-CA.yml
+++ b/rails/locale/fr-CA.yml
@@ -95,6 +95,9 @@ fr-CA:
       x_months:
         one: 1 mois
         other: "%{count} mois"
+      x_years:
+        one: 1 an
+        other: "%{count} ans"
       x_seconds:
         one: 1 seconde
         other: "%{count} secondes"
@@ -170,11 +173,11 @@ fr-CA:
       decimal_units:
         format: "%n %u"
         units:
-          billion: Milliard
-          million: Million
-          quadrillion: Million de milliards
-          thousand: Millier
-          trillion: Mille milliard
+          billion: milliard
+          million: million
+          quadrillion: million de milliards
+          thousand: millier
+          trillion: billion
           unit: ''
       format:
         delimiter: ''
@@ -185,12 +188,14 @@ fr-CA:
         format: "%n %u"
         units:
           byte:
-            one: Octet
-            other: Octets
+            one: octet
+            other: octets
           gb: Go
           kb: ko
           mb: Mo
           tb: To
+          pb: Po
+          eb: Eo
     percentage:
       format:
         delimiter: ''

--- a/rails/locale/fr-CA.yml
+++ b/rails/locale/fr-CA.yml
@@ -122,7 +122,7 @@ fr-CA:
       invalid: n'est pas valide
       less_than: doit être inférieur à %{count}
       less_than_or_equal_to: doit être inférieur ou égal à %{count}
-      model_invalid: "Validation échouée: %{errors}"
+      model_invalid: "Validation échouée : %{errors}"
       not_a_number: n'est pas un nombre
       not_an_integer: doit être un nombre entier
       odd: doit être impair

--- a/rails/locale/fr-CA.yml
+++ b/rails/locale/fr-CA.yml
@@ -5,7 +5,7 @@ fr-CA:
       messages:
         record_invalid: 'La validation a échoué : %{errors}'
         restrict_dependent_destroy:
-          has_one: "Vous ne pouvez pas supprimer l'enregistrement car une personne à charge %{record} existe"
+          has_one: "Vous ne pouvez pas supprimer l'enregistrement car un(e) %{record} dépendant(e) existe"
           has_many: "Vous ne pouvez pas supprimer l'enregistrement parce que les %{record} dépendants existent"
   date:
     abbr_day_names:
@@ -141,15 +141,15 @@ fr-CA:
     template:
       body: 'Veuillez vérifier les champs suivants : '
       header:
-        one: 'Impossible d''enregistrer ce %{model} : 1 erreur'
-        other: 'Impossible d''enregistrer ce %{model} : %{count} erreurs'
+        one: 'Impossible d''enregistrer ce(tte) %{model} : 1 erreur'
+        other: 'Impossible d''enregistrer ce(tte) %{model} : %{count} erreurs'
   helpers:
     select:
       prompt: Veuillez sélectionner
     submit:
-      create: Créer un %{model}
-      submit: Enregistrer ce %{model}
-      update: Modifier ce %{model}
+      create: Créer un(e) %{model}
+      submit: Enregistrer ce(tte) %{model}
+      update: Modifier ce(tte) %{model}
   number:
     currency:
       format:

--- a/rails/locale/fr-CH.yml
+++ b/rails/locale/fr-CH.yml
@@ -64,40 +64,40 @@ fr-CH:
     distance_in_words:
       about_x_hours:
         one: environ une heure
-        other: environ %{count} heures
+        other: environ %{count} heures
       about_x_months:
         one: environ un mois
-        other: environ %{count} mois
+        other: environ %{count} mois
       about_x_years:
         one: environ un an
-        other: environ %{count} ans
+        other: environ %{count} ans
       almost_x_years:
         one: presqu'un an
         other: presque %{count} ans
       half_a_minute: une demi-minute
       less_than_x_minutes:
-        one: moins d'une minute
-        other: moins de %{count} minutes
-        zero: moins d'une minute
+        one: moins d'une minute
+        other: moins de %{count} minutes
+        zero: moins d'une minute
       less_than_x_seconds:
-        one: moins d'une seconde
-        other: moins de %{count} secondes
+        one: moins d'une seconde
+        other: moins de %{count} secondes
         zero: moins d'une seconde
       over_x_years:
         one: plus d'un an
-        other: plus de %{count} ans
+        other: plus de %{count} ans
       x_days:
-        one: 1 jour
-        other: "%{count} jours"
+        one: 1 jour
+        other: "%{count} jours"
       x_minutes:
-        one: 1 minute
-        other: "%{count} minutes"
+        one: 1 minute
+        other: "%{count} minutes"
       x_months:
-        one: 1 mois
-        other: "%{count} mois"
+        one: 1 mois
+        other: "%{count} mois"
       x_seconds:
-        one: 1 seconde
-        other: "%{count} secondes"
+        one: 1 seconde
+        other: "%{count} secondes"
     prompts:
       day: Jour
       hour: Heure
@@ -139,7 +139,7 @@ fr-CH:
         other: ne fait pas la bonne longueur (doit comporter %{count} caractères)
       other_than: doit être différent de %{count}
     template:
-      body: 'Veuillez vérifier les champs suivants : '
+      body: 'Veuillez vérifier les champs suivants : '
       header:
         one: 'Impossible d''enregistrer ce %{model} : 1 erreur'
         other: 'Impossible d''enregistrer ce %{model} : %{count} erreurs'

--- a/rails/locale/fr-CH.yml
+++ b/rails/locale/fr-CH.yml
@@ -122,7 +122,7 @@ fr-CH:
       invalid: n'est pas valide
       less_than: doit être inférieur à %{count}
       less_than_or_equal_to: doit être inférieur ou égal à %{count}
-      model_invalid: "Validation échouée: %{errors}"
+      model_invalid: "Validation échouée : %{errors}"
       not_a_number: n'est pas un nombre
       not_an_integer: doit être un nombre entier
       odd: doit être impair

--- a/rails/locale/fr-CH.yml
+++ b/rails/locale/fr-CH.yml
@@ -5,7 +5,7 @@ fr-CH:
       messages:
         record_invalid: 'La validation a échoué : %{errors}'
         restrict_dependent_destroy:
-          has_one: "Vous ne pouvez pas supprimer l'enregistrement car une personne à charge %{record} existe"
+          has_one: "Vous ne pouvez pas supprimer l'enregistrement car un(e) %{record} dépendant(e) existe"
           has_many: "Vous ne pouvez pas supprimer l'enregistrement parce que les %{record} dépendants existent"
   date:
     abbr_day_names:
@@ -141,15 +141,15 @@ fr-CH:
     template:
       body: 'Veuillez vérifier les champs suivants : '
       header:
-        one: 'Impossible d''enregistrer ce %{model} : 1 erreur'
-        other: 'Impossible d''enregistrer ce %{model} : %{count} erreurs'
+        one: 'Impossible d''enregistrer ce(tte) %{model} : 1 erreur'
+        other: 'Impossible d''enregistrer ce(tte) %{model} : %{count} erreurs'
   helpers:
     select:
       prompt: Veuillez sélectionner
     submit:
-      create: Créer un %{model}
-      submit: Enregistrer ce %{model}
-      update: Modifier ce %{model}
+      create: Créer un(e) %{model}
+      submit: Enregistrer ce(tte) %{model}
+      update: Modifier ce(tte) %{model}
   number:
     currency:
       format:

--- a/rails/locale/fr-CH.yml
+++ b/rails/locale/fr-CH.yml
@@ -95,6 +95,9 @@ fr-CH:
       x_months:
         one: 1 mois
         other: "%{count} mois"
+      x_years:
+        one: 1 an
+        other: "%{count} ans"
       x_seconds:
         one: 1 seconde
         other: "%{count} secondes"
@@ -191,6 +194,8 @@ fr-CH:
           kb: ko
           mb: Mo
           tb: To
+          pb: Po
+          eb: Eo
     percentage:
       format:
         delimiter: ''

--- a/rails/locale/fr-FR.yml
+++ b/rails/locale/fr-FR.yml
@@ -95,6 +95,9 @@ fr-FR:
       x_months:
         one: 1 mois
         other: "%{count} mois"
+      x_years:
+        one: 1 an
+        other: "%{count} ans"
       x_seconds:
         one: 1 seconde
         other: "%{count} secondes"
@@ -171,9 +174,7 @@ fr-FR:
         format: "%n %u"
         units:
           billion: milliard
-          million:
-            one: million
-            other: millions
+          million: million
           quadrillion: million de milliards
           thousand: millier
           trillion: billion
@@ -193,6 +194,8 @@ fr-FR:
           kb: ko
           mb: Mo
           tb: To
+          pb: Po
+          eb: Eo
     percentage:
       format:
         delimiter: ''

--- a/rails/locale/fr.yml
+++ b/rails/locale/fr.yml
@@ -96,7 +96,7 @@ fr:
         one: 1 mois
         other: "%{count} mois"
       x_years:
-        one: un an
+        one: 1 an
         other: "%{count} ans"
       x_seconds:
         one: 1 seconde
@@ -174,9 +174,7 @@ fr:
         format: "%n %u"
         units:
           billion: milliard
-          million:
-            one: million
-            other: millions
+          million: million
           quadrillion: million de milliards
           thousand: millier
           trillion: billion


### PR DESCRIPTION
Hello,

Everything is pretty much self-explanatory, ask if it is unclear.

~~Normalization makes it much easier to compare locales, because all the keys are alphabetically sorted. For example `fr.yml` and `fr-CA.yml` has keys at different positions, making it a bit of a pain to diff in the editor.~~ See #791

French is my mother tongue, it makes no sense to lowercase the days/months/million/etc names, also some of the translations are just plain incorrect, for example

``` 
Vous ne pouvez pas supprimer l'enregistrement car une personne à charge %{record} existe
```

Translates to:

```
You can not delete the record because someone dependant %{record} exists
```

After some tests, the translation came straight from google translate.