### PR TITLE
Normalize locales

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,20 +10,24 @@ Centralization of locale data collection for Ruby on Rails.
 
 Include the gem to your Gemfile:
 
-    gem 'rails-i18n', '~> 6.0.0.beta1' # For 6.0.0.beta1 or higher
-    gem 'rails-i18n', '~> 5.1' # For 5.0.x, 5.1.x and 5.2.x
-    gem 'rails-i18n', '~> 4.0' # For 4.0.x
-    gem 'rails-i18n', '~> 3.0' # For 3.x
-    gem 'rails-i18n', github: 'svenfuchs/rails-i18n', branch: 'master' # For 5.x
-    gem 'rails-i18n', github: 'svenfuchs/rails-i18n', branch: 'rails-4-x' # For 4.x
-    gem 'rails-i18n', github: 'svenfuchs/rails-i18n', branch: 'rails-3-x' # For 3.x
+``` ruby
+gem 'rails-i18n', '~> 6.0.0.beta1' # For 6.0.0.beta1 or higher
+gem 'rails-i18n', '~> 5.1' # For 5.0.x, 5.1.x and 5.2.x
+gem 'rails-i18n', '~> 4.0' # For 4.0.x
+gem 'rails-i18n', '~> 3.0' # For 3.x
+gem 'rails-i18n', github: 'svenfuchs/rails-i18n', branch: 'master' # For 5.x
+gem 'rails-i18n', github: 'svenfuchs/rails-i18n', branch: 'rails-4-x' # For 4.x
+gem 'rails-i18n', github: 'svenfuchs/rails-i18n', branch: 'rails-3-x' # For 3.x
+```
 
 Alternatively, execute the following command:
 
-    gem install rails-i18n -v '~> 6.0.0.beta1' # For 6.0.0.beta1 or higher
-    gem install rails-i18n -v '~> 5.1' # For  For 5.0.x, 5.1.x and 5.2.x
-    gem install rails-i18n -v '~> 4.0' # For 4.0.x
-    gem install rails-i18n -v '~> 3.0' # For 3.x
+``` shell
+gem install rails-i18n -v '~> 6.0.0.beta1' # For 6.0.0.beta1 or higher
+gem install rails-i18n -v '~> 5.1' # For  For 5.0.x, 5.1.x and 5.2.x
+gem install rails-i18n -v '~> 4.0' # For 4.0.x
+gem install rails-i18n -v '~> 3.0' # For 3.x
+```
 
 Note that your Ruby on Rails version must be 3.0 or higher in order to install the `rails-i18n` gem. For rails 2.x, install it manually as described in the Manual Installation section below.
 
@@ -31,11 +35,15 @@ Note that your Ruby on Rails version must be 3.0 or higher in order to install t
 
 `rails-i18n` gem initially loads all available locale files, pluralization and transliteration rules. This default behaviour can be changed. If you specify in `config/environments/*` the locales which have to be loaded via `I18n.available_locales` option:
 
-    config.i18n.available_locales = ['es-CO', :de]
+``` ruby
+config.i18n.available_locales = ['es-CO', :de]
+```
 
 or
 
-    config.i18n.available_locales = :nl
+``` ruby
+config.i18n.available_locales = :nl
+```
 
 ## Manual Installation
 
@@ -89,7 +97,7 @@ fonts have a glyph, there are still many fonts that will not render the characte
 If you want to provide a different value, you can create a custom locale file under
 `config/locales/tr.yml` and override the respective key:
 
-```YAML
+``` yaml
 tr:
   number:
     currency:
@@ -123,28 +131,40 @@ If not,
 
 Before committing and pushing your changes, test the integrity of your locale file.
 
-    bundle exec rake spec
+``` shell
+bundle exec rake spec
+```
 
 Make sure you have included all translations with:
 
-    bundle exec rake i18n-spec:completeness rails/locale/en.yml rails/locale/YOUR_NEW_LOCALE.yml
+``` shell
+bundle exec rake i18n-spec:completeness rails/locale/en.yml rails/locale/YOUR_NEW_LOCALE.yml
+```
 
 Make sure it is normalized with:
 
-    thor locales:normalize LOCALE # or "thor locales:normalize_all"
+``` shell
+thor locales:normalize LOCALE # or "thor locales:normalize_all"
+```
 
 You can list all complete and incomplete locales:
 
-    thor locales:complete
-    thor locales:incomplete
+``` shell
+thor locales:complete
+thor locales:incomplete
+```
 
 Also, you can list all available locales:
 
-    thor locales:list
+``` shell
+thor locales:list
+```
 
 You can list all missing keys:
 
-    i18n-tasks missing es
+``` shell
+i18n-tasks missing es
+```
 
 ### Edit README.md
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,10 @@ Make sure you have included all translations with:
 
     bundle exec rake i18n-spec:completeness rails/locale/en.yml rails/locale/YOUR_NEW_LOCALE.yml
 
+Make sure it is normalized with:
+
+    thor locales:normalize LOCALE # or "thor locales:normalize_all"
+
 You can list all complete and incomplete locales:
 
     thor locales:complete

--- a/locales.thor
+++ b/locales.thor
@@ -1,4 +1,5 @@
 require File.dirname(__FILE__) + '/rails/test/lib/key_structure.rb'
+require File.dirname(__FILE__) + '/rails/test/lib/normalize.rb'
 $LOAD_PATH.unshift(File.dirname(__FILE__) + '/lib') unless $LOAD_PATH.include?(File.dirname(__FILE__) + '/lib')
 
 class Locales < Thor
@@ -51,6 +52,22 @@ class Locales < Thor
     end
 
     puts "The structure is good." if good
+  end
+
+  desc 'normalize LOCALE', 'Normalize locale file.'
+  def normalize(locale)
+    Dir.glob(format('%s/rails/locale/%s.{rb,yml}', File.dirname(__FILE__), locale)) do |filename|
+      h = YAML.load_file(filename)
+      File.write(filename, Normalize.deep_sort(h).to_yaml)
+    end
+  end
+
+  desc 'normalize_all', 'Normalize all locale files.'
+  def normalize_all
+    Dir.glob(format('%s/rails/locale/*.{rb,yml}', File.dirname(__FILE__))) do |filename|
+      h = YAML.load_file(filename)
+      File.write(filename, Normalize.deep_sort(h).to_yaml)
+    end
   end
 
   desc 'list', 'List locale names.'

--- a/rails/locale/af.yml
+++ b/rails/locale/af.yml
@@ -5,8 +5,8 @@ af:
       messages:
         record_invalid: 'Validering het misluk: %{errors}'
         restrict_dependent_destroy:
-          has_one: "Kan rekord nie skrap nie omdat 'n afhanklike %{record} bestaan"
-          has_many: 'Kan rekord nie skrap nie omdat afhanklike %{record} bestaan'
+          has_one: Kan rekord nie skrap nie omdat 'n afhanklike %{record} bestaan
+          has_many: Kan rekord nie skrap nie omdat afhanklike %{record} bestaan
   date:
     abbr_day_names:
     - Son
@@ -17,7 +17,7 @@ af:
     - Vry
     - Sat
     abbr_month_names:
-    -
+    - 
     - Jan
     - Feb
     - Mar
@@ -43,7 +43,7 @@ af:
       long: "%B %d, %Y"
       short: "%b %d"
     month_names:
-    -
+    - 
     - Januarie
     - Februarie
     - Maart
@@ -75,43 +75,42 @@ af:
         one: sowat 1 jaar
         other: sowat %{count} jaar
       half_a_minute: halfminuut
-      less_than_x_minutes:
-        one: minder as 1 minuut
-        other: minder as %{count} minute
       less_than_x_seconds:
         one: minder as 1 sekonde
         other: minder as %{count} sekondes
+      less_than_x_minutes:
+        one: minder as 1 minuut
+        other: minder as %{count} minute
       over_x_years:
         one: meer as 1 jaar
         other: meer as %{count} jaar
-      x_days:
-        one: 1 dag
-        other: "%{count} days"
+      x_seconds:
+        one: 1 sekonde
+        other: "%{count} sekondes"
       x_minutes:
         one: 1 minuut
         other: "%{count} minute"
+      x_days:
+        one: 1 dag
+        other: "%{count} days"
       x_months:
         one: 1 maand
         other: "%{count} maande"
       x_years:
         one: 1 jaar
         other: "%{count} jare"
-      x_seconds:
-        one: 1 sekonde
-        other: "%{count} sekondes"
     prompts:
-      day: Dag
-      hour: Uur
-      minute: Minuut
-      month: Maand
       second: Sekondes
+      minute: Minuut
+      hour: Uur
+      day: Dag
+      month: Maand
       year: Jaar
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: moet aanvaar word
       blank: mag nie leeg wees nie
-      present: moet leeg wees
       confirmation: pas nie by bevestiging nie
       empty: mag nie leeg wees nie
       equal_to: moet gelyk wees aan %{count}
@@ -127,6 +126,8 @@ af:
       not_a_number: is nie 'n getal nie
       not_an_integer: moet 'n heelgetal wees
       odd: moet onewe wees
+      other_than: moet anders wees as %{count}
+      present: moet leeg wees
       required: moet bestaan
       taken: is reeds geneem
       too_long:
@@ -138,7 +139,6 @@ af:
       wrong_length:
         one: is die verkeerde lengte (moet 1 karakter wees)
         other: is die verkeerde lengte (moet %{count} karakters wees)
-      other_than: moet anders wees as %{count}
     template:
       body: 'There were problems with the following fields:'
       header:

--- a/rails/locale/ar.yml
+++ b/rails/locale/ar.yml
@@ -17,7 +17,7 @@ ar:
     - الجمعة
     - السّبت
     abbr_month_names:
-    -
+    - 
     - ينا
     - فبر
     - مار
@@ -43,7 +43,7 @@ ar:
       long: "%e %B، %Y"
       short: "%e %b"
     month_names:
-    -
+    - 
     - يناير
     - فبراير
     - مارس
@@ -91,13 +91,6 @@ ar:
         many: ما يقرب من %{count} سنة
         other: ما يقرب من %{count} سنة
       half_a_minute: نصف دقيقة
-      less_than_x_minutes:
-        zero: أقل من صفر دقائق
-        one: أقل من دقيقة
-        two: أقل من دقيقتان
-        few: أقل من %{count} دقائق
-        many: أقل من %{count} دقيقة
-        other: أقل من %{count} دقيقة
       less_than_x_seconds:
         zero: أقل من صفر ثواني
         one: أقل من ثانية
@@ -105,6 +98,13 @@ ar:
         few: أقل من %{count} ثوان
         many: أقل من %{count} ثانية
         other: أقل من %{count} ثانية
+      less_than_x_minutes:
+        zero: أقل من صفر دقائق
+        one: أقل من دقيقة
+        two: أقل من دقيقتان
+        few: أقل من %{count} دقائق
+        many: أقل من %{count} دقيقة
+        other: أقل من %{count} دقيقة
       over_x_years:
         zero: أكثر من صفر سنوات
         one: أكثر من سنة
@@ -112,27 +112,6 @@ ar:
         few: أكثر من %{count} سنوات
         many: أكثر من %{count} سنة
         other: أكثر من %{count} سنة
-      x_days:
-        zero: صفر أيام
-        one: يوم واحد
-        two: يومان
-        few: "%{count} أيام"
-        many: "%{count} يوم"
-        other: "%{count} يوم"
-      x_minutes:
-        zero: صفر دقائق
-        one: دقيقة واحدة
-        two: دقيقتان
-        few: "%{count} دقائق"
-        many: "%{count} دقيقة"
-        other: "%{count} دقيقة"
-      x_months:
-        zero: صفر أشهر
-        one: شهر واحد
-        two: شهران
-        few: "%{count} أشهر"
-        many: "%{count} شهر"
-        other: "%{count} شهر"
       x_seconds:
         zero: صفر ثواني
         one: ثانية واحدة
@@ -140,33 +119,61 @@ ar:
         few: "%{count} ثوان"
         many: "%{count} ثانية"
         other: "%{count} ثانية"
+      x_minutes:
+        zero: صفر دقائق
+        one: دقيقة واحدة
+        two: دقيقتان
+        few: "%{count} دقائق"
+        many: "%{count} دقيقة"
+        other: "%{count} دقيقة"
+      x_days:
+        zero: صفر أيام
+        one: يوم واحد
+        two: يومان
+        few: "%{count} أيام"
+        many: "%{count} يوم"
+        other: "%{count} يوم"
+      x_months:
+        zero: صفر أشهر
+        one: شهر واحد
+        two: شهران
+        few: "%{count} أشهر"
+        many: "%{count} شهر"
+        other: "%{count} شهر"
     prompts:
-      day: اليوم
-      hour: ساعة
-      minute: دقيقة
-      month: الشهر
       second: ثانية
+      minute: دقيقة
+      hour: ساعة
+      day: اليوم
+      month: الشهر
       year: السنة
   errors:
     format: "%{message}"
     messages:
       accepted: يجب أن تقبل %{attribute}
       blank: لا يمكن أن يكون محتوى %{attribute} فارغاً
-      present:  يجب ترك حقل %{attribute} فارغاً
       confirmation: محتوى %{attribute} لا يتوافق مع %{attribute}
       empty: لا يمكن أن يكون محتوى %{attribute} فارغاً
       equal_to: يجب أن يساوي طول %{attribute} %{count}
       even: يجب أن يكون عدد %{attribute} زوجياً
-      exclusion:  حقل %{attribute} محجوز
+      exclusion: حقل %{attribute} محجوز
       greater_than: ميجب أن يكون عدد %{attribute} أكبر من %{count}
       greater_than_or_equal_to: يجب أن يكون عدد %{attribute} أكبر أو يساوي %{count}
-      inclusion:  "%{attribute} غير وارد في القائمة"
+      inclusion: "%{attribute} غير وارد في القائمة"
       invalid: محتوى %{attribute} غير صالح
       less_than: يجب أن يكون عدد %{attribute} أصغر من %{count}
       less_than_or_equal_to: يجب أن يكون عدد %{attribute} أصغر أو  يساوي %{count}
       not_a_number: يجب أن يكون محتوى %{attribute} رقماً
       not_an_integer: يجب أن يكون عدد %{attribute} عدد صحيحاً
       odd: يجب أن يكون عدد %{attribute} عدداً فردياً
+      other_than:
+        zero: طول %{attribute} يجب ألاّ يكون صفر حرف
+        one: طول %{attribute} يجب ألاّ يكون حرفاً واحداً
+        two: طول %{attribute} يجب ألاّ يكون حرفان
+        few: طول %{attribute} يجب ألاّ يكون %{count} أحرف
+        many: طول %{attribute} يجب ألاّ يكون %{count} حرفاً
+        other: طول %{attribute} يجب ألاّ يكون %{count} حرفاً
+      present: يجب ترك حقل %{attribute} فارغاً
       taken: حقل %{attribute} محجوز مسبقاً
       too_long:
         zero: محتوى %{attribute} أطول من اللّازم (الحد الأقصى هو ولا حرف)
@@ -189,22 +196,15 @@ ar:
         few: طول %{attribute} غير مطابق للحد المطلوب (يجب أن يكون %{count} أحرف)
         many: طول %{attribute} غير مطابق للحد المطلوب (يجب أن يكون %{count} حرف)
         other: طول %{attribute} غير مطابق للحد المطلوب (يجب أن يكون %{count} حرف)
-      other_than:
-        zero: طول %{attribute} يجب ألاّ يكون صفر حرف
-        one: طول %{attribute} يجب ألاّ يكون حرفاً واحداً
-        two: طول %{attribute} يجب ألاّ يكون حرفان
-        few: طول %{attribute} يجب ألاّ يكون %{count} أحرف
-        many: طول %{attribute} يجب ألاّ يكون %{count} حرفاً
-        other: طول %{attribute} يجب ألاّ يكون %{count} حرفاً
     template:
-      body: "يُرجى التحقّق من الحقول التّالية:%{attribute}"
+      body: يُرجى التحقّق من الحقول التّالية:%{attribute}
       header:
-        zero: 'ليس بالامكان حفظ %{model} لسبب ولا خطأ.'
-        one: 'ليس بالامكان حفظ %{model} لسبب وجود خطأ واحد.'
-        two: 'ليس بالامكان حفظ %{model} لسبب وجود خطئان.'
-        few: 'ليس بالامكان حفظ %{model} لسبب وجود %{count} أخطاء.'
-        many: 'ليس بالامكان حفظ %{model} لسبب وجود %{count} خطأ.'
-        other: 'ليس بالامكان حفظ %{model} لسبب وجود %{count} خطأ.'
+        zero: ليس بالامكان حفظ %{model} لسبب ولا خطأ.
+        one: ليس بالامكان حفظ %{model} لسبب وجود خطأ واحد.
+        two: ليس بالامكان حفظ %{model} لسبب وجود خطئان.
+        few: ليس بالامكان حفظ %{model} لسبب وجود %{count} أخطاء.
+        many: ليس بالامكان حفظ %{model} لسبب وجود %{count} خطأ.
+        other: ليس بالامكان حفظ %{model} لسبب وجود %{count} خطأ.
   helpers:
     select:
       prompt: يُرجى الاختيار

--- a/rails/locale/az.yml
+++ b/rails/locale/az.yml
@@ -5,8 +5,8 @@ az:
       messages:
         record_invalid: 'Yoxlama uğursuz oldu: %{errors}'
         restrict_dependent_destroy:
-          has_one: "Əlaqəli %{record} yazı olduğundan bu yazını silmək mümkün deyil"
-          has_many: "Əlaqəli %{record} yazılar olduğundan bu yazını silmək mümkün deyil"
+          has_one: Əlaqəli %{record} yazı olduğundan bu yazını silmək mümkün deyil
+          has_many: Əlaqəli %{record} yazılar olduğundan bu yazını silmək mümkün deyil
   date:
     abbr_day_names:
     - B.
@@ -17,7 +17,7 @@ az:
     - C.
     - Ş.
     abbr_month_names:
-    -
+    - 
     - Yan
     - Fev
     - Mar
@@ -43,7 +43,7 @@ az:
       long: "%d %B %Y"
       short: "%d %b"
     month_names:
-    -
+    - 
     - Yanvar
     - Fevral
     - Mart
@@ -75,40 +75,39 @@ az:
         one: təqribən 1 il
         other: təqribən %{count} il
       half_a_minute: yarım dəqiqə
-      less_than_x_minutes:
-        one: 1 dəqiqədən az
-        other: "%{count} dəqiqədən az"
       less_than_x_seconds:
         one: 1 saniyədən az
         other: "%{count} saniyədən az"
+      less_than_x_minutes:
+        one: 1 dəqiqədən az
+        other: "%{count} dəqiqədən az"
       over_x_years:
         one: 1 ildən çox
         other: "%{count} ildən çox"
-      x_days:
-        one: 1 gün
-        other: "%{count} gün"
-      x_minutes:
-        one: 1 dəqiqə
-        other: "%{count} dəqiqə"
-      x_months:
-        one: 1 ay
-        other: "%{count} ay"
       x_seconds:
         one: 1 saniyə
         other: "%{count} saniyə"
+      x_minutes:
+        one: 1 dəqiqə
+        other: "%{count} dəqiqə"
+      x_days:
+        one: 1 gün
+        other: "%{count} gün"
+      x_months:
+        one: 1 ay
+        other: "%{count} ay"
     prompts:
-      day: Gün
-      hour: Saat
-      minute: Dəqiqə
-      month: Ay
       second: Saniyə
+      minute: Dəqiqə
+      hour: Saat
+      day: Gün
+      month: Ay
       year: İl
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: qəbul olunmalıdır
       blank: boş ola bilməz
-      present: boş olmalıdır
       confirmation: təsdiqə uygun deyil
       empty: boş ola bilməz
       equal_to: "%{count}-ə bərabər olmalıdır"
@@ -120,16 +119,17 @@ az:
       invalid: yanlışdır
       less_than: "%{count}-dən kiçik olmalıdır"
       less_than_or_equal_to: kiçik və ya %{count}-ə bərabər olmalıdır
-      model_invalid: "Yoxlama uğursuz oldu: %{errors}"
+      model_invalid: 'Yoxlama uğursuz oldu: %{errors}'
       not_a_number: rəqəm deyil
       not_an_integer: tam rəqəm olmalıdır
       odd: tək olmalıdır
+      other_than: "%{count}-dən fərqli olmalıdır"
+      present: boş olmalıdır
       required: mövcud olmalıdır
       taken: artıq mövcuddur
       too_long: çox uzundur (%{count} simvoldan çox olmalı deyil)
       too_short: çox qısadır (%{count} simvoldan az olmalı deyil)
       wrong_length: uzunluqu səhvdir (%{count} simvol olmalıdır)
-      other_than: "%{count}-dən fərqli olmalıdır"
     template:
       body: 'Aşağıdaki səhvlər üzə çıxdı:'
       header:

--- a/rails/locale/be.yml
+++ b/rails/locale/be.yml
@@ -17,7 +17,7 @@ be:
     - Суб
     - Ндз
     abbr_month_names:
-    -
+    - 
     - Сту
     - Лют
     - Сак
@@ -43,7 +43,7 @@ be:
       long: "%-d %B %Y"
       short: "%-d %b"
     month_names:
-    -
+    - 
     - Студзень
     - Люты
     - Сакавік
@@ -63,79 +63,78 @@ be:
   datetime:
     distance_in_words:
       about_x_hours:
+        one: каля %{count} гадзіны
         few: каля %{count} гадзін
         many: каля %{count} гадзін
-        one: каля %{count} гадзіны
         other: каля %{count} гадзін
       about_x_months:
+        one: каля %{count} месяца
         few: каля %{count} месяцаў
         many: каля %{count} месяцаў
-        one: каля %{count} месяца
         other: каля %{count} месяцаў
       about_x_years:
+        one: каля %{count} года
         few: каля %{count} гадоў
         many: каля %{count} гадоў
-        one: каля %{count} года
         other: каля %{count} гадоў
       almost_x_years:
+        one: амаль %{count} год
         few: амаль %{count} гады
         many: амаль %{count} гадоў
-        one: амаль %{count} год
         other: амаль %{count} гадоў
       half_a_minute: палова хвіліны
-      less_than_x_minutes:
-        few: меней за %{count} хвіліны
-        many: меней за %{count} хвілін
-        one: меней за %{count} хвіліну
-        other: меней за %{count} хвіліны
       less_than_x_seconds:
+        one: меней за %{count} секунду
         few: меней за %{count} секунды
         many: меней за %{count} секунд
-        one: меней за %{count} секунду
         other: меней за %{count} секунды
+      less_than_x_minutes:
+        one: меней за %{count} хвіліну
+        few: меней за %{count} хвіліны
+        many: меней за %{count} хвілін
+        other: меней за %{count} хвіліны
       over_x_years:
+        one: болей за %{count} год
         few: болей за %{count} гады
         many: болей за %{count} гадоў
-        one: болей за %{count} год
         other: болей за %{count} года
-      x_days:
-        few: "%{count} дні"
-        many: "%{count} дзён"
-        one: "%{count} дзень"
-        other: "%{count} дня"
-      x_minutes:
-        few: "%{count} хвіліны"
-        many: "%{count} хвілін"
-        one: "%{count} хвіліна"
-        other: "%{count} хвіліны"
-      x_months:
-        few: "%{count} месяцы"
-        many: "%{count} месяцаў"
-        one: "%{count} месяц"
-        other: "%{count} месяца"
-      x_years:
-        few: "%{count} гады"
-        many: "%{count} гадоў"
-        one: "%{count} год"
-        other: "%{count} года"
       x_seconds:
+        one: "%{count} секунда"
         few: "%{count} секунды"
         many: "%{count} секунд"
-        one: "%{count} секунда"
         other: "%{count} секунды"
+      x_minutes:
+        one: "%{count} хвіліна"
+        few: "%{count} хвіліны"
+        many: "%{count} хвілін"
+        other: "%{count} хвіліны"
+      x_days:
+        one: "%{count} дзень"
+        few: "%{count} дні"
+        many: "%{count} дзён"
+        other: "%{count} дня"
+      x_months:
+        one: "%{count} месяц"
+        few: "%{count} месяцы"
+        many: "%{count} месяцаў"
+        other: "%{count} месяца"
+      x_years:
+        one: "%{count} год"
+        few: "%{count} гады"
+        many: "%{count} гадоў"
+        other: "%{count} года"
     prompts:
-      day: Дзень
-      hour: Гадзіна
-      minute: Хвіліна
-      month: Месяц
       second: Секунда
+      minute: Хвіліна
+      hour: Гадзіна
+      day: Дзень
+      month: Месяц
       year: Год
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: трэба прыняць
       blank: не можа быць пустым
-      present: павінна быць пустым
       confirmation: не супадае з %{attribute}
       empty: не можа быць пустым
       equal_to: павінна быць роўным %{count}
@@ -151,30 +150,31 @@ be:
       not_a_number: гэта не лічба
       not_an_integer: павінна быць цэлай лічбай
       odd: павінна быць няцотным
+      other_than: павінна адрознівацца ад %{count}
+      present: павінна быць пустым
       required: не можа адсутнічаць
       taken: ўжо занята
       too_long:
+        one: занадта доўгі (максімум %{count} сімвал)
         few: занадта доўгі (максімум %{count} сімвала)
         many: занадта доўгі (максімум %{count} сімвалаў)
-        one: занадта доўгі (максімум %{count} сімвал)
         other: занадта доўгі (максімум %{count} сімвалаў)
       too_short:
+        one: занадта кароткі (мінімум %{count} сімвал)
         few: занадта кароткі (мінімум %{count} сімвала)
         many: занадта кароткі (мінімум %{count} сімвалаў)
-        one: занадта кароткі (мінімум %{count} сімвал)
         other: занадта кароткі (мінімум %{count} сімвалаў)
       wrong_length:
+        one: няправільная даўжыня (павінен быць %{count} сімвал)
         few: няправільная даўжыня (павінен быць %{count} сімвала)
         many: няправільная даўжыня (павінны быць %{count} сімвалаў)
-        one: няправільная даўжыня (павінен быць %{count} сімвал)
         other: няправільная даўжыня (павінны быць %{count} сімвалаў)
-      other_than: павінна адрознівацца ад %{count}
     template:
       body: 'Узніклі праблемы з наступнымі палямі:'
       header:
+        one: не атрымалася захаваць %{model} з-за %{count} памылкі
         few: не атрымалася захаваць %{model} з-за %{count} памылак
         many: не атрымалася захаваць %{model} з-за %{count} памылак
-        one: не атрымалася захаваць %{model} з-за %{count} памылкі
         other: не атрымалася захаваць %{model} з-за %{count} памылак
   helpers:
     select:
@@ -204,29 +204,29 @@ be:
         format: "%n %u"
         units:
           billion:
+            one: мільярд
             few: мільярда
             many: мільярдаў
-            one: мільярд
             other: мільярда
           million:
+            one: мільён
             few: мільёна
             many: мільёнаў
-            one: мільён
             other: мільёна
           quadrillion:
+            one: квадрыльён
             few: квадрыльёна
             many: квадрыльёнаў
-            one: квадрыльён
             other: квадрыльёна
           thousand:
+            one: тысяча
             few: тысячы
             many: тысяч
-            one: тысяча
             other: тысячы
           trillion:
+            one: трыльён
             few: трыльёна
             many: трыльёнаў
-            one: трыльён
             other: трыльёна
           unit: ''
       format:
@@ -238,16 +238,16 @@ be:
         format: "%n %u"
         units:
           byte:
+            one: байт
             few: байта
             many: байтаў
-            one: байт
             other: байта
+          eb: ЭБ
           gb: ГБ
           kb: КБ
           mb: МБ
-          tb: ТБ
           pb: ПБ
-          eb: ЭБ
+          tb: ТБ
     percentage:
       format:
         delimiter: ''

--- a/rails/locale/bg.yml
+++ b/rails/locale/bg.yml
@@ -14,7 +14,7 @@ bg:
     - пет
     - съб
     abbr_month_names:
-    -
+    - 
     - ян.
     - фев.
     - март
@@ -40,7 +40,7 @@ bg:
       long: "%d %B %Y"
       short: "%d %b"
     month_names:
-    -
+    - 
     - януари
     - февруари
     - март
@@ -72,33 +72,33 @@ bg:
         one: почти 1 година
         other: почти %{count} години
       half_a_minute: половин минута
-      less_than_x_minutes:
-        one: по-малко от 1 минута
-        other: по-малко от %{count} минути
       less_than_x_seconds:
         one: по-малко от 1 секунда
         other: по-малко от %{count} секунди
+      less_than_x_minutes:
+        one: по-малко от 1 минута
+        other: по-малко от %{count} минути
       over_x_years:
         one: над 1 година
         other: над %{count} години
-      x_days:
-        one: 1 ден
-        other: "%{count} дни"
-      x_minutes:
-        one: 1 минута
-        other: "%{count} минути"
-      x_months:
-        one: 1 месец
-        other: "%{count} месеца"
       x_seconds:
         one: 1 секунда
         other: "%{count} секунди"
+      x_minutes:
+        one: 1 минута
+        other: "%{count} минути"
+      x_days:
+        one: 1 ден
+        other: "%{count} дни"
+      x_months:
+        one: 1 месец
+        other: "%{count} месеца"
     prompts:
-      day: Ден
-      hour: Час
-      minute: Минута
-      month: Месец
       second: Секунда
+      minute: Минута
+      hour: Час
+      day: Ден
+      month: Месец
       year: Година
   errors:
     format: "%{attribute} %{message}"

--- a/rails/locale/bn.yml
+++ b/rails/locale/bn.yml
@@ -65,33 +65,33 @@ bn:
         one: প্রায় ১ বছর
         other: প্রায় %{count} বছর
       half_a_minute: অার্ধেক মিনিট
-      less_than_x_minutes:
-        one: ১ মিনিটের কম
-        other: "%{count} মিনিটের কম"
       less_than_x_seconds:
         one: '১ সেকেন্ডর কম '
         other: "%{count} সেকেন্ডের কম"
+      less_than_x_minutes:
+        one: ১ মিনিটের কম
+        other: "%{count} মিনিটের কম"
       over_x_years:
         one: ১ বছরের বেশি
         other: "%{count} বছরের বেশি"
-      x_days:
-        one: ১ দিন
-        other: "%{count} দিন"
-      x_minutes:
-        one: ১ মিনিট
-        other: "%{count} মিনিট"
-      x_months:
-        one: ১ মাস
-        other: "%{count} মাস"
       x_seconds:
         one: ১ সেকেন্ড
         other: "%{count} সেকেন্ড"
+      x_minutes:
+        one: ১ মিনিট
+        other: "%{count} মিনিট"
+      x_days:
+        one: ১ দিন
+        other: "%{count} দিন"
+      x_months:
+        one: ১ মাস
+        other: "%{count} মাস"
     prompts:
-      day: দিন
-      hour: ঘন্টা
-      minute: মিনিট
-      month: মাস
       second: সেকেন্ড
+      minute: মিনিট
+      hour: ঘন্টা
+      day: দিন
+      month: মাস
       year: বছর
   errors:
     format: "%{attribute} %{message}"

--- a/rails/locale/bs.yml
+++ b/rails/locale/bs.yml
@@ -17,7 +17,7 @@ bs:
     - pet
     - sub
     abbr_month_names:
-    -
+    - 
     - jan
     - feb
     - mar
@@ -43,7 +43,7 @@ bs:
       long: "%e. %B %Y."
       short: "%e. %b. %Y."
     month_names:
-    -
+    - 
     - januar
     - februar
     - mart
@@ -63,74 +63,73 @@ bs:
   datetime:
     distance_in_words:
       about_x_hours:
+        one: oko sat
         few: oko %{count} sata
         many: oko %{count} sati
-        one: oko sat
         other: oko %{count} sati
       about_x_months:
+        one: oko mjesec
         few: oko %{count} mjeseca
         many: oko %{count} mjeseci
-        one: oko mjesec
         other: oko %{count} mjeseci
       about_x_years:
+        one: oko godine
         few: oko %{count} godine
         many: oko %{count} godina
-        one: oko godine
         other: oko %{count} godina
       almost_x_years:
+        one: skoro 1 godina
         few: skoro %{count} godine
         many: skoro %{count} godina
-        one: skoro 1 godina
         other: skoro %{count} godina
       half_a_minute: pola minute
-      less_than_x_minutes:
-        few: manje od %{count} minute
-        many: manje od %{count} minuta
-        one: manje od minute
-        other: manje od %{count} minuta
       less_than_x_seconds:
+        one: manje od sekunde
         few: manje od %{count} sekunde
         many: manje od %{count} sekundi
-        one: manje od sekunde
         other: manje od %{count} sekundi
+      less_than_x_minutes:
+        one: manje od minute
+        few: manje od %{count} minute
+        many: manje od %{count} minuta
+        other: manje od %{count} minuta
       over_x_years:
+        one: preko godine
         few: preko %{count} godine
         many: preko %{count} godina
-        one: preko godine
         other: preko %{count} godina
-      x_days:
-        few: "%{count} dana"
-        many: "%{count} dana"
-        one: 1 dan
-        other: "%{count} dana"
-      x_minutes:
-        few: "%{count} minute"
-        many: "%{count} minuta"
-        one: 1 minut
-        other: "%{count} minuta"
-      x_months:
-        few: "%{count} mjeseca"
-        many: "%{count} mjeseci"
-        one: 1 mjesec
-        other: "%{count} mjeseci"
       x_seconds:
+        one: 1 sekund
         few: "%{count} sekunde"
         many: "%{count} sekundi"
-        one: 1 sekund
         other: "%{count} sekundi"
+      x_minutes:
+        one: 1 minut
+        few: "%{count} minute"
+        many: "%{count} minuta"
+        other: "%{count} minuta"
+      x_days:
+        one: 1 dan
+        few: "%{count} dana"
+        many: "%{count} dana"
+        other: "%{count} dana"
+      x_months:
+        one: 1 mjesec
+        few: "%{count} mjeseca"
+        many: "%{count} mjeseci"
+        other: "%{count} mjeseci"
     prompts:
-      day: dan
-      hour: sat
-      minute: minut
-      month: mjesec
       second: sekundi
+      minute: minut
+      hour: sat
+      day: dan
+      month: mjesec
       year: godina
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: mora biti prihvaćeno
       blank: ne smije biti prazno
-      present: mora biti prazno
       confirmation: se ne poklapa sa potvrdom
       empty: ne smije biti prazno
       equal_to: mora biti %{count}
@@ -145,17 +144,18 @@ bs:
       not_a_number: nije broj
       not_an_integer: mora biti cijeli broj
       odd: mora biti neparno
+      other_than: mora biti različito od %{count}
+      present: mora biti prazno
       taken: je već zauzet
       too_long: je predugo (maksimalno je dozvoljeno %{count} znakova)
       too_short: je prekratko (predviđeno je minimalno %{count} znakova)
       wrong_length: je pogrešne dužine (trebalo bi biti tačno %{count} znakova)
-      other_than: mora biti različito od %{count}
     template:
       body: 'Desili su se problemi sa slijedećim poljima:'
       header:
+        one: 1 greška je spriječila da se ovaj %{model} spremi
         few: "%{count} greške su spriječile da se ovaj %{model} spremi"
         many: "%{count} grešaka je spriječilo da se ovaj %{model} spremi"
-        one: 1 greška je spriječila da se ovaj %{model} spremi
         other: "%{count} grešaka je spriječilo da se ovaj %{model} spremi"
   helpers:
     select:
@@ -185,29 +185,29 @@ bs:
         format: "%n %u"
         units:
           billion:
+            one: milijarda
             few: milijarde
             many: milijardi
-            one: milijarda
             other: milijardi
           million:
+            one: milion
             few: miliona
             many: miliona
-            one: milion
             other: miliona
           quadrillion:
+            one: bilijarda
             few: bilijarde
             many: bilijardi
-            one: bilijarda
             other: bilijardi
           thousand:
+            one: hiljada
             few: hiljade
             many: hiljada
-            one: hiljada
             other: hiljada
           trillion:
+            one: bilion
             few: biliona
             many: biliona
-            one: bilion
             other: biliona
           unit: ''
       format:
@@ -219,9 +219,9 @@ bs:
         format: "%n %u"
         units:
           byte:
+            one: bajt
             few: bajta
             many: bajtova
-            one: bajt
             other: bajtova
           gb: GB
           kb: KB

--- a/rails/locale/ca.yml
+++ b/rails/locale/ca.yml
@@ -14,7 +14,7 @@ ca:
     - Dv
     - Ds
     abbr_month_names:
-    -
+    - 
     - Gen
     - Feb
     - Mar
@@ -40,7 +40,7 @@ ca:
       long: "%d de %B de %Y"
       short: "%d de %b"
     month_names:
-    -
+    - 
     - Gener
     - Febrer
     - Març
@@ -72,36 +72,36 @@ ca:
         one: quasi 1 any
         other: quasi %{count} anys
       half_a_minute: mig minut
-      less_than_x_minutes:
-        one: menys d'1 minut
-        other: menys de %{count} minuts
       less_than_x_seconds:
         one: menys d'1 segon
         other: menys de %{count} segons
+      less_than_x_minutes:
+        one: menys d'1 minut
+        other: menys de %{count} minuts
       over_x_years:
         one: més d'1 any
         other: més de %{count} anys
-      x_days:
-        one: 1 dia
-        other: "%{count} dies"
+      x_seconds:
+        one: 1 segon
+        other: "%{count} segons"
       x_minutes:
         one: 1 minut
         other: "%{count} minuts"
+      x_days:
+        one: 1 dia
+        other: "%{count} dies"
       x_months:
         one: 1 mes
         other: "%{count} mesos"
       x_years:
         one: 1 year
-        other: "%{count} years" 
-      x_seconds:
-        one: 1 segon
-        other: "%{count} segons"
+        other: "%{count} years"
     prompts:
-      day: dia
-      hour: hora
-      minute: minut
-      month: mes
       second: segon
+      minute: minut
+      hour: hora
+      day: dia
+      month: mes
       year: any
   errors:
     format: "%{attribute} %{message}"

--- a/rails/locale/cs.yml
+++ b/rails/locale/cs.yml
@@ -17,7 +17,7 @@ cs:
     - Pá
     - So
     abbr_month_names:
-    -
+    - 
     - led
     - úno
     - bře
@@ -43,7 +43,7 @@ cs:
       long: "%d. %B %Y"
       short: "%d %b"
     month_names:
-    -
+    - 
     - leden
     - únor
     - březen
@@ -79,47 +79,46 @@ cs:
         few: téměř %{count} roky
         other: téměř %{count} roky
       half_a_minute: půl minutou
-      less_than_x_minutes:
-        one: necelou minutou
-        few: ani ne %{count} minutami
-        other: ani ne %{count} minutami
       less_than_x_seconds:
         one: necelou sekundou
         few: ani ne %{count} sekundami
         other: ani ne %{count} sekundami
+      less_than_x_minutes:
+        one: necelou minutou
+        few: ani ne %{count} minutami
+        other: ani ne %{count} minutami
       over_x_years:
         one: více než rokem
         few: více než %{count} roky
         other: více než %{count} roky
-      x_days:
-        one: 24 hodinami
-        few: "%{count} dny"
-        other: "%{count} dny"
-      x_minutes:
-        one: minutou
-        few: "%{count} minutami"
-        other: "%{count} minutami"
-      x_months:
-        one: měsícem
-        few: "%{count} měsíci"
-        other: "%{count} měsíci"
       x_seconds:
         one: sekundou
         few: "%{count} sekundami"
         other: "%{count} sekundami"
+      x_minutes:
+        one: minutou
+        few: "%{count} minutami"
+        other: "%{count} minutami"
+      x_days:
+        one: 24 hodinami
+        few: "%{count} dny"
+        other: "%{count} dny"
+      x_months:
+        one: měsícem
+        few: "%{count} měsíci"
+        other: "%{count} měsíci"
     prompts:
-      day: Den
-      hour: Hodina
-      minute: Minuta
-      month: Měsíc
       second: Sekunda
+      minute: Minuta
+      hour: Hodina
+      day: Den
+      month: Měsíc
       year: Rok
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: musí být potvrzeno
       blank: je povinná položka
-      present: musí být prázdný/á/é
       confirmation: nebylo potvrzeno
       empty: nesmí být prázdný/á/é
       equal_to: musí být rovno %{count}
@@ -134,12 +133,13 @@ cs:
       not_a_number: není číslo
       not_an_integer: musí být celé číslo
       odd: musí být liché číslo
+      other_than: musí být rozdílný/á/é od %{count}
+      present: musí být prázdný/á/é
       required: musí existovat
       taken: již databáze obsahuje
       too_long: je příliš dlouhý/á/é (max. %{count} znaků)
       too_short: je příliš krátký/á/é (min. %{count} znaků)
       wrong_length: nemá správnou délku (očekáváno %{count} znaků)
-      other_than: musí být rozdílný/á/é od %{count}
     template:
       body: 'Následující pole obsahují chybně vyplněné údaje: '
       header:

--- a/rails/locale/cy.yml
+++ b/rails/locale/cy.yml
@@ -14,7 +14,7 @@ cy:
     - Gwe
     - Sad
     abbr_month_names:
-    -
+    - 
     - Ion
     - Chw
     - Maw
@@ -40,7 +40,7 @@ cy:
       long: "%B %d, %Y"
       short: "%b %d"
     month_names:
-    -
+    - 
     - Ionawr
     - Chwefror
     - Mawrth
@@ -88,13 +88,6 @@ cy:
         many: bron yn %{count} blynedd
         other: bron yn %{count} blynedd
       half_a_minute: hanner munud
-      less_than_x_minutes:
-        zero: llai na %{count} munud
-        one: llai na munud
-        two: llai na %{count} munud
-        few: llai na %{count} munud
-        many: llai na %{count} munud
-        other: llai na %{count} munud
       less_than_x_seconds:
         zero: llai na %{count} eiliad
         one: llai nag eiliad
@@ -102,6 +95,13 @@ cy:
         few: llai na %{count} eiliad
         many: llai na %{count} eiliad
         other: llai na %{count} eiliad
+      less_than_x_minutes:
+        zero: llai na %{count} munud
+        one: llai na munud
+        two: llai na %{count} munud
+        few: llai na %{count} munud
+        many: llai na %{count} munud
+        other: llai na %{count} munud
       over_x_years:
         zero: dros %{count} blynedd
         one: dros flwyddyn
@@ -109,27 +109,6 @@ cy:
         few: dros %{count} blynedd
         many: dros %{count} blynedd
         other: dros %{count} blynedd
-      x_days:
-        zero: "%{count} diwrnod"
-        one: 1 diwrnod
-        two: "%{count} diwrnod"
-        few: "%{count} diwrnod"
-        many: "%{count} diwrnod"
-        other: "%{count} diwrnod"
-      x_minutes:
-        zero: "%{count} o funudau"
-        one: 1 munud
-        two: "%{count} o funudau"
-        few: "%{count} o funudau"
-        many: "%{count} o funudau"
-        other: "%{count} o funudau"
-      x_months:
-        zero: "%{count} mis"
-        one: 1 mis
-        two: "%{count} mis"
-        few: "%{count} mis"
-        many: "%{count} mis"
-        other: "%{count} mis"
       x_seconds:
         zero: "%{count} o eiliadau"
         one: 1 eiliad
@@ -137,12 +116,33 @@ cy:
         few: "%{count} o eiliadau"
         many: "%{count} o eiliadau"
         other: "%{count} o eiliadau"
+      x_minutes:
+        zero: "%{count} o funudau"
+        one: 1 munud
+        two: "%{count} o funudau"
+        few: "%{count} o funudau"
+        many: "%{count} o funudau"
+        other: "%{count} o funudau"
+      x_days:
+        zero: "%{count} diwrnod"
+        one: 1 diwrnod
+        two: "%{count} diwrnod"
+        few: "%{count} diwrnod"
+        many: "%{count} diwrnod"
+        other: "%{count} diwrnod"
+      x_months:
+        zero: "%{count} mis"
+        one: 1 mis
+        two: "%{count} mis"
+        few: "%{count} mis"
+        many: "%{count} mis"
+        other: "%{count} mis"
     prompts:
-      day: Diwrnod
-      hour: Awr
-      minute: Munud
-      month: Mis
       second: Eiliad
+      minute: Munud
+      hour: Awr
+      day: Diwrnod
+      month: Mis
       year: Blwyddyn
   errors:
     format: "%{attribute} %{message}"

--- a/rails/locale/da.yml
+++ b/rails/locale/da.yml
@@ -17,7 +17,7 @@ da:
     - fre
     - lør
     abbr_month_names:
-    -
+    - 
     - jan
     - feb
     - mar
@@ -43,7 +43,7 @@ da:
       long: "%e. %B %Y"
       short: "%e. %b %Y"
     month_names:
-    -
+    - 
     - januar
     - februar
     - marts
@@ -75,43 +75,42 @@ da:
         one: næsten et år
         other: næsten %{count} år
       half_a_minute: et halvt minut
-      less_than_x_minutes:
-        one: mindre end et minut
-        other: mindre end %{count} minutter
       less_than_x_seconds:
         one: mindre end et sekund
         other: mindre end %{count} sekunder
+      less_than_x_minutes:
+        one: mindre end et minut
+        other: mindre end %{count} minutter
       over_x_years:
         one: mere end et år
         other: mere end %{count} år
-      x_days:
-        one: en dag
-        other: "%{count} dage"
+      x_seconds:
+        one: et sekund
+        other: "%{count} sekunder"
       x_minutes:
         one: et minut
         other: "%{count} minutter"
+      x_days:
+        one: en dag
+        other: "%{count} dage"
       x_months:
         one: en måned
         other: "%{count} måneder"
       x_years:
         one: et år
         other: "%{count} år"
-      x_seconds:
-        one: et sekund
-        other: "%{count} sekunder"
     prompts:
-      day: Dag
-      hour: Time
-      minute: Minut
-      month: Måned
       second: Sekund
+      minute: Minut
+      hour: Time
+      day: Dag
+      month: Måned
       year: År
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: skal accepteres
       blank: skal udfyldes
-      present: skal være tom
       confirmation: stemmer ikke overens med bekræftelse
       empty: må ikke udelades
       equal_to: skal være %{count}
@@ -123,16 +122,17 @@ da:
       invalid: er ikke gyldig
       less_than: skal være mindre end %{count}
       less_than_or_equal_to: skal være mindre end, eller lig med, %{count}
-      model_invalid: "Godkendelse gik galt: %{errors}"
+      model_invalid: 'Godkendelse gik galt: %{errors}'
       not_a_number: er ikke et tal
       not_an_integer: er ikke et heltal
       odd: skal være et ulige tal
+      other_than: skal være forskellig fra %{count}
+      present: skal være tom
       required: skal eksistere
       taken: er allerede brugt
       too_long: er for lang (højst %{count} tegn)
       too_short: er for kort (mindst %{count} tegn)
       wrong_length: har forkert længde (skulle være %{count} tegn)
-      other_than: skal være forskellig fra %{count}
     template:
       body: 'Der var problemer med følgende felter:'
       header:

--- a/rails/locale/de-AT.yml
+++ b/rails/locale/de-AT.yml
@@ -18,7 +18,7 @@ de-AT:
     - Fr
     - Sa
     abbr_month_names:
-    -
+    - 
     - Jän
     - Feb
     - Mär
@@ -44,7 +44,7 @@ de-AT:
       long: "%e. %B %Y"
       short: "%e. %b"
     month_names:
-    -
+    - 
     - Jänner
     - Februar
     - März
@@ -76,40 +76,39 @@ de-AT:
         one: fast ein Jahr
         other: fast %{count} Jahre
       half_a_minute: eine halbe Minute
-      less_than_x_minutes:
-        one: weniger als eine Minute
-        other: weniger als %{count} Minuten
       less_than_x_seconds:
         one: weniger als eine Sekunde
         other: weniger als %{count} Sekunden
+      less_than_x_minutes:
+        one: weniger als eine Minute
+        other: weniger als %{count} Minuten
       over_x_years:
         one: mehr als ein Jahr
         other: mehr als %{count} Jahre
-      x_days:
-        one: ein Tag
-        other: "%{count} Tage"
-      x_minutes:
-        one: eine Minute
-        other: "%{count} Minuten"
-      x_months:
-        one: ein Monat
-        other: "%{count} Monate"
       x_seconds:
         one: eine Sekunde
         other: "%{count} Sekunden"
+      x_minutes:
+        one: eine Minute
+        other: "%{count} Minuten"
+      x_days:
+        one: ein Tag
+        other: "%{count} Tage"
+      x_months:
+        one: ein Monat
+        other: "%{count} Monate"
     prompts:
-      day: Tag
-      hour: Stunden
-      minute: Minuten
-      month: Monat
       second: Sekunden
+      minute: Minuten
+      hour: Stunden
+      day: Tag
+      month: Monat
       year: Jahr
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: muss akzeptiert werden
       blank: muss ausgefüllt werden
-      present: darf nicht ausgefüllt werden
       confirmation: stimmt nicht mit %{attribute} überein
       empty: muss ausgefüllt werden
       equal_to: muss genau %{count} sein
@@ -124,8 +123,10 @@ de-AT:
       model_invalid: 'Gültigkeitsprüfung ist fehlgeschlagen: %{errors}'
       not_a_number: ist keine Zahl
       not_an_integer: muss ganzzahlig sein
-      required: muss ausgefüllt werden
       odd: muss ungerade sein
+      other_than: darf nicht gleich %{count} sein
+      present: darf nicht ausgefüllt werden
+      required: muss ausgefüllt werden
       taken: ist bereits vergeben
       too_long:
         one: ist zu lang (mehr als 1 Zeichen)
@@ -136,7 +137,6 @@ de-AT:
       wrong_length:
         one: hat die falsche Länge (muss genau 1 Zeichen haben)
         other: hat die falsche Länge (muss genau %{count} Zeichen haben)
-      other_than: darf nicht gleich %{count} sein
     template:
       body: 'Bitte überprüfen Sie die folgenden Felder:'
       header:

--- a/rails/locale/de-CH.yml
+++ b/rails/locale/de-CH.yml
@@ -18,7 +18,7 @@ de-CH:
     - Fr
     - Sa
     abbr_month_names:
-    -
+    - 
     - Jan
     - Feb
     - Mär
@@ -44,7 +44,7 @@ de-CH:
       long: "%e. %B %Y"
       short: "%e. %b"
     month_names:
-    -
+    - 
     - Januar
     - Februar
     - März
@@ -76,40 +76,39 @@ de-CH:
         one: fast ein Jahr
         other: fast %{count} Jahre
       half_a_minute: eine halbe Minute
-      less_than_x_minutes:
-        one: weniger als eine Minute
-        other: weniger als %{count} Minuten
       less_than_x_seconds:
         one: weniger als eine Sekunde
         other: weniger als %{count} Sekunden
+      less_than_x_minutes:
+        one: weniger als eine Minute
+        other: weniger als %{count} Minuten
       over_x_years:
         one: mehr als ein Jahr
         other: mehr als %{count} Jahre
-      x_days:
-        one: ein Tag
-        other: "%{count} Tage"
-      x_minutes:
-        one: eine Minute
-        other: "%{count} Minuten"
-      x_months:
-        one: ein Monat
-        other: "%{count} Monate"
       x_seconds:
         one: eine Sekunde
         other: "%{count} Sekunden"
+      x_minutes:
+        one: eine Minute
+        other: "%{count} Minuten"
+      x_days:
+        one: ein Tag
+        other: "%{count} Tage"
+      x_months:
+        one: ein Monat
+        other: "%{count} Monate"
     prompts:
-      day: Tag
-      hour: Stunden
-      minute: Minute
-      month: Monat
       second: Sekunde
+      minute: Minute
+      hour: Stunden
+      day: Tag
+      month: Monat
       year: Jahr
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: muss akzeptiert werden
       blank: muss ausgefüllt werden
-      present: darf nicht ausgefüllt werden
       confirmation: stimmt nicht mit %{attribute} überein
       empty: muss ausgefüllt werden
       equal_to: muss genau %{count} sein
@@ -124,8 +123,10 @@ de-CH:
       model_invalid: 'Gültigkeitsprüfung ist fehlgeschlagen: %{errors}'
       not_a_number: ist keine Zahl
       not_an_integer: muss ganzzahlig sein
-      required: muss ausgefüllt werden
       odd: muss ungerade sein
+      other_than: darf nicht gleich %{count} sein
+      present: darf nicht ausgefüllt werden
+      required: muss ausgefüllt werden
       taken: ist bereits vergeben
       too_long:
         one: ist zu lang (mehr als 1 Zeichen)
@@ -136,7 +137,6 @@ de-CH:
       wrong_length:
         one: hat die falsche Länge (muss genau 1 Zeichen haben)
         other: hat die falsche Länge (muss genau %{count} Zeichen haben)
-      other_than: darf nicht gleich %{count} sein
     template:
       body: 'Bitte überprüfen Sie die folgenden Felder:'
       header:

--- a/rails/locale/de-DE.yml
+++ b/rails/locale/de-DE.yml
@@ -18,7 +18,7 @@ de-DE:
     - Fr
     - Sa
     abbr_month_names:
-    -
+    - 
     - Jan
     - Feb
     - Mär
@@ -44,7 +44,7 @@ de-DE:
       long: "%e. %B %Y"
       short: "%e. %b"
     month_names:
-    -
+    - 
     - Januar
     - Februar
     - März
@@ -76,40 +76,39 @@ de-DE:
         one: fast ein Jahr
         other: fast %{count} Jahre
       half_a_minute: eine halbe Minute
-      less_than_x_minutes:
-        one: weniger als eine Minute
-        other: weniger als %{count} Minuten
       less_than_x_seconds:
         one: weniger als eine Sekunde
         other: weniger als %{count} Sekunden
+      less_than_x_minutes:
+        one: weniger als eine Minute
+        other: weniger als %{count} Minuten
       over_x_years:
         one: mehr als ein Jahr
         other: mehr als %{count} Jahre
-      x_days:
-        one: ein Tag
-        other: "%{count} Tage"
-      x_minutes:
-        one: eine Minute
-        other: "%{count} Minuten"
-      x_months:
-        one: ein Monat
-        other: "%{count} Monate"
       x_seconds:
         one: eine Sekunde
         other: "%{count} Sekunden"
+      x_minutes:
+        one: eine Minute
+        other: "%{count} Minuten"
+      x_days:
+        one: ein Tag
+        other: "%{count} Tage"
+      x_months:
+        one: ein Monat
+        other: "%{count} Monate"
     prompts:
-      day: Tag
-      hour: Stunden
-      minute: Minute
-      month: Monat
       second: Sekunde
+      minute: Minute
+      hour: Stunden
+      day: Tag
+      month: Monat
       year: Jahr
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: muss akzeptiert werden
       blank: muss ausgefüllt werden
-      present: darf nicht ausgefüllt werden
       confirmation: stimmt nicht mit %{attribute} überein
       empty: muss ausgefüllt werden
       equal_to: muss genau %{count} sein
@@ -124,8 +123,10 @@ de-DE:
       model_invalid: 'Gültigkeitsprüfung ist fehlgeschlagen: %{errors}'
       not_a_number: ist keine Zahl
       not_an_integer: muss ganzzahlig sein
-      required: muss ausgefüllt werden
       odd: muss ungerade sein
+      other_than: darf nicht gleich %{count} sein
+      present: darf nicht ausgefüllt werden
+      required: muss ausgefüllt werden
       taken: ist bereits vergeben
       too_long:
         one: ist zu lang (mehr als 1 Zeichen)
@@ -136,7 +137,6 @@ de-DE:
       wrong_length:
         one: hat die falsche Länge (muss genau 1 Zeichen haben)
         other: hat die falsche Länge (muss genau %{count} Zeichen haben)
-      other_than: darf nicht gleich %{count} sein
     template:
       body: 'Bitte überprüfen Sie die folgenden Felder:'
       header:

--- a/rails/locale/de.yml
+++ b/rails/locale/de.yml
@@ -18,7 +18,7 @@ de:
     - Fr
     - Sa
     abbr_month_names:
-    -
+    - 
     - Jan
     - Feb
     - Mär
@@ -44,7 +44,7 @@ de:
       long: "%e. %B %Y"
       short: "%e. %b"
     month_names:
-    -
+    - 
     - Januar
     - Februar
     - März
@@ -76,43 +76,42 @@ de:
         one: fast ein Jahr
         other: fast %{count} Jahre
       half_a_minute: eine halbe Minute
-      less_than_x_minutes:
-        one: weniger als eine Minute
-        other: weniger als %{count} Minuten
       less_than_x_seconds:
         one: weniger als eine Sekunde
         other: weniger als %{count} Sekunden
+      less_than_x_minutes:
+        one: weniger als eine Minute
+        other: weniger als %{count} Minuten
       over_x_years:
         one: mehr als ein Jahr
         other: mehr als %{count} Jahre
-      x_days:
-        one: ein Tag
-        other: "%{count} Tage"
+      x_seconds:
+        one: eine Sekunde
+        other: "%{count} Sekunden"
       x_minutes:
         one: eine Minute
         other: "%{count} Minuten"
+      x_days:
+        one: ein Tag
+        other: "%{count} Tage"
       x_months:
         one: ein Monat
         other: "%{count} Monate"
       x_years:
         one: ein Jahr
         other: "%{count} Jahr"
-      x_seconds:
-        one: eine Sekunde
-        other: "%{count} Sekunden"
     prompts:
-      day: Tag
-      hour: Stunden
-      minute: Minute
-      month: Monat
       second: Sekunde
+      minute: Minute
+      hour: Stunden
+      day: Tag
+      month: Monat
       year: Jahr
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: muss akzeptiert werden
       blank: muss ausgefüllt werden
-      present: darf nicht ausgefüllt werden
       confirmation: stimmt nicht mit %{attribute} überein
       empty: muss ausgefüllt werden
       equal_to: muss genau %{count} sein
@@ -128,6 +127,8 @@ de:
       not_a_number: ist keine Zahl
       not_an_integer: muss ganzzahlig sein
       odd: muss ungerade sein
+      other_than: darf nicht gleich %{count} sein
+      present: darf nicht ausgefüllt werden
       required: muss ausgefüllt werden
       taken: ist bereits vergeben
       too_long:
@@ -139,7 +140,6 @@ de:
       wrong_length:
         one: hat die falsche Länge (muss genau 1 Zeichen haben)
         other: hat die falsche Länge (muss genau %{count} Zeichen haben)
-      other_than: darf nicht gleich %{count} sein
     template:
       body: 'Bitte überprüfen Sie die folgenden Felder:'
       header:

--- a/rails/locale/el-CY.yml
+++ b/rails/locale/el-CY.yml
@@ -3,7 +3,7 @@ el-CY:
   activerecord:
     errors:
       messages:
-        record_invalid: ! 'Η επικύρωση απέτυχε: %{errors}'
+        record_invalid: 'Η επικύρωση απέτυχε: %{errors}'
   date:
     abbr_day_names:
     - Κυρ
@@ -14,7 +14,7 @@ el-CY:
     - Παρ
     - Σάβ
     abbr_month_names:
-    -
+    - 
     - Ιαν
     - Φεβ
     - Μαρ
@@ -36,11 +36,11 @@ el-CY:
     - Παρασκευή
     - Σάββατο
     formats:
-      default: ! '%d/%m/%Y'
-      long: ! '%e %B %Y'
-      short: ! '%d %b'
+      default: "%d/%m/%Y"
+      long: "%e %B %Y"
+      short: "%d %b"
     month_names:
-    -
+    - 
     - Ιανουάριος
     - Φεβρουάριος
     - Μάρτιος
@@ -72,36 +72,36 @@ el-CY:
         one: σχεδόν ένα χρόνο
         other: σχεδόν %{count} χρόνια
       half_a_minute: μισό λεπτό
-      less_than_x_minutes:
-        one: λιγότερο από ένα λεπτό
-        other: λιγότερο από %{count} λεπτά
       less_than_x_seconds:
         one: λιγότερο από ένα δευτερόλεπτο
         other: λιγότερο από %{count} δευτερόλεπτα
+      less_than_x_minutes:
+        one: λιγότερο από ένα λεπτό
+        other: λιγότερο από %{count} λεπτά
       over_x_years:
         one: πάνω από ένα χρόνο
         other: πάνω από %{count} χρόνια
-      x_days:
-        one: 1 μέρα
-        other: ! '%{count} ημέρες'
-      x_minutes:
-        one: 1 λεπτό
-        other: ! '%{count} λεπτά'
-      x_months:
-        one: 1 μήνα
-        other: ! '%{count} μήνες'
       x_seconds:
         one: 1 δευτερόλεπτο
-        other: ! '%{count} δευτερόλεπτα'
+        other: "%{count} δευτερόλεπτα"
+      x_minutes:
+        one: 1 λεπτό
+        other: "%{count} λεπτά"
+      x_days:
+        one: 1 μέρα
+        other: "%{count} ημέρες"
+      x_months:
+        one: 1 μήνα
+        other: "%{count} μήνες"
     prompts:
-      day: Ημέρα
-      hour: Ώρα
-      minute: Λεπτό
-      month: Μήνας
       second: Δευτερόλεπτο
+      minute: Λεπτό
+      hour: Ώρα
+      day: Ημέρα
+      month: Μήνας
       year: Έτος
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: πρέπει να είναι αποδεκτό
       blank: δεν πρέπει να είναι κενό
@@ -130,10 +130,10 @@ el-CY:
         one: έχει λανθασμένο μήκος (πρέπει να είναι 1 χαρακτήρας)
         other: έχει λανθασμένο μήκος (πρέπει να είναι %{count} χαρακτήρες)
     template:
-      body: ! 'Υπήρξαν προβλήματα με τα ακόλουθα πεδία:'
+      body: 'Υπήρξαν προβλήματα με τα ακόλουθα πεδία:'
       header:
         one: 1 λάθος εμπόδισε αυτό το %{model} να αποθηκευτεί.
-        other: ! '%{count} λάθη εμπόδισαν αυτό το %{model} να αποθηκευτεί.'
+        other: "%{count} λάθη εμπόδισαν αυτό το %{model} να αποθηκευτεί."
   helpers:
     select:
       prompt: Παρακαλώ επιλέξτε
@@ -145,21 +145,21 @@ el-CY:
     currency:
       format:
         delimiter: "."
-        format: ! '%n %u'
+        format: "%n %u"
         precision: 2
-        separator: ! ','
+        separator: ","
         significant: false
         strip_insignificant_zeros: false
-        unit: €
+        unit: "€"
     format:
       delimiter: "."
       precision: 3
-      separator: ! ','
+      separator: ","
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: δισεκατομμύριο
           million: εκατομμύριο
@@ -173,7 +173,7 @@ el-CY:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Byte
@@ -190,13 +190,13 @@ el-CY:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ' και '
-      two_words_connector: ! ' και '
-      words_connector: ! ', '
+      last_word_connector: " και "
+      two_words_connector: " και "
+      words_connector: ", "
   time:
     am: π.μ.
     formats:
-      default: ! '%d %B %Y %H:%M'
-      long: ! '%A %d %B %Y %H:%M:%S %Z'
-      short: ! '%d %b %H:%M'
+      default: "%d %B %Y %H:%M"
+      long: "%A %d %B %Y %H:%M:%S %Z"
+      short: "%d %b %H:%M"
     pm: μ.μ.

--- a/rails/locale/el.yml
+++ b/rails/locale/el.yml
@@ -3,7 +3,7 @@ el:
   activerecord:
     errors:
       messages:
-        record_invalid: ! 'Η επικύρωση απέτυχε: %{errors}'
+        record_invalid: 'Η επικύρωση απέτυχε: %{errors}'
   date:
     abbr_day_names:
     - Κυρ
@@ -14,7 +14,7 @@ el:
     - Παρ
     - Σάβ
     abbr_month_names:
-    -
+    - 
     - Ιαν
     - Φεβ
     - Μαρ
@@ -36,11 +36,11 @@ el:
     - Παρασκευή
     - Σάββατο
     formats:
-      default: ! '%d/%m/%Y'
-      long: ! '%e %B %Y'
-      short: ! '%d %b'
+      default: "%d/%m/%Y"
+      long: "%e %B %Y"
+      short: "%d %b"
     month_names:
-    -
+    - 
     - Ιανουάριος
     - Φεβρουάριος
     - Μάρτιος
@@ -72,36 +72,36 @@ el:
         one: σχεδόν ένα χρόνο
         other: σχεδόν %{count} χρόνια
       half_a_minute: μισό λεπτό
-      less_than_x_minutes:
-        one: λιγότερο από ένα λεπτό
-        other: λιγότερο από %{count} λεπτά
       less_than_x_seconds:
         one: λιγότερο από ένα δευτερόλεπτο
         other: λιγότερο από %{count} δευτερόλεπτα
+      less_than_x_minutes:
+        one: λιγότερο από ένα λεπτό
+        other: λιγότερο από %{count} λεπτά
       over_x_years:
         one: πάνω από ένα χρόνο
         other: πάνω από %{count} χρόνια
-      x_days:
-        one: 1 μέρα
-        other: ! '%{count} ημέρες'
-      x_minutes:
-        one: 1 λεπτό
-        other: ! '%{count} λεπτά'
-      x_months:
-        one: 1 μήνα
-        other: ! '%{count} μήνες'
       x_seconds:
         one: 1 δευτερόλεπτο
-        other: ! '%{count} δευτερόλεπτα'
+        other: "%{count} δευτερόλεπτα"
+      x_minutes:
+        one: 1 λεπτό
+        other: "%{count} λεπτά"
+      x_days:
+        one: 1 μέρα
+        other: "%{count} ημέρες"
+      x_months:
+        one: 1 μήνα
+        other: "%{count} μήνες"
     prompts:
-      day: Ημέρα
-      hour: Ώρα
-      minute: Λεπτό
-      month: Μήνας
       second: Δευτερόλεπτο
+      minute: Λεπτό
+      hour: Ώρα
+      day: Ημέρα
+      month: Μήνας
       year: Έτος
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: πρέπει να είναι αποδεκτό
       blank: δεν πρέπει να είναι κενό
@@ -130,10 +130,10 @@ el:
         one: έχει λανθασμένο μήκος (πρέπει να είναι 1 χαρακτήρας)
         other: έχει λανθασμένο μήκος (πρέπει να είναι %{count} χαρακτήρες)
     template:
-      body: ! 'Υπήρξαν προβλήματα με τα ακόλουθα πεδία:'
+      body: 'Υπήρξαν προβλήματα με τα ακόλουθα πεδία:'
       header:
         one: 1 λάθος εμπόδισε αυτό το %{model} να αποθηκευτεί.
-        other: ! '%{count} λάθη εμπόδισαν αυτό το %{model} να αποθηκευτεί.'
+        other: "%{count} λάθη εμπόδισαν αυτό το %{model} να αποθηκευτεί."
   helpers:
     select:
       prompt: Παρακαλώ επιλέξτε
@@ -145,21 +145,21 @@ el:
     currency:
       format:
         delimiter: "."
-        format: ! '%n %u'
+        format: "%n %u"
         precision: 2
-        separator: ! ','
+        separator: ","
         significant: false
         strip_insignificant_zeros: false
-        unit: €
+        unit: "€"
     format:
       delimiter: "."
       precision: 3
-      separator: ! ','
+      separator: ","
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: δισεκατομμύριο
           million: εκατομμύριο
@@ -173,7 +173,7 @@ el:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Byte
@@ -190,13 +190,13 @@ el:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ' και '
-      two_words_connector: ! ' και '
-      words_connector: ! ', '
+      last_word_connector: " και "
+      two_words_connector: " και "
+      words_connector: ", "
   time:
     am: π.μ.
     formats:
-      default: ! '%d %B %Y %H:%M'
-      long: ! '%A %d %B %Y %H:%M:%S %Z'
-      short: ! '%d %b %H:%M'
+      default: "%d %B %Y %H:%M"
+      long: "%A %d %B %Y %H:%M:%S %Z"
+      short: "%d %b %H:%M"
     pm: μ.μ.

--- a/rails/locale/en-AU.yml
+++ b/rails/locale/en-AU.yml
@@ -3,10 +3,10 @@ en-AU:
   activerecord:
     errors:
       messages:
-        record_invalid: "Validation failed: %{errors}"
+        record_invalid: 'Validation failed: %{errors}'
         restrict_dependent_destroy:
-          has_one: "Cannot delete record because a dependent %{record} exists"
-          has_many: "Cannot delete record because dependent %{record} exist"
+          has_one: Cannot delete record because a dependent %{record} exists
+          has_many: Cannot delete record because dependent %{record} exist
   date:
     abbr_day_names:
     - Sun
@@ -17,7 +17,7 @@ en-AU:
     - Fri
     - Sat
     abbr_month_names:
-    -
+    - 
     - Jan
     - Feb
     - Mar
@@ -43,7 +43,7 @@ en-AU:
       long: "%d %B, %Y"
       short: "%d %b"
     month_names:
-    -
+    - 
     - January
     - February
     - March
@@ -75,43 +75,42 @@ en-AU:
         one: almost 1 year
         other: almost %{count} years
       half_a_minute: half a minute
-      less_than_x_minutes:
-        one: less than a minute
-        other: less than %{count} minutes
       less_than_x_seconds:
         one: less than 1 second
         other: less than %{count} seconds
+      less_than_x_minutes:
+        one: less than a minute
+        other: less than %{count} minutes
       over_x_years:
         one: over 1 year
         other: over %{count} years
-      x_days:
-        one: 1 day
-        other: "%{count} days"
+      x_seconds:
+        one: 1 second
+        other: "%{count} seconds"
       x_minutes:
         one: 1 minute
         other: "%{count} minutes"
+      x_days:
+        one: 1 day
+        other: "%{count} days"
       x_months:
         one: 1 month
         other: "%{count} months"
       x_years:
         one: 1 year
         other: "%{count} years"
-      x_seconds:
-        one: 1 second
-        other: "%{count} seconds"
     prompts:
-      day: Day
-      hour: Hour
-      minute: Minute
-      month: Month
       second: Seconds
+      minute: Minute
+      hour: Hour
+      day: Day
+      month: Month
       year: Year
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: must be accepted
       blank: can't be blank
-      present: must be blank
       confirmation: doesn't match %{attribute}
       empty: can't be empty
       equal_to: must be equal to %{count}
@@ -123,10 +122,12 @@ en-AU:
       invalid: is invalid
       less_than: must be less than %{count}
       less_than_or_equal_to: must be less than or equal to %{count}
-      model_invalid: "Validation failed: %{errors}"
+      model_invalid: 'Validation failed: %{errors}'
       not_a_number: is not a number
       not_an_integer: must be an integer
       odd: must be odd
+      other_than: must be other than %{count}
+      present: must be blank
       required: must exist
       taken: has already been taken
       too_long:
@@ -138,7 +139,6 @@ en-AU:
       wrong_length:
         one: is the wrong length (should be 1 character)
         other: is the wrong length (should be %{count} characters)
-      other_than: must be other than %{count}
     template:
       body: 'There were problems with the following fields:'
       header:
@@ -188,12 +188,12 @@ en-AU:
           byte:
             one: Byte
             other: Bytes
+          eb: EB
           gb: GB
           kb: KB
           mb: MB
-          tb: TB
           pb: PB
-          eb: EB
+          tb: TB
     percentage:
       format:
         delimiter: ''

--- a/rails/locale/en-CA.yml
+++ b/rails/locale/en-CA.yml
@@ -3,10 +3,10 @@ en-CA:
   activerecord:
     errors:
       messages:
-        record_invalid: "Validation failed: %{errors}"
+        record_invalid: 'Validation failed: %{errors}'
         restrict_dependent_destroy:
-          has_one: "Cannot delete record because a dependent %{record} exists"
-          has_many: "Cannot delete record because dependent %{record} exist"
+          has_one: Cannot delete record because a dependent %{record} exists
+          has_many: Cannot delete record because dependent %{record} exist
   date:
     abbr_day_names:
     - Sun
@@ -17,7 +17,7 @@ en-CA:
     - Fri
     - Sat
     abbr_month_names:
-    -
+    - 
     - Jan
     - Feb
     - Mar
@@ -43,7 +43,7 @@ en-CA:
       long: "%B %d, %Y"
       short: "%d %b"
     month_names:
-    -
+    - 
     - January
     - February
     - March
@@ -75,43 +75,42 @@ en-CA:
         one: almost 1 year
         other: almost %{count} years
       half_a_minute: half a minute
-      less_than_x_minutes:
-        one: less than a minute
-        other: less than %{count} minutes
       less_than_x_seconds:
         one: less than 1 second
         other: less than %{count} seconds
+      less_than_x_minutes:
+        one: less than a minute
+        other: less than %{count} minutes
       over_x_years:
         one: over 1 year
         other: over %{count} years
-      x_days:
-        one: 1 day
-        other: "%{count} days"
+      x_seconds:
+        one: 1 second
+        other: "%{count} seconds"
       x_minutes:
         one: 1 minute
         other: "%{count} minutes"
+      x_days:
+        one: 1 day
+        other: "%{count} days"
       x_months:
         one: 1 month
         other: "%{count} months"
       x_years:
         one: 1 year
         other: "%{count} years"
-      x_seconds:
-        one: 1 second
-        other: "%{count} seconds"
     prompts:
-      day: Day
-      hour: Hour
-      minute: Minute
-      month: Month
       second: Seconds
+      minute: Minute
+      hour: Hour
+      day: Day
+      month: Month
       year: Year
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: must be accepted
       blank: can't be blank
-      present: must be blank
       confirmation: doesn't match %{attribute}
       empty: can't be empty
       equal_to: must be equal to %{count}
@@ -123,10 +122,12 @@ en-CA:
       invalid: is invalid
       less_than: must be less than %{count}
       less_than_or_equal_to: must be less than or equal to %{count}
-      model_invalid: "Validation failed: %{errors}"
+      model_invalid: 'Validation failed: %{errors}'
       not_a_number: is not a number
       not_an_integer: must be an integer
       odd: must be odd
+      other_than: must be other than %{count}
+      present: must be blank
       required: must exist
       taken: has already been taken
       too_long:
@@ -138,7 +139,6 @@ en-CA:
       wrong_length:
         one: is the wrong length (should be 1 character)
         other: is the wrong length (should be %{count} characters)
-      other_than: must be other than %{count}
     template:
       body: 'There were problems with the following fields:'
       header:
@@ -188,12 +188,12 @@ en-CA:
           byte:
             one: Byte
             other: Bytes
+          eb: EB
           gb: GB
           kb: KB
           mb: MB
-          tb: TB
           pb: PB
-          eb: EB
+          tb: TB
     percentage:
       format:
         delimiter: ''

--- a/rails/locale/en-CY.yml
+++ b/rails/locale/en-CY.yml
@@ -3,10 +3,10 @@ en-CY:
   activerecord:
     errors:
       messages:
-        record_invalid: "Validation failed: %{errors}"
+        record_invalid: 'Validation failed: %{errors}'
         restrict_dependent_destroy:
-          has_one: "Cannot delete record because a dependent %{record} exists"
-          has_many: "Cannot delete record because dependent %{record} exist"
+          has_one: Cannot delete record because a dependent %{record} exists
+          has_many: Cannot delete record because dependent %{record} exist
   date:
     abbr_day_names:
     - Sun
@@ -17,7 +17,7 @@ en-CY:
     - Fri
     - Sat
     abbr_month_names:
-    -
+    - 
     - Jan
     - Feb
     - Mar
@@ -43,7 +43,7 @@ en-CY:
       long: "%d %B, %Y"
       short: "%d %b"
     month_names:
-    -
+    - 
     - January
     - February
     - March
@@ -75,43 +75,42 @@ en-CY:
         one: almost 1 year
         other: almost %{count} years
       half_a_minute: half a minute
-      less_than_x_minutes:
-        one: less than a minute
-        other: less than %{count} minutes
       less_than_x_seconds:
         one: less than 1 second
         other: less than %{count} seconds
+      less_than_x_minutes:
+        one: less than a minute
+        other: less than %{count} minutes
       over_x_years:
         one: over 1 year
         other: over %{count} years
-      x_days:
-        one: 1 day
-        other: "%{count} days"
+      x_seconds:
+        one: 1 second
+        other: "%{count} seconds"
       x_minutes:
         one: 1 minute
         other: "%{count} minutes"
+      x_days:
+        one: 1 day
+        other: "%{count} days"
       x_months:
         one: 1 month
         other: "%{count} months"
       x_years:
         one: 1 year
         other: "%{count} years"
-      x_seconds:
-        one: 1 second
-        other: "%{count} seconds"
     prompts:
-      day: Day
-      hour: Hour
-      minute: Minute
-      month: Month
       second: Seconds
+      minute: Minute
+      hour: Hour
+      day: Day
+      month: Month
       year: Year
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: must be accepted
       blank: can't be blank
-      present: must be blank
       confirmation: doesn't match %{attribute}
       empty: can't be empty
       equal_to: must be equal to %{count}
@@ -123,10 +122,12 @@ en-CY:
       invalid: is invalid
       less_than: must be less than %{count}
       less_than_or_equal_to: must be less than or equal to %{count}
-      model_invalid: "Validation failed: %{errors}"
+      model_invalid: 'Validation failed: %{errors}'
       not_a_number: is not a number
       not_an_integer: must be an integer
       odd: must be odd
+      other_than: must be other than %{count}
+      present: must be blank
       required: must exist
       taken: has already been taken
       too_long:
@@ -138,7 +139,6 @@ en-CY:
       wrong_length:
         one: is the wrong length (should be 1 character)
         other: is the wrong length (should be %{count} characters)
-      other_than: must be other than %{count}
     template:
       body: 'There were problems with the following fields:'
       header:
@@ -188,12 +188,12 @@ en-CY:
           byte:
             one: Byte
             other: Bytes
+          eb: EB
           gb: GB
           kb: KB
           mb: MB
-          tb: TB
           pb: PB
-          eb: EB
+          tb: TB
     percentage:
       format:
         delimiter: ''

--- a/rails/locale/en-GB.yml
+++ b/rails/locale/en-GB.yml
@@ -3,10 +3,10 @@ en-GB:
   activerecord:
     errors:
       messages:
-        record_invalid: "Validation failed: %{errors}"
+        record_invalid: 'Validation failed: %{errors}'
         restrict_dependent_destroy:
-          has_one: "Cannot delete record because a dependent %{record} exists"
-          has_many: "Cannot delete record because dependent %{record} exist"
+          has_one: Cannot delete record because a dependent %{record} exists
+          has_many: Cannot delete record because dependent %{record} exist
   date:
     abbr_day_names:
     - Sun
@@ -17,7 +17,7 @@ en-GB:
     - Fri
     - Sat
     abbr_month_names:
-    -
+    - 
     - Jan
     - Feb
     - Mar
@@ -43,7 +43,7 @@ en-GB:
       long: "%d %B, %Y"
       short: "%d %b"
     month_names:
-    -
+    - 
     - January
     - February
     - March
@@ -75,43 +75,42 @@ en-GB:
         one: almost 1 year
         other: almost %{count} years
       half_a_minute: half a minute
-      less_than_x_minutes:
-        one: less than a minute
-        other: less than %{count} minutes
       less_than_x_seconds:
         one: less than 1 second
         other: less than %{count} seconds
+      less_than_x_minutes:
+        one: less than a minute
+        other: less than %{count} minutes
       over_x_years:
         one: over 1 year
         other: over %{count} years
-      x_days:
-        one: 1 day
-        other: "%{count} days"
+      x_seconds:
+        one: 1 second
+        other: "%{count} seconds"
       x_minutes:
         one: 1 minute
         other: "%{count} minutes"
+      x_days:
+        one: 1 day
+        other: "%{count} days"
       x_months:
         one: 1 month
         other: "%{count} months"
       x_years:
         one: 1 year
         other: "%{count} years"
-      x_seconds:
-        one: 1 second
-        other: "%{count} seconds"
     prompts:
-      day: Day
-      hour: Hour
-      minute: Minute
-      month: Month
       second: Seconds
+      minute: Minute
+      hour: Hour
+      day: Day
+      month: Month
       year: Year
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: must be accepted
       blank: can't be blank
-      present: must be blank
       confirmation: doesn't match %{attribute}
       empty: can't be empty
       equal_to: must be equal to %{count}
@@ -123,10 +122,12 @@ en-GB:
       invalid: is invalid
       less_than: must be less than %{count}
       less_than_or_equal_to: must be less than or equal to %{count}
-      model_invalid: "Validation failed: %{errors}"
+      model_invalid: 'Validation failed: %{errors}'
       not_a_number: is not a number
       not_an_integer: must be an integer
       odd: must be odd
+      other_than: must be other than %{count}
+      present: must be blank
       required: must exist
       taken: has already been taken
       too_long:
@@ -138,7 +139,6 @@ en-GB:
       wrong_length:
         one: is the wrong length (should be 1 character)
         other: is the wrong length (should be %{count} characters)
-      other_than: must be other than %{count}
     template:
       body: 'There were problems with the following fields:'
       header:
@@ -188,12 +188,12 @@ en-GB:
           byte:
             one: Byte
             other: Bytes
+          eb: EB
           gb: GB
           kb: KB
           mb: MB
-          tb: TB
           pb: PB
-          eb: EB
+          tb: TB
     percentage:
       format:
         delimiter: ''

--- a/rails/locale/en-IE.yml
+++ b/rails/locale/en-IE.yml
@@ -3,10 +3,10 @@ en-IE:
   activerecord:
     errors:
       messages:
-        record_invalid: "Validation failed: %{errors}"
+        record_invalid: 'Validation failed: %{errors}'
         restrict_dependent_destroy:
-          has_one: "Cannot delete record because a dependent %{record} exists"
-          has_many: "Cannot delete record because dependent %{record} exist"
+          has_one: Cannot delete record because a dependent %{record} exists
+          has_many: Cannot delete record because dependent %{record} exist
   date:
     abbr_day_names:
     - Sun
@@ -17,7 +17,7 @@ en-IE:
     - Fri
     - Sat
     abbr_month_names:
-    -
+    - 
     - Jan
     - Feb
     - Mar
@@ -43,7 +43,7 @@ en-IE:
       long: "%d %B, %Y"
       short: "%d %b"
     month_names:
-    -
+    - 
     - January
     - February
     - March
@@ -75,43 +75,42 @@ en-IE:
         one: almost 1 year
         other: almost %{count} years
       half_a_minute: half a minute
-      less_than_x_minutes:
-        one: less than a minute
-        other: less than %{count} minutes
       less_than_x_seconds:
         one: less than 1 second
         other: less than %{count} seconds
+      less_than_x_minutes:
+        one: less than a minute
+        other: less than %{count} minutes
       over_x_years:
         one: over 1 year
         other: over %{count} years
-      x_days:
-        one: 1 day
-        other: "%{count} days"
+      x_seconds:
+        one: 1 second
+        other: "%{count} seconds"
       x_minutes:
         one: 1 minute
         other: "%{count} minutes"
+      x_days:
+        one: 1 day
+        other: "%{count} days"
       x_months:
         one: 1 month
         other: "%{count} months"
       x_years:
         one: 1 year
         other: "%{count} years"
-      x_seconds:
-        one: 1 second
-        other: "%{count} seconds"
     prompts:
-      day: Day
-      hour: Hour
-      minute: Minute
-      month: Month
       second: Seconds
+      minute: Minute
+      hour: Hour
+      day: Day
+      month: Month
       year: Year
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: must be accepted
       blank: can't be blank
-      present: must be blank
       confirmation: doesn't match %{attribute}
       empty: can't be empty
       equal_to: must be equal to %{count}
@@ -123,10 +122,12 @@ en-IE:
       invalid: is invalid
       less_than: must be less than %{count}
       less_than_or_equal_to: must be less than or equal to %{count}
-      model_invalid: "Validation failed: %{errors}"
+      model_invalid: 'Validation failed: %{errors}'
       not_a_number: is not a number
       not_an_integer: must be an integer
       odd: must be odd
+      other_than: must be other than %{count}
+      present: must be blank
       required: must exist
       taken: has already been taken
       too_long:
@@ -138,7 +139,6 @@ en-IE:
       wrong_length:
         one: is the wrong length (should be 1 character)
         other: is the wrong length (should be %{count} characters)
-      other_than: must be other than %{count}
     template:
       body: 'There were problems with the following fields:'
       header:
@@ -188,12 +188,12 @@ en-IE:
           byte:
             one: Byte
             other: Bytes
+          eb: EB
           gb: GB
           kb: KB
           mb: MB
-          tb: TB
           pb: PB
-          eb: EB
+          tb: TB
     percentage:
       format:
         delimiter: ''

--- a/rails/locale/en-IN.yml
+++ b/rails/locale/en-IN.yml
@@ -3,10 +3,10 @@ en-IN:
   activerecord:
     errors:
       messages:
-        record_invalid: "Validation failed: %{errors}"
+        record_invalid: 'Validation failed: %{errors}'
         restrict_dependent_destroy:
-          has_one: "Cannot delete record because a dependent %{record} exists"
-          has_many: "Cannot delete record because dependent %{record} exist"
+          has_one: Cannot delete record because a dependent %{record} exists
+          has_many: Cannot delete record because dependent %{record} exist
   date:
     abbr_day_names:
     - Sun
@@ -17,7 +17,7 @@ en-IN:
     - Fri
     - Sat
     abbr_month_names:
-    -
+    - 
     - Jan
     - Feb
     - Mar
@@ -43,7 +43,7 @@ en-IN:
       long: "%B %d, %Y"
       short: "%b %d"
     month_names:
-    -
+    - 
     - January
     - February
     - March
@@ -75,43 +75,42 @@ en-IN:
         one: almost 1 year
         other: almost %{count} years
       half_a_minute: half a minute
-      less_than_x_minutes:
-        one: less than a minute
-        other: less than %{count} minutes
       less_than_x_seconds:
         one: less than 1 second
         other: less than %{count} seconds
+      less_than_x_minutes:
+        one: less than a minute
+        other: less than %{count} minutes
       over_x_years:
         one: over 1 year
         other: over %{count} years
-      x_days:
-        one: 1 day
-        other: "%{count} days"
+      x_seconds:
+        one: 1 second
+        other: "%{count} seconds"
       x_minutes:
         one: 1 minute
         other: "%{count} minutes"
+      x_days:
+        one: 1 day
+        other: "%{count} days"
       x_months:
         one: 1 month
         other: "%{count} months"
       x_years:
         one: 1 year
         other: "%{count} years"
-      x_seconds:
-        one: 1 second
-        other: "%{count} seconds"
     prompts:
-      day: Day
-      hour: Hour
-      minute: Minute
-      month: Month
       second: Seconds
+      minute: Minute
+      hour: Hour
+      day: Day
+      month: Month
       year: Year
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: must be accepted
       blank: can't be blank
-      present: must be blank
       confirmation: doesn't match %{attribute}
       empty: can't be empty
       equal_to: must be equal to %{count}
@@ -123,10 +122,12 @@ en-IN:
       invalid: is invalid
       less_than: must be less than %{count}
       less_than_or_equal_to: must be less than or equal to %{count}
-      model_invalid: "Validation failed: %{errors}"
+      model_invalid: 'Validation failed: %{errors}'
       not_a_number: is not a number
       not_an_integer: must be an integer
       odd: must be odd
+      other_than: must be other than %{count}
+      present: must be blank
       required: must exist
       taken: has already been taken
       too_long:
@@ -138,7 +139,6 @@ en-IN:
       wrong_length:
         one: is the wrong length (should be 1 character)
         other: is the wrong length (should be %{count} characters)
-      other_than: must be other than %{count}
     template:
       body: 'There were problems with the following fields:'
       header:
@@ -188,12 +188,12 @@ en-IN:
           byte:
             one: Byte
             other: Bytes
+          eb: EB
           gb: GB
           kb: KB
           mb: MB
-          tb: TB
           pb: PB
-          eb: EB
+          tb: TB
     percentage:
       format:
         delimiter: ''

--- a/rails/locale/en-NZ.yml
+++ b/rails/locale/en-NZ.yml
@@ -3,10 +3,10 @@ en-NZ:
   activerecord:
     errors:
       messages:
-        record_invalid: "Validation failed: %{errors}"
+        record_invalid: 'Validation failed: %{errors}'
         restrict_dependent_destroy:
-          has_one: "Cannot delete record because a dependent %{record} exists"
-          has_many: "Cannot delete record because dependent %{record} exist"
+          has_one: Cannot delete record because a dependent %{record} exists
+          has_many: Cannot delete record because dependent %{record} exist
   date:
     abbr_day_names:
     - Sun
@@ -17,7 +17,7 @@ en-NZ:
     - Fri
     - Sat
     abbr_month_names:
-    -
+    - 
     - Jan
     - Feb
     - Mar
@@ -43,7 +43,7 @@ en-NZ:
       long: "%d %B, %Y"
       short: "%d %b"
     month_names:
-    -
+    - 
     - January
     - February
     - March
@@ -75,43 +75,42 @@ en-NZ:
         one: almost 1 year
         other: almost %{count} years
       half_a_minute: half a minute
-      less_than_x_minutes:
-        one: less than a minute
-        other: less than %{count} minutes
       less_than_x_seconds:
         one: less than 1 second
         other: less than %{count} seconds
+      less_than_x_minutes:
+        one: less than a minute
+        other: less than %{count} minutes
       over_x_years:
         one: over 1 year
         other: over %{count} years
-      x_days:
-        one: 1 day
-        other: "%{count} days"
+      x_seconds:
+        one: 1 second
+        other: "%{count} seconds"
       x_minutes:
         one: 1 minute
         other: "%{count} minutes"
+      x_days:
+        one: 1 day
+        other: "%{count} days"
       x_months:
         one: 1 month
         other: "%{count} months"
       x_years:
         one: 1 year
         other: "%{count} years"
-      x_seconds:
-        one: 1 second
-        other: "%{count} seconds"
     prompts:
-      day: Day
-      hour: Hour
-      minute: Minute
-      month: Month
       second: Seconds
+      minute: Minute
+      hour: Hour
+      day: Day
+      month: Month
       year: Year
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: must be accepted
       blank: can't be blank
-      present: must be blank
       confirmation: doesn't match %{attribute}
       empty: can't be empty
       equal_to: must be equal to %{count}
@@ -123,10 +122,12 @@ en-NZ:
       invalid: is invalid
       less_than: must be less than %{count}
       less_than_or_equal_to: must be less than or equal to %{count}
-      model_invalid: "Validation failed: %{errors}"
+      model_invalid: 'Validation failed: %{errors}'
       not_a_number: is not a number
       not_an_integer: must be an integer
       odd: must be odd
+      other_than: must be other than %{count}
+      present: must be blank
       required: must exist
       taken: has already been taken
       too_long:
@@ -138,7 +139,6 @@ en-NZ:
       wrong_length:
         one: is the wrong length (should be 1 character)
         other: is the wrong length (should be %{count} characters)
-      other_than: must be other than %{count}
     template:
       body: 'There were problems with the following fields:'
       header:
@@ -188,12 +188,12 @@ en-NZ:
           byte:
             one: Byte
             other: Bytes
+          eb: EB
           gb: GB
           kb: KB
           mb: MB
-          tb: TB
           pb: PB
-          eb: EB
+          tb: TB
     percentage:
       format:
         delimiter: ''

--- a/rails/locale/en-US.yml
+++ b/rails/locale/en-US.yml
@@ -3,10 +3,10 @@ en-US:
   activerecord:
     errors:
       messages:
-        record_invalid: "Validation failed: %{errors}"
+        record_invalid: 'Validation failed: %{errors}'
         restrict_dependent_destroy:
-          has_one: "Cannot delete record because a dependent %{record} exists"
-          has_many: "Cannot delete record because dependent %{record} exist"
+          has_one: Cannot delete record because a dependent %{record} exists
+          has_many: Cannot delete record because dependent %{record} exist
   date:
     abbr_day_names:
     - Sun
@@ -17,7 +17,7 @@ en-US:
     - Fri
     - Sat
     abbr_month_names:
-    -
+    - 
     - Jan
     - Feb
     - Mar
@@ -43,7 +43,7 @@ en-US:
       long: "%B %d, %Y"
       short: "%b %d"
     month_names:
-    -
+    - 
     - January
     - February
     - March
@@ -75,43 +75,42 @@ en-US:
         one: almost 1 year
         other: almost %{count} years
       half_a_minute: half a minute
-      less_than_x_minutes:
-        one: less than a minute
-        other: less than %{count} minutes
       less_than_x_seconds:
         one: less than 1 second
         other: less than %{count} seconds
+      less_than_x_minutes:
+        one: less than a minute
+        other: less than %{count} minutes
       over_x_years:
         one: over 1 year
         other: over %{count} years
-      x_days:
-        one: 1 day
-        other: "%{count} days"
+      x_seconds:
+        one: 1 second
+        other: "%{count} seconds"
       x_minutes:
         one: 1 minute
         other: "%{count} minutes"
+      x_days:
+        one: 1 day
+        other: "%{count} days"
       x_months:
         one: 1 month
         other: "%{count} months"
       x_years:
         one: 1 year
         other: "%{count} years"
-      x_seconds:
-        one: 1 second
-        other: "%{count} seconds"
     prompts:
-      day: Day
-      hour: Hour
-      minute: Minute
-      month: Month
       second: Seconds
+      minute: Minute
+      hour: Hour
+      day: Day
+      month: Month
       year: Year
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: must be accepted
       blank: can't be blank
-      present: must be blank
       confirmation: doesn't match %{attribute}
       empty: can't be empty
       equal_to: must be equal to %{count}
@@ -123,10 +122,12 @@ en-US:
       invalid: is invalid
       less_than: must be less than %{count}
       less_than_or_equal_to: must be less than or equal to %{count}
-      model_invalid: "Validation failed: %{errors}"
+      model_invalid: 'Validation failed: %{errors}'
       not_a_number: is not a number
       not_an_integer: must be an integer
       odd: must be odd
+      other_than: must be other than %{count}
+      present: must be blank
       required: must exist
       taken: has already been taken
       too_long:
@@ -138,7 +139,6 @@ en-US:
       wrong_length:
         one: is the wrong length (should be 1 character)
         other: is the wrong length (should be %{count} characters)
-      other_than: must be other than %{count}
     template:
       body: 'There were problems with the following fields:'
       header:
@@ -188,12 +188,12 @@ en-US:
           byte:
             one: Byte
             other: Bytes
+          eb: EB
           gb: GB
           kb: KB
           mb: MB
-          tb: TB
           pb: PB
-          eb: EB
+          tb: TB
     percentage:
       format:
         delimiter: ''

--- a/rails/locale/en-ZA.yml
+++ b/rails/locale/en-ZA.yml
@@ -3,10 +3,10 @@ en-ZA:
   activerecord:
     errors:
       messages:
-        record_invalid: "Validation failed: %{errors}"
+        record_invalid: 'Validation failed: %{errors}'
         restrict_dependent_destroy:
-          has_one: "Cannot delete record because a dependent %{record} exists"
-          has_many: "Cannot delete record because dependent %{record} exist"
+          has_one: Cannot delete record because a dependent %{record} exists
+          has_many: Cannot delete record because dependent %{record} exist
   date:
     abbr_day_names:
     - Sun
@@ -17,7 +17,7 @@ en-ZA:
     - Fri
     - Sat
     abbr_month_names:
-    -
+    - 
     - Jan
     - Feb
     - Mar
@@ -43,7 +43,7 @@ en-ZA:
       long: "%B %d, %Y"
       short: "%b %d"
     month_names:
-    -
+    - 
     - January
     - February
     - March
@@ -75,43 +75,42 @@ en-ZA:
         one: almost 1 year
         other: almost %{count} years
       half_a_minute: half a minute
-      less_than_x_minutes:
-        one: less than a minute
-        other: less than %{count} minutes
       less_than_x_seconds:
         one: less than 1 second
         other: less than %{count} seconds
+      less_than_x_minutes:
+        one: less than a minute
+        other: less than %{count} minutes
       over_x_years:
         one: over 1 year
         other: over %{count} years
-      x_days:
-        one: 1 day
-        other: "%{count} days"
+      x_seconds:
+        one: 1 second
+        other: "%{count} seconds"
       x_minutes:
         one: 1 minute
         other: "%{count} minutes"
+      x_days:
+        one: 1 day
+        other: "%{count} days"
       x_months:
         one: 1 month
         other: "%{count} months"
       x_years:
         one: 1 year
         other: "%{count} years"
-      x_seconds:
-        one: 1 second
-        other: "%{count} seconds"
     prompts:
-      day: Day
-      hour: Hour
-      minute: Minute
-      month: Month
       second: Seconds
+      minute: Minute
+      hour: Hour
+      day: Day
+      month: Month
       year: Year
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: must be accepted
       blank: can't be blank
-      present: must be blank
       confirmation: doesn't match %{attribute}
       empty: can't be empty
       equal_to: must be equal to %{count}
@@ -123,10 +122,12 @@ en-ZA:
       invalid: is invalid
       less_than: must be less than %{count}
       less_than_or_equal_to: must be less than or equal to %{count}
-      model_invalid: "Validation failed: %{errors}"
+      model_invalid: 'Validation failed: %{errors}'
       not_a_number: is not a number
       not_an_integer: must be an integer
       odd: must be odd
+      other_than: must be other than %{count}
+      present: must be blank
       required: must exist
       taken: has already been taken
       too_long:
@@ -138,7 +139,6 @@ en-ZA:
       wrong_length:
         one: is the wrong length (should be 1 character)
         other: is the wrong length (should be %{count} characters)
-      other_than: must be other than %{count}
     template:
       body: 'There were problems with the following fields:'
       header:
@@ -188,12 +188,12 @@ en-ZA:
           byte:
             one: Byte
             other: Bytes
+          eb: EB
           gb: GB
           kb: KB
           mb: MB
-          tb: TB
           pb: PB
-          eb: EB
+          tb: TB
     percentage:
       format:
         delimiter: ''

--- a/rails/locale/en.yml
+++ b/rails/locale/en.yml
@@ -3,10 +3,10 @@ en:
   activerecord:
     errors:
       messages:
-        record_invalid: "Validation failed: %{errors}"
+        record_invalid: 'Validation failed: %{errors}'
         restrict_dependent_destroy:
-          has_one: "Cannot delete record because a dependent %{record} exists"
-          has_many: "Cannot delete record because dependent %{record} exist"
+          has_one: Cannot delete record because a dependent %{record} exists
+          has_many: Cannot delete record because dependent %{record} exist
   date:
     abbr_day_names:
     - Sun
@@ -17,7 +17,7 @@ en:
     - Fri
     - Sat
     abbr_month_names:
-    -
+    - 
     - Jan
     - Feb
     - Mar
@@ -43,7 +43,7 @@ en:
       long: "%B %d, %Y"
       short: "%b %d"
     month_names:
-    -
+    - 
     - January
     - February
     - March
@@ -75,43 +75,42 @@ en:
         one: almost 1 year
         other: almost %{count} years
       half_a_minute: half a minute
-      less_than_x_minutes:
-        one: less than a minute
-        other: less than %{count} minutes
       less_than_x_seconds:
         one: less than 1 second
         other: less than %{count} seconds
+      less_than_x_minutes:
+        one: less than a minute
+        other: less than %{count} minutes
       over_x_years:
         one: over 1 year
         other: over %{count} years
-      x_days:
-        one: 1 day
-        other: "%{count} days"
+      x_seconds:
+        one: 1 second
+        other: "%{count} seconds"
       x_minutes:
         one: 1 minute
         other: "%{count} minutes"
+      x_days:
+        one: 1 day
+        other: "%{count} days"
       x_months:
         one: 1 month
         other: "%{count} months"
       x_years:
         one: 1 year
         other: "%{count} years"
-      x_seconds:
-        one: 1 second
-        other: "%{count} seconds"
     prompts:
-      day: Day
-      hour: Hour
-      minute: Minute
-      month: Month
       second: Seconds
+      minute: Minute
+      hour: Hour
+      day: Day
+      month: Month
       year: Year
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: must be accepted
       blank: can't be blank
-      present: must be blank
       confirmation: doesn't match %{attribute}
       empty: can't be empty
       equal_to: must be equal to %{count}
@@ -123,10 +122,12 @@ en:
       invalid: is invalid
       less_than: must be less than %{count}
       less_than_or_equal_to: must be less than or equal to %{count}
-      model_invalid: "Validation failed: %{errors}"
+      model_invalid: 'Validation failed: %{errors}'
       not_a_number: is not a number
       not_an_integer: must be an integer
       odd: must be odd
+      other_than: must be other than %{count}
+      present: must be blank
       required: must exist
       taken: has already been taken
       too_long:
@@ -138,7 +139,6 @@ en:
       wrong_length:
         one: is the wrong length (should be 1 character)
         other: is the wrong length (should be %{count} characters)
-      other_than: must be other than %{count}
     template:
       body: 'There were problems with the following fields:'
       header:
@@ -188,12 +188,12 @@ en:
           byte:
             one: Byte
             other: Bytes
+          eb: EB
           gb: GB
           kb: KB
           mb: MB
-          tb: TB
           pb: PB
-          eb: EB
+          tb: TB
     percentage:
       format:
         delimiter: ''

--- a/rails/locale/eo.yml
+++ b/rails/locale/eo.yml
@@ -14,7 +14,7 @@ eo:
     - ven
     - sab
     abbr_month_names:
-    -
+    - 
     - jan.
     - feb.
     - mar.
@@ -40,7 +40,7 @@ eo:
       long: "%e %B %Y"
       short: "%e %b"
     month_names:
-    -
+    - 
     - januaro
     - februaro
     - marto
@@ -72,35 +72,35 @@ eo:
         one: preskaŭ unu jaro
         other: preskaŭ %{count} jaroj
       half_a_minute: duona minuto
-      less_than_x_minutes:
-        one: malpli ol unu minuto
-        other: malpli ol %{count} minutoj
-        zero: malpli ol unu minuto
       less_than_x_seconds:
+        zero: malpli ol unu sekundo
         one: malpli ol unu sekundo
         other: malpli ol %{count} sekundoj
-        zero: malpli ol unu sekundo
+      less_than_x_minutes:
+        zero: malpli ol unu minuto
+        one: malpli ol unu minuto
+        other: malpli ol %{count} minutoj
       over_x_years:
         one: pli ol unu jaro
         other: pli ol %{count} jaroj
-      x_days:
-        one: 1 tago
-        other: "%{count} tagoj"
-      x_minutes:
-        one: 1 minuto
-        other: "%{count} minutoj"
-      x_months:
-        one: 1 monato
-        other: "%{count} monatoj"
       x_seconds:
         one: 1 sekundo
         other: "%{count} sekundoj"
+      x_minutes:
+        one: 1 minuto
+        other: "%{count} minutoj"
+      x_days:
+        one: 1 tago
+        other: "%{count} tagoj"
+      x_months:
+        one: 1 monato
+        other: "%{count} monatoj"
     prompts:
-      day: Tago
-      hour: Horo
-      minute: Minuto
-      month: Monato
       second: Sekundo
+      minute: Minuto
+      hour: Horo
+      day: Tago
+      month: Monato
       year: Jaro
   errors:
     format: "%{attribute} %{message}"

--- a/rails/locale/es-419.yml
+++ b/rails/locale/es-419.yml
@@ -3,9 +3,10 @@ es-419:
   activerecord:
     errors:
       messages:
-        record_invalid: "La validación falló: %{errors}"
+        record_invalid: 'La validación falló: %{errors}'
         restrict_dependent_destroy:
-          has_one: No se puede eliminar el registro porque existe un(a) %{record} dependiente
+          has_one: No se puede eliminar el registro porque existe un(a) %{record}
+            dependiente
           has_many: No se puede eliminar el registro porque existen %{record} dependientes
   date:
     abbr_day_names:
@@ -17,7 +18,7 @@ es-419:
     - vie
     - sáb
     abbr_month_names:
-    -
+    - 
     - ene
     - feb
     - mar
@@ -43,7 +44,7 @@ es-419:
       long: "%A, %d de %B de %Y"
       short: "%d de %b"
     month_names:
-    -
+    - 
     - enero
     - febrero
     - marzo
@@ -75,43 +76,42 @@ es-419:
         one: casi 1 año
         other: casi %{count} años
       half_a_minute: medio minuto
-      less_than_x_minutes:
-        one: menos de 1 minuto
-        other: menos de %{count} minutos
       less_than_x_seconds:
         one: menos de 1 segundo
         other: menos de %{count} segundos
+      less_than_x_minutes:
+        one: menos de 1 minuto
+        other: menos de %{count} minutos
       over_x_years:
         one: más de 1 año
         other: más de %{count} años
-      x_days:
-        one: 1 día
-        other: "%{count} días"
+      x_seconds:
+        one: 1 segundo
+        other: "%{count} segundos"
       x_minutes:
         one: 1 minuto
         other: "%{count} minutos"
+      x_days:
+        one: 1 día
+        other: "%{count} días"
       x_months:
         one: 1 mes
         other: "%{count} meses"
       x_years:
         one: 1 año
         other: "%{count} años"
-      x_seconds:
-        one: 1 segundo
-        other: "%{count} segundos"
     prompts:
-      day: Día
-      hour: Hora
-      minute: Minuto
-      month: Mes
       second: Segundos
+      minute: Minuto
+      hour: Hora
+      day: Día
+      month: Mes
       year: Año
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: debe ser aceptado
       blank: no puede estar en blanco
-      present: debe estar en blanco
       confirmation: no coincide
       empty: no puede estar vacío
       equal_to: debe ser igual a %{count}
@@ -123,10 +123,12 @@ es-419:
       invalid: es inválido
       less_than: debe ser menor que %{count}
       less_than_or_equal_to: debe ser menor o igual que %{count}
-      model_invalid: "La validación falló: %{errors}"
+      model_invalid: 'La validación falló: %{errors}'
       not_a_number: no es un número
       not_an_integer: debe ser un entero
       odd: debe ser un número non
+      other_than: debe ser diferente de %{count}
+      present: debe estar en blanco
       required: debe existir
       taken: ya ha sido tomado
       too_long:
@@ -138,7 +140,6 @@ es-419:
       wrong_length:
         one: longitud errónea (debe ser de 1 caracter)
         other: longitud errónea (debe ser de %{count} caracteres)
-      other_than: debe ser diferente de %{count}
     template:
       body: 'Revise que los siguientes campos sean válidos:'
       header:
@@ -192,12 +193,12 @@ es-419:
           byte:
             one: Byte
             other: Bytes
+          eb: EB
           gb: GB
           kb: KB
           mb: MB
-          tb: TB
           pb: PB
-          eb: EB
+          tb: TB
     percentage:
       format:
         delimiter: ","

--- a/rails/locale/es-AR.yml
+++ b/rails/locale/es-AR.yml
@@ -3,7 +3,7 @@ es-AR:
   activerecord:
     errors:
       messages:
-        record_invalid: "La validación falló: %{errors}"
+        record_invalid: 'La validación falló: %{errors}'
         restrict_dependent_destroy:
           has_one: No se puede eliminar el registro porque existe un %{record} dependiente
           has_many: No se puede eliminar el registro porque existen %{record} dependientes
@@ -17,7 +17,7 @@ es-AR:
     - vie
     - sáb
     abbr_month_names:
-    -
+    - 
     - ene
     - feb
     - mar
@@ -43,7 +43,7 @@ es-AR:
       long: "%A, %d de %B de %Y"
       short: "%d de %b"
     month_names:
-    -
+    - 
     - enero
     - febrero
     - marzo
@@ -75,43 +75,42 @@ es-AR:
         one: casi 1 año
         other: casi %{count} años
       half_a_minute: medio minuto
-      less_than_x_minutes:
-        one: menos de 1 minuto
-        other: menos de %{count} minutos
       less_than_x_seconds:
         one: menos de 1 segundo
         other: menos de %{count} segundos
+      less_than_x_minutes:
+        one: menos de 1 minuto
+        other: menos de %{count} minutos
       over_x_years:
         one: más de 1 año
         other: más de %{count} años
-      x_days:
-        one: 1 día
-        other: "%{count} días"
+      x_seconds:
+        one: 1 segundo
+        other: "%{count} segundos"
       x_minutes:
         one: 1 minuto
         other: "%{count} minutos"
+      x_days:
+        one: 1 día
+        other: "%{count} días"
       x_months:
         one: 1 mes
         other: "%{count} meses"
       x_years:
         one: 1 año
         other: "%{count} años"
-      x_seconds:
-        one: 1 segundo
-        other: "%{count} segundos"
     prompts:
-      day: Día
-      hour: Hora
-      minute: Minuto
-      month: Mes
       second: Segundos
+      minute: Minuto
+      hour: Hora
+      day: Día
+      month: Mes
       year: Año
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: debe ser aceptado
       blank: no puede estar en blanco
-      present: debe estar en blanco
       confirmation: no coincide
       empty: no puede estar vacío
       equal_to: debe ser igual a %{count}
@@ -123,10 +122,12 @@ es-AR:
       invalid: es inválido
       less_than: debe ser menor que %{count}
       less_than_or_equal_to: debe ser menor o igual que %{count}
-      model_invalid: "La validación falló: %{errors}"
+      model_invalid: 'La validación falló: %{errors}'
       not_a_number: no es un número
       not_an_integer: debe ser un entero
       odd: debe ser un número non
+      other_than: debe ser distinto de %{count}
+      present: debe estar en blanco
       required: debe existir
       taken: ya ha sido tomado
       too_long:
@@ -138,7 +139,6 @@ es-AR:
       wrong_length:
         one: longitud errónea (debe ser de 1 caracter)
         other: longitud errónea (debe ser de %{count} caracteres)
-      other_than: debe ser distinto de %{count}
     template:
       body: 'Revise que los siguientes campos sean válidos:'
       header:
@@ -192,12 +192,12 @@ es-AR:
           byte:
             one: Byte
             other: Bytes
+          eb: EB
           gb: GB
           kb: KB
           mb: MB
-          tb: TB
           pb: PB
-          eb: EB
+          tb: TB
     percentage:
       format:
         delimiter: ","

--- a/rails/locale/es-CL.yml
+++ b/rails/locale/es-CL.yml
@@ -3,7 +3,7 @@ es-CL:
   activerecord:
     errors:
       messages:
-        record_invalid: "La validación falló: %{errors}"
+        record_invalid: 'La validación falló: %{errors}'
         restrict_dependent_destroy:
           has_one: No se puede eliminar el registro porque existe un %{record} dependiente
           has_many: No se puede eliminar el registro porque existen %{record} dependientes
@@ -17,7 +17,7 @@ es-CL:
     - vie
     - sáb
     abbr_month_names:
-    -
+    - 
     - ene
     - feb
     - mar
@@ -43,7 +43,7 @@ es-CL:
       long: "%A %d de %B de %Y"
       short: "%d de %b"
     month_names:
-    -
+    - 
     - enero
     - febrero
     - marzo
@@ -75,43 +75,42 @@ es-CL:
         one: casi 1 año
         other: casi %{count} años
       half_a_minute: medio minuto
-      less_than_x_minutes:
-        one: menos de 1 minuto
-        other: menos de %{count} minutos
       less_than_x_seconds:
         one: menos de 1 segundo
         other: menos de %{count} segundos
+      less_than_x_minutes:
+        one: menos de 1 minuto
+        other: menos de %{count} minutos
       over_x_years:
         one: más de 1 año
         other: más de %{count} años
-      x_days:
-        one: 1 día
-        other: "%{count} días"
+      x_seconds:
+        one: 1 segundo
+        other: "%{count} segundos"
       x_minutes:
         one: 1 minuto
         other: "%{count} minutos"
+      x_days:
+        one: 1 día
+        other: "%{count} días"
       x_months:
         one: 1 mes
         other: "%{count} meses"
       x_years:
         one: 1 año
         other: "%{count} años"
-      x_seconds:
-        one: 1 segundo
-        other: "%{count} segundos"
     prompts:
-      day: Día
-      hour: Hora
-      minute: Minutos
-      month: Mes
       second: Segundos
+      minute: Minutos
+      hour: Hora
+      day: Día
+      month: Mes
       year: Año
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: debe ser aceptado
       blank: no puede estar en blanco
-      present: debe estar en blanco
       confirmation: no coincide
       empty: no puede estar vacío
       equal_to: debe ser igual a %{count}
@@ -123,10 +122,12 @@ es-CL:
       invalid: no es válido
       less_than: debe ser menor que %{count}
       less_than_or_equal_to: debe ser menor que o igual a %{count}
-      model_invalid: "La validación falló: %{errors}"
+      model_invalid: 'La validación falló: %{errors}'
       not_a_number: no es un número
       not_an_integer: debe ser un entero
       odd: debe ser impar
+      other_than: debe ser distinto de %{count}
+      present: debe estar en blanco
       required: debe existir
       taken: ya está en uso
       too_long:
@@ -138,7 +139,6 @@ es-CL:
       wrong_length:
         one: no tiene la longitud correcta (1 caracter exacto)
         other: no tiene la longitud correcta (%{count} caracteres exactos)
-      other_than: debe ser distinto de %{count}
     template:
       body: 'Se encontraron problemas con los siguientes campos:'
       header:
@@ -192,12 +192,12 @@ es-CL:
           byte:
             one: Byte
             other: Bytes
+          eb: EB
           gb: GB
           kb: KB
           mb: MB
-          tb: TB
           pb: PB
-          eb: EB
+          tb: TB
     percentage:
       format:
         delimiter: ''

--- a/rails/locale/es-CO.yml
+++ b/rails/locale/es-CO.yml
@@ -3,7 +3,7 @@ es-CO:
   activerecord:
     errors:
       messages:
-        record_invalid: "La validación falló: %{errors}"
+        record_invalid: 'La validación falló: %{errors}'
         restrict_dependent_destroy:
           has_one: No se puede eliminar el registro porque existe un %{record} dependiente
           has_many: No se puede eliminar el registro porque existen %{record} dependientes
@@ -17,7 +17,7 @@ es-CO:
     - vie
     - sáb
     abbr_month_names:
-    -
+    - 
     - ene
     - feb
     - mar
@@ -43,7 +43,7 @@ es-CO:
       long: "%A, %d de %B de %Y"
       short: "%d de %b"
     month_names:
-    -
+    - 
     - enero
     - febrero
     - marzo
@@ -75,43 +75,42 @@ es-CO:
         one: casi 1 año
         other: casi %{count} años
       half_a_minute: medio minuto
-      less_than_x_minutes:
-        one: menos de 1 minuto
-        other: menos de %{count} minutos
       less_than_x_seconds:
         one: menos de 1 segundo
         other: menos de %{count} segundos
+      less_than_x_minutes:
+        one: menos de 1 minuto
+        other: menos de %{count} minutos
       over_x_years:
         one: más de 1 año
         other: más de %{count} años
-      x_days:
-        one: 1 día
-        other: "%{count} días"
+      x_seconds:
+        one: 1 segundo
+        other: "%{count} segundos"
       x_minutes:
         one: 1 minuto
         other: "%{count} minutos"
+      x_days:
+        one: 1 día
+        other: "%{count} días"
       x_months:
         one: 1 mes
         other: "%{count} meses"
       x_years:
         one: 1 año
         other: "%{count} años"
-      x_seconds:
-        one: 1 segundo
-        other: "%{count} segundos"
     prompts:
-      day: Día
-      hour: Hora
-      minute: Minuto
-      month: Mes
       second: Segundos
+      minute: Minuto
+      hour: Hora
+      day: Día
+      month: Mes
       year: Año
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: debe ser aceptado
       blank: no puede estar en blanco
-      present: debe estar en blanco
       confirmation: no coincide
       empty: no puede estar vacío
       equal_to: debe ser igual a %{count}
@@ -123,10 +122,12 @@ es-CO:
       invalid: es inválido
       less_than: debe ser menor que %{count}
       less_than_or_equal_to: debe ser menor o igual que %{count}
-      model_invalid: "La validación falló: %{errors}"
+      model_invalid: 'La validación falló: %{errors}'
       not_a_number: no es un número
       not_an_integer: debe ser un entero
       odd: debe ser un número impar
+      other_than: debe ser distinto de %{count}
+      present: debe estar en blanco
       required: debe existir
       taken: ya ha sido tomado
       too_long:
@@ -138,7 +139,6 @@ es-CO:
       wrong_length:
         one: longitud errónea (debe ser de 1 caracter)
         other: longitud errónea (debe ser de %{count} caracteres)
-      other_than: debe ser distinto de %{count}
     template:
       body: 'Revise que los siguientes campos sean válidos:'
       header:
@@ -192,12 +192,12 @@ es-CO:
           byte:
             one: Byte
             other: Bytes
+          eb: EB
           gb: GB
           kb: KB
           mb: MB
-          tb: TB
           pb: PB
-          eb: EB
+          tb: TB
     percentage:
       format:
         delimiter: ","

--- a/rails/locale/es-CR.yml
+++ b/rails/locale/es-CR.yml
@@ -3,7 +3,7 @@ es-CR:
   activerecord:
     errors:
       messages:
-        record_invalid: "La validación falló: %{errors}"
+        record_invalid: 'La validación falló: %{errors}'
         restrict_dependent_destroy:
           has_one: No se puede eliminar el registro porque existe un %{record} dependiente
           has_many: No se puede eliminar el registro porque existen %{record} dependientes
@@ -17,7 +17,7 @@ es-CR:
     - vie
     - sáb
     abbr_month_names:
-    -
+    - 
     - ene
     - feb
     - mar
@@ -43,7 +43,7 @@ es-CR:
       long: "%A, %d de %B de %Y"
       short: "%d de %b"
     month_names:
-    -
+    - 
     - enero
     - febrero
     - marzo
@@ -75,43 +75,42 @@ es-CR:
         one: casi 1 año
         other: casi %{count} años
       half_a_minute: medio minuto
-      less_than_x_minutes:
-        one: menos de 1 minuto
-        other: menos de %{count} minutos
       less_than_x_seconds:
         one: menos de 1 segundo
         other: menos de %{count} segundos
+      less_than_x_minutes:
+        one: menos de 1 minuto
+        other: menos de %{count} minutos
       over_x_years:
         one: más de 1 año
         other: más de %{count} años
-      x_days:
-        one: 1 día
-        other: "%{count} días"
+      x_seconds:
+        one: 1 segundo
+        other: "%{count} segundos"
       x_minutes:
         one: 1 minuto
         other: "%{count} minutos"
+      x_days:
+        one: 1 día
+        other: "%{count} días"
       x_months:
         one: 1 mes
         other: "%{count} meses"
       x_years:
         one: 1 año
         other: "%{count} años"
-      x_seconds:
-        one: 1 segundo
-        other: "%{count} segundos"
     prompts:
-      day: Día
-      hour: Hora
-      minute: Minuto
-      month: Mes
       second: Segundos
+      minute: Minuto
+      hour: Hora
+      day: Día
+      month: Mes
       year: Año
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: debe ser aceptado
       blank: no puede estar en blanco
-      present: debe estar en blanco
       confirmation: no coincide
       empty: no puede estar vacío
       equal_to: debe ser igual a %{count}
@@ -123,10 +122,12 @@ es-CR:
       invalid: es inválido
       less_than: debe ser menor que %{count}
       less_than_or_equal_to: debe ser menor o igual que %{count}
-      model_invalid: "La validación falló: %{errors}"
+      model_invalid: 'La validación falló: %{errors}'
       not_a_number: no es un número
       not_an_integer: debe ser un entero
       odd: debe ser un número impar
+      other_than: debe ser distinto de %{count}
+      present: debe estar en blanco
       required: debe existir
       taken: ya ha sido utilizado
       too_long:
@@ -138,7 +139,6 @@ es-CR:
       wrong_length:
         one: longitud errónea (debe ser de 1 caracter)
         other: longitud errónea (debe ser de %{count} caracteres)
-      other_than: debe ser distinto de %{count}
     template:
       body: 'Revise que los siguientes campos sean válidos:'
       header:
@@ -192,12 +192,12 @@ es-CR:
           byte:
             one: Byte
             other: Bytes
+          eb: EB
           gb: GB
           kb: KB
           mb: MB
-          tb: TB
           pb: PB
-          eb: EB
+          tb: TB
     percentage:
       format:
         delimiter: ","

--- a/rails/locale/es-EC.yml
+++ b/rails/locale/es-EC.yml
@@ -3,9 +3,10 @@ es-EC:
   activerecord:
     errors:
       messages:
-        record_invalid: "La validación falló: %{errors}"
+        record_invalid: 'La validación falló: %{errors}'
         restrict_dependent_destroy:
-          has_one: No se puede eliminar el registro porque existe un(a) %{record} dependiente
+          has_one: No se puede eliminar el registro porque existe un(a) %{record}
+            dependiente
           has_many: No se puede eliminar el registro porque existen %{record} dependientes
   date:
     abbr_day_names:
@@ -17,7 +18,7 @@ es-EC:
     - vie
     - sáb
     abbr_month_names:
-    -
+    - 
     - ene
     - feb
     - mar
@@ -43,7 +44,7 @@ es-EC:
       long: "%A, %-d de %B de %Y"
       short: "%-d de %b"
     month_names:
-    -
+    - 
     - enero
     - febrero
     - marzo
@@ -75,43 +76,42 @@ es-EC:
         one: casi 1 año
         other: casi %{count} años
       half_a_minute: medio minuto
-      less_than_x_minutes:
-        one: menos de 1 minuto
-        other: menos de %{count} minutos
       less_than_x_seconds:
         one: menos de 1 segundo
         other: menos de %{count} segundos
+      less_than_x_minutes:
+        one: menos de 1 minuto
+        other: menos de %{count} minutos
       over_x_years:
         one: más de 1 año
         other: más de %{count} años
-      x_days:
-        one: 1 día
-        other: "%{count} días"
+      x_seconds:
+        one: 1 segundo
+        other: "%{count} segundos"
       x_minutes:
         one: 1 minuto
         other: "%{count} minutos"
+      x_days:
+        one: 1 día
+        other: "%{count} días"
       x_months:
         one: 1 mes
         other: "%{count} meses"
       x_years:
         one: 1 año
         other: "%{count} años"
-      x_seconds:
-        one: 1 segundo
-        other: "%{count} segundos"
     prompts:
-      day: Día
-      hour: Hora
-      minute: Minuto
-      month: Mes
       second: Segundos
+      minute: Minuto
+      hour: Hora
+      day: Día
+      month: Mes
       year: Año
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: debe ser aceptado
       blank: no puede estar en blanco
-      present: debe estar en blanco
       confirmation: no coincide
       empty: no puede estar vacío
       equal_to: debe ser igual a %{count}
@@ -123,10 +123,12 @@ es-EC:
       invalid: no es válido
       less_than: debe ser menor que %{count}
       less_than_or_equal_to: debe ser menor que o igual a %{count}
-      model_invalid: "La validación falló: %{errors}"
+      model_invalid: 'La validación falló: %{errors}'
       not_a_number: no es un número
       not_an_integer: debe ser un entero
       odd: debe ser un número impar
+      other_than: debe ser diferente de %{count}
+      present: debe estar en blanco
       required: debe existir
       taken: ya está en uso
       too_long:
@@ -138,7 +140,6 @@ es-EC:
       wrong_length:
         one: no tiene la longitud correcta (debe ser de 1 caracter)
         other: no tiene la longitud correcta (debe ser de %{count} caracteres)
-      other_than: debe ser diferente de %{count}
     template:
       body: 'Revise que los siguientes campos sean válidos:'
       header:
@@ -192,12 +193,12 @@ es-EC:
           byte:
             one: Byte
             other: Bytes
+          eb: EB
           gb: GB
           kb: KB
           mb: MB
-          tb: TB
           pb: PB
-          eb: EB
+          tb: TB
     percentage:
       format:
         delimiter: ''

--- a/rails/locale/es-ES.yml
+++ b/rails/locale/es-ES.yml
@@ -3,7 +3,7 @@ es-ES:
   activerecord:
     errors:
       messages:
-        record_invalid: "La validación falló: %{errors}"
+        record_invalid: 'La validación falló: %{errors}'
         restrict_dependent_destroy:
           has_one: No se puede eliminar el registro porque existe un %{record} dependiente
           has_many: No se puede eliminar el registro porque existen %{record} dependientes
@@ -17,7 +17,7 @@ es-ES:
     - vie
     - sáb
     abbr_month_names:
-    -
+    - 
     - ene
     - feb
     - mar
@@ -43,7 +43,7 @@ es-ES:
       long: "%d de %B de %Y"
       short: "%d de %b"
     month_names:
-    -
+    - 
     - enero
     - febrero
     - marzo
@@ -75,43 +75,42 @@ es-ES:
         one: casi 1 año
         other: casi %{count} años
       half_a_minute: medio minuto
-      less_than_x_minutes:
-        one: menos de 1 minuto
-        other: menos de %{count} minutos
       less_than_x_seconds:
         one: menos de 1 segundo
         other: menos de %{count} segundos
+      less_than_x_minutes:
+        one: menos de 1 minuto
+        other: menos de %{count} minutos
       over_x_years:
         one: más de 1 año
         other: más de %{count} años
-      x_days:
-        one: 1 día
-        other: "%{count} días"
+      x_seconds:
+        one: 1 segundo
+        other: "%{count} segundos"
       x_minutes:
         one: 1 minuto
         other: "%{count} minutos"
+      x_days:
+        one: 1 día
+        other: "%{count} días"
       x_months:
         one: 1 mes
         other: "%{count} meses"
       x_years:
         one: 1 año
         other: "%{count} años"
-      x_seconds:
-        one: 1 segundo
-        other: "%{count} segundos"
     prompts:
-      day: Día
-      hour: Hora
-      minute: Minutos
-      month: Mes
       second: Segundos
+      minute: Minutos
+      hour: Hora
+      day: Día
+      month: Mes
       year: Año
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: debe ser aceptado
       blank: no puede estar en blanco
-      present: debe estar en blanco
       confirmation: no coincide
       empty: no puede estar vacío
       equal_to: debe ser igual a %{count}
@@ -123,22 +122,23 @@ es-ES:
       invalid: no es válido
       less_than: debe ser menor que %{count}
       less_than_or_equal_to: debe ser menor que o igual a %{count}
-      model_invalid: "La validación falló: %{errors}"
+      model_invalid: 'La validación falló: %{errors}'
       not_a_number: no es un número
       not_an_integer: debe ser un entero
       odd: debe ser impar
+      other_than: debe ser distinto de %{count}
+      present: debe estar en blanco
       required: debe existir
       taken: ya está en uso
       too_long:
-        one: "es demasiado largo (1 carácter máximo)"
-        other: "es demasiado largo (%{count} caracteres máximo)"
+        one: es demasiado largo (1 carácter máximo)
+        other: es demasiado largo (%{count} caracteres máximo)
       too_short:
-        one: "es demasiado corto (1 carácter mínimo)"
-        other: "es demasiado corto (%{count} caracteres mínimo)"
+        one: es demasiado corto (1 carácter mínimo)
+        other: es demasiado corto (%{count} caracteres mínimo)
       wrong_length:
-        one: "no tiene la longitud correcta (1 carácter exactos)"
-        other: "no tiene la longitud correcta (%{count} caracteres exactos)"
-      other_than: debe ser distinto de %{count}
+        one: no tiene la longitud correcta (1 carácter exactos)
+        other: no tiene la longitud correcta (%{count} caracteres exactos)
     template:
       body: 'Se encontraron problemas con los siguientes campos:'
       header:
@@ -192,12 +192,12 @@ es-ES:
           byte:
             one: Byte
             other: Bytes
+          eb: EB
           gb: GB
           kb: KB
           mb: MB
-          tb: TB
           pb: PB
-          eb: EB
+          tb: TB
     percentage:
       format:
         delimiter: ''

--- a/rails/locale/es-MX.yml
+++ b/rails/locale/es-MX.yml
@@ -3,7 +3,7 @@ es-MX:
   activerecord:
     errors:
       messages:
-        record_invalid: "La validación falló: %{errors}"
+        record_invalid: 'La validación falló: %{errors}'
         restrict_dependent_destroy:
           has_one: El registro no puede ser eliminado pues existe un %{record} dependiente
           has_many: El registro no puede ser eliminado pues existen %{record} dependientes
@@ -17,7 +17,7 @@ es-MX:
     - vie
     - sáb
     abbr_month_names:
-    -
+    - 
     - ene
     - feb
     - mar
@@ -43,7 +43,7 @@ es-MX:
       long: "%A, %d de %B de %Y"
       short: "%d de %b"
     month_names:
-    -
+    - 
     - enero
     - febrero
     - marzo
@@ -75,43 +75,42 @@ es-MX:
         one: casi 1 año
         other: casi %{count} años
       half_a_minute: medio minuto
-      less_than_x_minutes:
-        one: menos de 1 minuto
-        other: menos de %{count} minutos
       less_than_x_seconds:
         one: menos de 1 segundo
         other: menos de %{count} segundos
+      less_than_x_minutes:
+        one: menos de 1 minuto
+        other: menos de %{count} minutos
       over_x_years:
         one: más de 1 año
         other: más de %{count} años
-      x_days:
-        one: 1 día
-        other: "%{count} días"
+      x_seconds:
+        one: 1 segundo
+        other: "%{count} segundos"
       x_minutes:
         one: 1 minuto
         other: "%{count} minutos"
+      x_days:
+        one: 1 día
+        other: "%{count} días"
       x_months:
         one: 1 mes
         other: "%{count} meses"
       x_years:
         one: 1 año
         other: "%{count} años"
-      x_seconds:
-        one: 1 segundo
-        other: "%{count} segundos"
     prompts:
-      day: Día
-      hour: Hora
-      minute: Minuto
-      month: Mes
       second: Segundos
+      minute: Minuto
+      hour: Hora
+      day: Día
+      month: Mes
       year: Año
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: debe ser aceptado
       blank: no puede estar en blanco
-      present: debe estar en blanco
       confirmation: no coincide
       empty: no puede estar vacío
       equal_to: debe ser igual a %{count}
@@ -123,10 +122,12 @@ es-MX:
       invalid: es inválido
       less_than: debe ser menor que %{count}
       less_than_or_equal_to: debe ser menor o igual que %{count}
-      model_invalid: "La validación falló: %{errors}"
+      model_invalid: 'La validación falló: %{errors}'
       not_a_number: no es un número
       not_an_integer: debe ser un entero
       odd: debe ser un número non
+      other_than: debe ser diferente a %{count}
+      present: debe estar en blanco
       required: debe existir
       taken: ya ha sido tomado
       too_long:
@@ -138,7 +139,6 @@ es-MX:
       wrong_length:
         one: longitud errónea (debe ser de 1 caracter)
         other: longitud errónea (debe ser de %{count} caracteres)
-      other_than: debe ser diferente a %{count}
     template:
       body: 'Revise que los siguientes campos sean válidos:'
       header:
@@ -192,12 +192,12 @@ es-MX:
           byte:
             one: Byte
             other: Bytes
+          eb: EB
           gb: GB
           kb: KB
           mb: MB
-          tb: TB
           pb: PB
-          eb: EB
+          tb: TB
     percentage:
       format:
         delimiter: ","

--- a/rails/locale/es-NI.yml
+++ b/rails/locale/es-NI.yml
@@ -3,7 +3,7 @@ es-NI:
   activerecord:
     errors:
       messages:
-        record_invalid: "La validación falló: %{errors}"
+        record_invalid: 'La validación falló: %{errors}'
         restrict_dependent_destroy:
           has_one: No se puede eliminar el registro porque existe un %{record} dependiente
           has_many: No se puede eliminar el registro porque existen %{record} dependientes
@@ -17,7 +17,7 @@ es-NI:
     - vie
     - sáb
     abbr_month_names:
-    -
+    - 
     - ene
     - feb
     - mar
@@ -43,7 +43,7 @@ es-NI:
       long: "%A, %d de %B de %Y"
       short: "%d de %b"
     month_names:
-    -
+    - 
     - enero
     - febrero
     - marzo
@@ -75,43 +75,42 @@ es-NI:
         one: casi 1 año
         other: casi %{count} años
       half_a_minute: medio minuto
-      less_than_x_minutes:
-        one: menos de 1 minuto
-        other: menos de %{count} minutos
       less_than_x_seconds:
         one: menos de 1 segundo
         other: menos de %{count} segundos
+      less_than_x_minutes:
+        one: menos de 1 minuto
+        other: menos de %{count} minutos
       over_x_years:
         one: más de 1 año
         other: más de %{count} años
-      x_days:
-        one: 1 día
-        other: "%{count} días"
+      x_seconds:
+        one: 1 segundo
+        other: "%{count} segundos"
       x_minutes:
         one: 1 minuto
         other: "%{count} minutos"
+      x_days:
+        one: 1 día
+        other: "%{count} días"
       x_months:
         one: 1 mes
         other: "%{count} meses"
       x_years:
         one: 1 año
         other: "%{count} años"
-      x_seconds:
-        one: 1 segundo
-        other: "%{count} segundos"
     prompts:
-      day: Día
-      hour: Hora
-      minute: Minuto
-      month: Mes
       second: Segundo
+      minute: Minuto
+      hour: Hora
+      day: Día
+      month: Mes
       year: Año
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: debe ser aceptado
       blank: no puede estar en blanco
-      present: debe estar en blanco
       confirmation: no coincide
       empty: no puede estar vacío
       equal_to: debe ser igual a %{count}
@@ -123,10 +122,12 @@ es-NI:
       invalid: es inválido
       less_than: debe ser menor que %{count}
       less_than_or_equal_to: debe ser menor o igual que %{count}
-      model_invalid: "La validación falló: %{errors}"
+      model_invalid: 'La validación falló: %{errors}'
       not_a_number: no es un número
       not_an_integer: debe ser un entero
       odd: debe ser un número impar
+      other_than: debe ser distinto de %{count}
+      present: debe estar en blanco
       required: debe existir
       taken: ya ha sido utilizado
       too_long:
@@ -138,9 +139,8 @@ es-NI:
       wrong_length:
         one: longitud errónea (debe ser de 1 caracter)
         other: longitud errónea (debe ser de %{count} caracteres)
-      other_than: debe ser distinto de %{count}
     template:
-      body: "Revise que los siguientes campos sean válidos:"
+      body: 'Revise que los siguientes campos sean válidos:'
       header:
         one: "%{model} no pudo guardarse debido a 1 error"
         other: "%{model} no pudo guardarse debido a %{count} errores"
@@ -160,7 +160,7 @@ es-NI:
         separator: "."
         significant: false
         strip_insignificant_zeros: false
-        unit: "C$"
+        unit: C$
     format:
       delimiter: ","
       precision: 2
@@ -180,7 +180,7 @@ es-NI:
           trillion:
             one: billón
             other: billones
-          unit: ""
+          unit: ''
       format:
         delimiter: ","
         precision: 3
@@ -192,12 +192,12 @@ es-NI:
           byte:
             one: Byte
             other: Bytes
+          eb: EB
           gb: GB
           kb: KB
           mb: MB
-          tb: TB
           pb: PB
-          eb: EB
+          tb: TB
     percentage:
       format:
         delimiter: ","

--- a/rails/locale/es-PA.yml
+++ b/rails/locale/es-PA.yml
@@ -3,9 +3,10 @@ es-PA:
   activerecord:
     errors:
       messages:
-        record_invalid: "La validación falló: %{errors}"
+        record_invalid: 'La validación falló: %{errors}'
         restrict_dependent_destroy:
-          has_one: No se puede eliminar el registro porque existe un(a) %{record} dependiente
+          has_one: No se puede eliminar el registro porque existe un(a) %{record}
+            dependiente
           has_many: No se puede eliminar el registro porque existen %{record} dependientes
   date:
     abbr_day_names:
@@ -17,7 +18,7 @@ es-PA:
     - vie
     - sáb
     abbr_month_names:
-    -
+    - 
     - ene
     - feb
     - mar
@@ -43,7 +44,7 @@ es-PA:
       long: "%A, %-d de %B de %Y"
       short: "%-d de %b"
     month_names:
-    -
+    - 
     - enero
     - febrero
     - marzo
@@ -75,43 +76,42 @@ es-PA:
         one: casi 1 año
         other: casi %{count} años
       half_a_minute: medio minuto
-      less_than_x_minutes:
-        one: menos de 1 minuto
-        other: menos de %{count} minutos
       less_than_x_seconds:
         one: menos de 1 segundo
         other: menos de %{count} segundos
+      less_than_x_minutes:
+        one: menos de 1 minuto
+        other: menos de %{count} minutos
       over_x_years:
         one: más de 1 año
         other: más de %{count} años
-      x_days:
-        one: 1 día
-        other: "%{count} días"
+      x_seconds:
+        one: 1 segundo
+        other: "%{count} segundos"
       x_minutes:
         one: 1 minuto
         other: "%{count} minutos"
+      x_days:
+        one: 1 día
+        other: "%{count} días"
       x_months:
         one: 1 mes
         other: "%{count} meses"
       x_years:
         one: 1 año
         other: "%{count} años"
-      x_seconds:
-        one: 1 segundo
-        other: "%{count} segundos"
     prompts:
-      day: Día
-      hour: Hora
-      minute: Minuto
-      month: Mes
       second: Segundo
+      minute: Minuto
+      hour: Hora
+      day: Día
+      month: Mes
       year: Año
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: debe ser aceptado(a)
       blank: no puede estar en blanco
-      present: debe estar en blanco
       confirmation: no coincide
       empty: no puede estar vacío(a)
       equal_to: debe ser igual a %{count}
@@ -123,10 +123,12 @@ es-PA:
       invalid: no es válido(a)
       less_than: debe ser menor que %{count}
       less_than_or_equal_to: debe ser menor que o igual a %{count}
-      model_invalid: "La validación falló: %{errors}"
+      model_invalid: 'La validación falló: %{errors}'
       not_a_number: no es un número
       not_an_integer: debe ser un número entero
       odd: debe ser un número impar
+      other_than: debe ser diferente de %{count}
+      present: debe estar en blanco
       required: debe existir
       taken: ya está en uso
       too_long:
@@ -138,12 +140,12 @@ es-PA:
       wrong_length:
         one: no tiene la longitud correcta (debe ser de 1 caracter)
         other: no tiene la longitud correcta (debe ser de %{count} caracteres)
-      other_than: debe ser diferente de %{count}
     template:
-      body: "Revise que los siguientes campos sean válidos:"
+      body: 'Revise que los siguientes campos sean válidos:'
       header:
         one: No se pudo guardar este(a) %{model} porque se encontró 1 error
-        other: No se pudo guardar este(a) %{model} porque se encontraron %{count} errores
+        other: No se pudo guardar este(a) %{model} porque se encontraron %{count}
+          errores
   helpers:
     select:
       prompt: Por favor seleccione
@@ -180,9 +182,9 @@ es-PA:
           trillion:
             one: billón
             other: billones
-          unit: ""
+          unit: ''
       format:
-        delimiter: ""
+        delimiter: ''
         precision: 3
         significant: true
         strip_insignificant_zeros: true
@@ -192,19 +194,19 @@ es-PA:
           byte:
             one: Byte
             other: Bytes
+          eb: EB
           gb: GB
           kb: KB
           mb: MB
-          tb: TB
           pb: PB
-          eb: EB
+          tb: TB
     percentage:
       format:
-        delimiter: ""
+        delimiter: ''
         format: "%n%"
     precision:
       format:
-        delimiter: ""
+        delimiter: ''
   support:
     array:
       last_word_connector: " y "

--- a/rails/locale/es-PE.yml
+++ b/rails/locale/es-PE.yml
@@ -3,7 +3,7 @@ es-PE:
   activerecord:
     errors:
       messages:
-        record_invalid: "Falla de validación: %{errors}"
+        record_invalid: 'Falla de validación: %{errors}'
         restrict_dependent_destroy:
           has_one: No se puede eliminar el registro porque existe un %{record} dependiente
           has_many: No se puede eliminar el registro porque existen %{record} dependientes
@@ -17,7 +17,7 @@ es-PE:
     - vie
     - sáb
     abbr_month_names:
-    -
+    - 
     - ene
     - feb
     - mar
@@ -43,7 +43,7 @@ es-PE:
       long: "%A, %d de %B del %Y"
       short: "%d de %b"
     month_names:
-    -
+    - 
     - enero
     - febrero
     - marzo
@@ -75,43 +75,42 @@ es-PE:
         one: casi 1 año
         other: casi %{count} años
       half_a_minute: medio minuto
-      less_than_x_minutes:
-        one: menos de 1 minuto
-        other: menos de %{count} minutos
       less_than_x_seconds:
         one: menos de 1 segundo
         other: menos de %{count} segundos
+      less_than_x_minutes:
+        one: menos de 1 minuto
+        other: menos de %{count} minutos
       over_x_years:
         one: más de 1 año
         other: más de %{count} años
-      x_days:
-        one: 1 día
-        other: "%{count} días"
+      x_seconds:
+        one: 1 segundo
+        other: "%{count} segundos"
       x_minutes:
         one: 1 minuto
         other: "%{count} minutos"
+      x_days:
+        one: 1 día
+        other: "%{count} días"
       x_months:
         one: 1 mes
         other: "%{count} meses"
       x_years:
         one: 1 año
         other: "%{count} años"
-      x_seconds:
-        one: 1 segundo
-        other: "%{count} segundos"
     prompts:
-      day: Día
-      hour: Hora
-      minute: Minuto
-      month: Mes
       second: Segundos
+      minute: Minuto
+      hour: Hora
+      day: Día
+      month: Mes
       year: Año
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: debe ser aceptado
       blank: no puede estar en blanco
-      present: debe estar en blanco
       confirmation: no coincide
       empty: no puede estar vacío
       equal_to: debe ser igual a %{count}
@@ -123,10 +122,12 @@ es-PE:
       invalid: es inválido
       less_than: debe ser menor que %{count}
       less_than_or_equal_to: debe ser menor o igual que %{count}
-      model_invalid: "Falla de validación: %{errors}"
+      model_invalid: 'Falla de validación: %{errors}'
       not_a_number: no es un número
       not_an_integer: debe ser un entero
       odd: debe ser un número non
+      other_than: debe ser distinto de %{count}
+      present: debe estar en blanco
       required: debe existir
       taken: ya ha sido tomado
       too_long:
@@ -138,7 +139,6 @@ es-PE:
       wrong_length:
         one: longitud errónea (debe ser de 1 caracter)
         other: longitud errónea (debe ser de %{count} caracteres)
-      other_than: debe ser distinto de %{count}
     template:
       body: 'Revise que los siguientes campos sean válidos:'
       header:
@@ -192,12 +192,12 @@ es-PE:
           byte:
             one: Byte
             other: Bytes
+          eb: EB
           gb: GB
           kb: KB
           mb: MB
-          tb: TB
           pb: PB
-          eb: EB
+          tb: TB
     percentage:
       format:
         delimiter: ","

--- a/rails/locale/es-US.yml
+++ b/rails/locale/es-US.yml
@@ -3,7 +3,7 @@ es-US:
   activerecord:
     errors:
       messages:
-        record_invalid: "La validación falló: %{errors}"
+        record_invalid: 'La validación falló: %{errors}'
         restrict_dependent_destroy:
           has_one: No se puede eliminar el registro porque existe un %{record} dependiente
           has_many: No se puede eliminar el registro porque existen %{record} dependientes
@@ -17,7 +17,7 @@ es-US:
     - vie
     - sáb
     abbr_month_names:
-    -
+    - 
     - ene
     - feb
     - mar
@@ -43,7 +43,7 @@ es-US:
       long: "%A, %d de %B de %Y"
       short: "%d de %b"
     month_names:
-    -
+    - 
     - enero
     - febrero
     - marzo
@@ -75,43 +75,42 @@ es-US:
         one: casi 1 año
         other: casi %{count} años
       half_a_minute: medio minuto
-      less_than_x_minutes:
-        one: menos de 1 minuto
-        other: menos de %{count} minutos
       less_than_x_seconds:
         one: menos de 1 segundo
         other: menos de %{count} segundos
+      less_than_x_minutes:
+        one: menos de 1 minuto
+        other: menos de %{count} minutos
       over_x_years:
         one: más de 1 año
         other: más de %{count} años
-      x_days:
-        one: 1 día
-        other: "%{count} días"
+      x_seconds:
+        one: 1 segundo
+        other: "%{count} segundos"
       x_minutes:
         one: 1 minuto
         other: "%{count} minutos"
+      x_days:
+        one: 1 día
+        other: "%{count} días"
       x_months:
         one: 1 mes
         other: "%{count} meses"
       x_years:
         one: 1 año
         other: "%{count} años"
-      x_seconds:
-        one: 1 segundo
-        other: "%{count} segundos"
     prompts:
-      day: Día
-      hour: Hora
-      minute: Minuto
-      month: Mes
       second: Segundos
+      minute: Minuto
+      hour: Hora
+      day: Día
+      month: Mes
       year: Año
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: debe ser aceptado
       blank: no puede estar en blanco
-      present: debe estar en blanco
       confirmation: no coincide
       empty: no puede estar vacío
       equal_to: debe ser igual a %{count}
@@ -123,10 +122,12 @@ es-US:
       invalid: es inválido
       less_than: debe ser menor que %{count}
       less_than_or_equal_to: debe ser menor o igual que %{count}
-      model_invalid: "La validación falló: %{errors}"
+      model_invalid: 'La validación falló: %{errors}'
       not_a_number: no es un número
       not_an_integer: debe ser un entero
       odd: debe ser un número non
+      other_than: debe ser distinto de %{count}
+      present: debe estar en blanco
       required: debe existir
       taken: ya ha sido tomado
       too_long:
@@ -138,7 +139,6 @@ es-US:
       wrong_length:
         one: longitud errónea (debe ser de 1 caracter)
         other: longitud errónea (debe ser de %{count} caracteres)
-      other_than: debe ser distinto de %{count}
     template:
       body: 'Revise que los siguientes campos sean válidos:'
       header:
@@ -192,12 +192,12 @@ es-US:
           byte:
             one: Byte
             other: Bytes
+          eb: EB
           gb: GB
           kb: KB
           mb: MB
-          tb: TB
           pb: PB
-          eb: EB
+          tb: TB
     percentage:
       format:
         delimiter: ","

--- a/rails/locale/es-VE.yml
+++ b/rails/locale/es-VE.yml
@@ -3,7 +3,7 @@ es-VE:
   activerecord:
     errors:
       messages:
-        record_invalid: "La validación falló: %{errors}"
+        record_invalid: 'La validación falló: %{errors}'
         restrict_dependent_destroy:
           has_one: No se puede eliminar el registro porque existe un %{record} dependiente
           has_many: No se puede eliminar el registro porque existen %{record} dependientes
@@ -17,7 +17,7 @@ es-VE:
     - vie
     - sáb
     abbr_month_names:
-    -
+    - 
     - ene
     - feb
     - mar
@@ -43,7 +43,7 @@ es-VE:
       long: "%A, %d de %B de %Y"
       short: "%d de %b"
     month_names:
-    -
+    - 
     - enero
     - febrero
     - marzo
@@ -75,43 +75,42 @@ es-VE:
         one: casi 1 año
         other: casi %{count} años
       half_a_minute: medio minuto
-      less_than_x_minutes:
-        one: menos de 1 minuto
-        other: menos de %{count} minutos
       less_than_x_seconds:
         one: menos de 1 segundo
         other: menos de %{count} segundos
+      less_than_x_minutes:
+        one: menos de 1 minuto
+        other: menos de %{count} minutos
       over_x_years:
         one: más de 1 año
         other: más de %{count} años
-      x_days:
-        one: 1 día
-        other: "%{count} días"
+      x_seconds:
+        one: 1 segundo
+        other: "%{count} segundos"
       x_minutes:
         one: 1 minuto
         other: "%{count} minutos"
+      x_days:
+        one: 1 día
+        other: "%{count} días"
       x_months:
         one: 1 mes
         other: "%{count} meses"
       x_years:
         one: 1 año
         other: "%{count} años"
-      x_seconds:
-        one: 1 segundo
-        other: "%{count} segundos"
     prompts:
-      day: Día
-      hour: Hora
-      minute: Minuto
-      month: Mes
       second: Segundos
+      minute: Minuto
+      hour: Hora
+      day: Día
+      month: Mes
       year: Año
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: debe ser aceptado
       blank: no puede estar en blanco
-      present: debe estar en blanco
       confirmation: no coincide
       empty: no puede estar vacío
       equal_to: debe ser igual a %{count}
@@ -123,10 +122,12 @@ es-VE:
       invalid: no es válido
       less_than: debe ser menor que %{count}
       less_than_or_equal_to: debe ser menor o igual que %{count}
-      model_invalid: "La validación falló: %{errors}"
+      model_invalid: 'La validación falló: %{errors}'
       not_a_number: no es un número
       not_an_integer: debe ser un entero
       odd: debe ser un número impar
+      other_than: debe ser distinto de %{count}
+      present: debe estar en blanco
       required: debe existir
       taken: ya está en uso
       too_long:
@@ -138,7 +139,6 @@ es-VE:
       wrong_length:
         one: longitud errónea (debe ser de 1 caracter)
         other: longitud errónea (debe ser de %{count} caracteres)
-      other_than: debe ser distinto de %{count}
     template:
       body: 'Revise que los siguientes campos sean válidos:'
       header:
@@ -192,12 +192,12 @@ es-VE:
           byte:
             one: Byte
             other: Bytes
+          eb: EB
           gb: GB
           kb: KB
           mb: MB
-          tb: TB
           pb: PB
-          eb: EB
+          tb: TB
     percentage:
       format:
         delimiter: ","

--- a/rails/locale/es.yml
+++ b/rails/locale/es.yml
@@ -3,7 +3,7 @@ es:
   activerecord:
     errors:
       messages:
-        record_invalid: "La validación falló: %{errors}"
+        record_invalid: 'La validación falló: %{errors}'
         restrict_dependent_destroy:
           has_one: No se puede eliminar el registro porque existe un %{record} dependiente
           has_many: No se puede eliminar el registro porque existen %{record} dependientes
@@ -17,7 +17,7 @@ es:
     - vie
     - sáb
     abbr_month_names:
-    -
+    - 
     - ene
     - feb
     - mar
@@ -43,7 +43,7 @@ es:
       long: "%-d de %B de %Y"
       short: "%-d de %b"
     month_names:
-    -
+    - 
     - enero
     - febrero
     - marzo
@@ -75,43 +75,42 @@ es:
         one: casi 1 año
         other: casi %{count} años
       half_a_minute: medio minuto
-      less_than_x_minutes:
-        one: menos de 1 minuto
-        other: menos de %{count} minutos
       less_than_x_seconds:
         one: menos de 1 segundo
         other: menos de %{count} segundos
+      less_than_x_minutes:
+        one: menos de 1 minuto
+        other: menos de %{count} minutos
       over_x_years:
         one: más de 1 año
         other: más de %{count} años
-      x_days:
-        one: 1 día
-        other: "%{count} días"
+      x_seconds:
+        one: 1 segundo
+        other: "%{count} segundos"
       x_minutes:
         one: 1 minuto
         other: "%{count} minutos"
+      x_days:
+        one: 1 día
+        other: "%{count} días"
       x_months:
         one: 1 mes
         other: "%{count} meses"
       x_years:
         one: 1 año
         other: "%{count} años"
-      x_seconds:
-        one: 1 segundo
-        other: "%{count} segundos"
     prompts:
-      day: Día
-      hour: Hora
-      minute: Minutos
-      month: Mes
       second: Segundos
+      minute: Minutos
+      hour: Hora
+      day: Día
+      month: Mes
       year: Año
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: debe ser aceptado
       blank: no puede estar en blanco
-      present: debe estar en blanco
       confirmation: no coincide
       empty: no puede estar vacío
       equal_to: debe ser igual a %{count}
@@ -123,22 +122,23 @@ es:
       invalid: no es válido
       less_than: debe ser menor que %{count}
       less_than_or_equal_to: debe ser menor que o igual a %{count}
-      model_invalid: "La validación falló: %{errors}"
+      model_invalid: 'La validación falló: %{errors}'
       not_a_number: no es un número
       not_an_integer: debe ser un entero
       odd: debe ser impar
+      other_than: debe ser distinto de %{count}
+      present: debe estar en blanco
       required: debe existir
       taken: ya está en uso
       too_long:
-        one: "es demasiado largo (1 carácter máximo)"
-        other: "es demasiado largo (%{count} caracteres máximo)"
+        one: es demasiado largo (1 carácter máximo)
+        other: es demasiado largo (%{count} caracteres máximo)
       too_short:
-        one: "es demasiado corto (1 carácter mínimo)"
-        other: "es demasiado corto (%{count} caracteres mínimo)"
+        one: es demasiado corto (1 carácter mínimo)
+        other: es demasiado corto (%{count} caracteres mínimo)
       wrong_length:
-        one: "no tiene la longitud correcta (1 carácter exactos)"
-        other: "no tiene la longitud correcta (%{count} caracteres exactos)"
-      other_than: debe ser distinto de %{count}
+        one: no tiene la longitud correcta (1 carácter exactos)
+        other: no tiene la longitud correcta (%{count} caracteres exactos)
     template:
       body: 'Se encontraron problemas con los siguientes campos:'
       header:
@@ -192,12 +192,12 @@ es:
           byte:
             one: Byte
             other: Bytes
+          eb: EB
           gb: GB
           kb: KB
           mb: MB
-          tb: TB
           pb: PB
-          eb: EB
+          tb: TB
     percentage:
       format:
         delimiter: ''

--- a/rails/locale/et.yml
+++ b/rails/locale/et.yml
@@ -5,8 +5,8 @@ et:
       messages:
         record_invalid: 'Valideerimine ebaõnnestus: %{errors}'
         restrict_dependent_destroy:
-          has_one: "Ei saa kirjet kustutada kuna sõltuv %{record} on olemas"
-          has_many: "Ei saa kirjet kustutada kuna sõltuvad %{record} on olemas"
+          has_one: Ei saa kirjet kustutada kuna sõltuv %{record} on olemas
+          has_many: Ei saa kirjet kustutada kuna sõltuvad %{record} on olemas
   date:
     abbr_day_names:
     - P
@@ -17,7 +17,7 @@ et:
     - R
     - L
     abbr_month_names:
-    -
+    - 
     - jaan.
     - veebr.
     - märts
@@ -43,7 +43,7 @@ et:
       long: "%d. %B %Y"
       short: "%d.%m.%y"
     month_names:
-    -
+    - 
     - jaanuar
     - veebruar
     - märts
@@ -75,43 +75,42 @@ et:
         one: peaaegu üks aasta
         other: peaaegu %{count} aastat
       half_a_minute: pool minutit
-      less_than_x_minutes:
-        one: vähem kui %{count} minut
-        other: vähem kui %{count} minutit
       less_than_x_seconds:
         one: vähem kui %{count} sekund
         other: vähem kui %{count} sekundit
+      less_than_x_minutes:
+        one: vähem kui %{count} minut
+        other: vähem kui %{count} minutit
       over_x_years:
         one: üle %{count} aasta
         other: üle %{count} aasta
-      x_days:
-        one: "%{count} päev"
-        other: "%{count} päeva"
+      x_seconds:
+        one: "%{count} sekund"
+        other: "%{count} sekundit"
       x_minutes:
         one: "%{count} minut"
         other: "%{count} minutit"
+      x_days:
+        one: "%{count} päev"
+        other: "%{count} päeva"
       x_months:
         one: "%{count} kuu"
         other: "%{count} kuud"
       x_years:
         one: "%{count} aasta"
         other: "%{count} aastat"
-      x_seconds:
-        one: "%{count} sekund"
-        other: "%{count} sekundit"
     prompts:
-      day: Päev
-      hour: Tunde
-      minute: Minutit
-      month: Kuu
       second: Sekundit
+      minute: Minutit
+      hour: Tunde
+      day: Päev
+      month: Kuu
       year: Aasta
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: peab olema heaks kiidetud
       blank: on täitmata
-      present: peab olema täitmata
       confirmation: ei vasta kinnitusele
       empty: on tühi
       equal_to: peab olema võrdne arvuga %{count}
@@ -123,16 +122,17 @@ et:
       invalid: ei ole korrektne
       less_than: peab olema vähem kui %{count}
       less_than_or_equal_to: peab olema vähem või võrdne arvuga %{count}
-      model_invalid: "Valideerimine ebaõnnestus: %{errors}"
+      model_invalid: 'Valideerimine ebaõnnestus: %{errors}'
       not_a_number: ei ole number
       not_an_integer: peab olema täisarv
       odd: peab olema paaritu arv
+      other_than: peab olema midagi muud kui %{count}
+      present: peab olema täitmata
       required: peab olemas olema
       taken: on juba võetud
       too_long: on liiga pikk (maksimum on %{count} tähemärki)
       too_short: on liiga lühike (miinimum on %{count} tähemärki)
       wrong_length: on vale pikkusega (peab olema %{count} tähemärki)
-      other_than: peab olema midagi muud kui %{count}
     template:
       body: 'Probleeme ilmnes järgmiste väljadega:'
       header:

--- a/rails/locale/eu.yml
+++ b/rails/locale/eu.yml
@@ -17,7 +17,7 @@ eu:
     - Osti
     - Lar
     abbr_month_names:
-    -
+    - 
     - Urt
     - Ots
     - Mar
@@ -43,7 +43,7 @@ eu:
       long: "%Y(e)ko %Bk %e"
       short: "%b %e"
     month_names:
-    -
+    - 
     - Urtarrila
     - Otsaila
     - Martxoa
@@ -75,40 +75,39 @@ eu:
         one: ia urte bat
         other: ia %{count} urte
       half_a_minute: minutu erdi
-      less_than_x_minutes:
-        one: 1 minutu bat baino gutxiago
-        other: "%{count} minutu baino gutxiago"
       less_than_x_seconds:
         one: segundu bat baino gutxiago
         other: "%{count} segundu baino gutxiago"
+      less_than_x_minutes:
+        one: 1 minutu bat baino gutxiago
+        other: "%{count} minutu baino gutxiago"
       over_x_years:
         one: urte bat baino gehiago
         other: "%{count} urte baino gehiago"
-      x_days:
-        one: egun bat
-        other: "%{count} egun"
-      x_minutes:
-        one: minutu bat
-        other: "%{count} minutu"
-      x_months:
-        one: hilabete bat
-        other: "%{count} hilabete"
       x_seconds:
         one: segundu bat
         other: "%{count} segundu"
+      x_minutes:
+        one: minutu bat
+        other: "%{count} minutu"
+      x_days:
+        one: egun bat
+        other: "%{count} egun"
+      x_months:
+        one: hilabete bat
+        other: "%{count} hilabete"
     prompts:
-      day: Egun
-      hour: Ordu
-      minute: Minutu
-      month: Hilabete
       second: Segundu
+      minute: Minutu
+      hour: Ordu
+      day: Egun
+      month: Hilabete
       year: Urte
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: onartuta izan behar da
       blank: ezin da zuriz utzi
-      present: zuriz egon behar da
       confirmation: ez dator bat konfirmazioarekin
       empty: ezin da hutsik egon
       equal_to: "%{count} izan behar da"
@@ -120,22 +119,23 @@ eu:
       invalid: ez da zuzena
       less_than: "%{count} baino txikiago izan behar da"
       less_than_or_equal_to: "%{count} baino txikiago edo berdin izan behar da"
-      model_invalid: "Baieztatzeak huts egin du: %{errors}"
+      model_invalid: 'Baieztatzeak huts egin du: %{errors}'
       not_a_number: ez da zenbaki bat
       not_an_integer: zenbaki osoa izan behar da
       odd: bakoitia izan behar du
+      other_than: "%{count}ren ezberdina izan behar du"
+      present: zuriz egon behar da
       required: egon behar du
       taken: hartuta dago
       too_long:
-        one: "luzeegia da (karaktere 1 gehienez)"
-        other: "luzeegia da (%{count} karaktere gehienez)"
+        one: luzeegia da (karaktere 1 gehienez)
+        other: luzeegia da (%{count} karaktere gehienez)
       too_short:
-        one: "laburregia da (karaktere 1 gutxienez)"
-        other: "laburregia da (%{count} karaktere gutxienez)"
+        one: laburregia da (karaktere 1 gutxienez)
+        other: laburregia da (%{count} karaktere gutxienez)
       wrong_length:
-        one: "ez du luzeera zuzena (karaktere 1 izan behar ditu)"
-        other: "ez du luzeera zuzena (%{count} karaktere izan behar ditu)"
-      other_than: "%{count}ren ezberdina izan behar du"
+        one: ez du luzeera zuzena (karaktere 1 izan behar ditu)
+        other: ez du luzeera zuzena (%{count} karaktere izan behar ditu)
     template:
       body: 'Arazoak egon dira ondoko eremuekin:'
       header:

--- a/rails/locale/fa.yml
+++ b/rails/locale/fa.yml
@@ -5,8 +5,9 @@ fa:
       messages:
         record_invalid: رکورد نامعتبر است %{errors}
         restrict_dependent_destroy:
+          has_one: نمی توان رکورد را حذف کرد بخاطر اینکه یک %{record} وابسته وجود
+            دارد
           has_many: نمی توان رکورد را حذف کرد بخاطر اینکه %{record} وابسته وجود دارد
-          has_one: نمی توان رکورد را حذف کرد بخاطر اینکه یک %{record} وابسته وجود دارد
   date:
     abbr_day_names:
     - ی
@@ -17,7 +18,7 @@ fa:
     - ج
     - ش
     abbr_month_names:
-    -
+    - 
     - ژانویه
     - فوریه
     - مارس
@@ -43,7 +44,7 @@ fa:
       long: "%e %B %Y"
       short: "%m/%d"
     month_names:
-    -
+    - 
     - ژانویه
     - فوریه
     - مارس
@@ -75,36 +76,36 @@ fa:
         one: حدود یک سال
         other: حدود %{count} سال
       half_a_minute: نیم دقیقه
-      less_than_x_minutes:
-        one: کمتر از یک دقیقه
-        other: کمتر از %{count} دقیقه
       less_than_x_seconds:
         one: یک ثانیه
         other: کمتر  از %{count} ثانیه
+      less_than_x_minutes:
+        one: کمتر از یک دقیقه
+        other: کمتر از %{count} دقیقه
       over_x_years:
         one: بیش از یک سال
         other: بیش از %{count} سال
-      x_days:
-        one: یک روز
-        other: "%{count} روز"
-      x_minutes:
-        one: یک دقیقه
-        other: "%{count} دقیقه"
-      x_months:
-        one: یک ماه
-        other: "%{count} ماه"
       x_seconds:
         one: یک ثانیه
         other: "%{count} ثانیه"
+      x_minutes:
+        one: یک دقیقه
+        other: "%{count} دقیقه"
+      x_days:
+        one: یک روز
+        other: "%{count} روز"
+      x_months:
+        one: یک ماه
+        other: "%{count} ماه"
       x_years:
         one: 1 سال
         other: "%{count} سال"
     prompts:
-      day: روز
-      hour: ساعت
-      minute: دقیقه
-      month: ماه
       second: ثانیه
+      minute: دقیقه
+      hour: ساعت
+      day: روز
+      month: ماه
       year: سال
   errors:
     format: "%{attribute} %{message}"
@@ -122,7 +123,7 @@ fa:
       invalid: نامعتبر است
       less_than: باید کمتر از %{count} باشد
       less_than_or_equal_to: باید کمتر یا برابر %{count} باشد
-      model_invalid: "رکورد نامعتبر است %{errors}"
+      model_invalid: رکورد نامعتبر است %{errors}
       not_a_number: عدد نیست
       not_an_integer: عدد صحیح نیست
       odd: باید فرد باشد
@@ -134,7 +135,7 @@ fa:
       too_short: کوتاه است (حداقل %{count} کاراکتر)
       wrong_length: نااندازه است (باید %{count} کاراکتر باشد)
     template:
-      body: "موارد زیر مشکل داشت:"
+      body: 'موارد زیر مشکل داشت:'
       header:
         one: 1 خطا جلوی ذخیره این %{model} را گرفت
         other: "%{count} خطا جلوی ذخیره این %{model} را گرفت"
@@ -170,9 +171,9 @@ fa:
           quadrillion: کادریلیون
           thousand: هزار
           trillion: تریلیون
-          unit: ""
+          unit: ''
       format:
-        delimiter: ""
+        delimiter: ''
         precision: 1
         significant: true
         strip_insignificant_zeros: true
@@ -188,10 +189,10 @@ fa:
           tb: ترابایت
     percentage:
       format:
-        delimiter: ""
+        delimiter: ''
     precision:
       format:
-        delimiter: ""
+        delimiter: ''
   support:
     array:
       last_word_connector: " و "

--- a/rails/locale/fi.yml
+++ b/rails/locale/fi.yml
@@ -5,8 +5,8 @@ fi:
       messages:
         record_invalid: 'Validointi epäonnistui: %{errors}'
         restrict_dependent_destroy:
-          has_one: "Ei voida poistaa mallia koska tästä riippuvainen %{record} löytyy"
-          has_many: "Ei voida poistaa mallia koska tästä riippuvaisia %{record} löytyy"
+          has_one: Ei voida poistaa mallia koska tästä riippuvainen %{record} löytyy
+          has_many: Ei voida poistaa mallia koska tästä riippuvaisia %{record} löytyy
   date:
     abbr_day_names:
     - su
@@ -17,7 +17,7 @@ fi:
     - pe
     - la
     abbr_month_names:
-    -
+    - 
     - tammi
     - helmi
     - maalis
@@ -43,7 +43,7 @@ fi:
       long: "%A %e. %Bta %Y"
       short: "%d. %b"
     month_names:
-    -
+    - 
     - tammikuu
     - helmikuu
     - maaliskuu
@@ -75,43 +75,42 @@ fi:
         one: melkein yksi vuosi
         other: melkein %{count} vuotta
       half_a_minute: puoli minuuttia
-      less_than_x_minutes:
-        one: alle minuutti
-        other: alle %{count} minuuttia
       less_than_x_seconds:
         one: alle sekunti
         other: alle %{count} sekuntia
+      less_than_x_minutes:
+        one: alle minuutti
+        other: alle %{count} minuuttia
       over_x_years:
         one: yli vuosi
         other: yli %{count} vuotta
-      x_days:
-        one: päivä
-        other: "%{count} päivää"
+      x_seconds:
+        one: sekunti
+        other: "%{count} sekuntia"
       x_minutes:
         one: minuutti
         other: "%{count} minuuttia"
+      x_days:
+        one: päivä
+        other: "%{count} päivää"
       x_months:
         one: kuukausi
         other: "%{count} kuukautta"
       x_years:
         one: vuosi
         other: "%{count} vuotta"
-      x_seconds:
-        one: sekunti
-        other: "%{count} sekuntia"
     prompts:
-      day: päivä
-      hour: tunti
-      minute: minuutti
-      month: kuukausi
       second: sekunti
+      minute: minuutti
+      hour: tunti
+      day: päivä
+      month: kuukausi
       year: vuosi
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: täytyy olla hyväksytty
       blank: ei voi olla sisällötön
-      present: täytyy olla sisällötön
       confirmation: ei vastaa varmennusta
       empty: ei voi olla tyhjä
       equal_to: täytyy olla yhtä suuri kuin %{count}
@@ -123,10 +122,11 @@ fi:
       invalid: on kelvoton
       less_than: täytyy olla pienempi kuin %{count}
       less_than_or_equal_to: täytyy olla pienempi tai yhtä suuri kuin %{count}
-      model_invalid: "Validointi epäonnistui: %{errors}"
+      model_invalid: 'Validointi epäonnistui: %{errors}'
       not_a_number: ei ole luku
       not_an_integer: ei ole kokonaisluku
       odd: täytyy olla pariton
+      present: täytyy olla sisällötön
       required: täytyy olla
       taken: on jo käytössä
       too_long:

--- a/rails/locale/fr-CA.yml
+++ b/rails/locale/fr-CA.yml
@@ -5,8 +5,10 @@ fr-CA:
       messages:
         record_invalid: 'La validation a échoué : %{errors}'
         restrict_dependent_destroy:
-          has_one: "Vous ne pouvez pas supprimer l'enregistrement car un(e) %{record} dépendant(e) existe"
-          has_many: "Vous ne pouvez pas supprimer l'enregistrement parce que les %{record} dépendants existent"
+          has_one: Vous ne pouvez pas supprimer l'enregistrement car un(e) %{record}
+            dépendant(e) existe
+          has_many: Vous ne pouvez pas supprimer l'enregistrement parce que les %{record}
+            dépendants existent
   date:
     abbr_day_names:
     - dim
@@ -17,7 +19,7 @@ fr-CA:
     - ven
     - sam
     abbr_month_names:
-    -
+    - 
     - jan.
     - fév.
     - mar.
@@ -43,7 +45,7 @@ fr-CA:
       long: "%d %B %Y"
       short: "%y-%m-%d"
     month_names:
-    -
+    - 
     - janvier
     - février
     - mars
@@ -75,45 +77,44 @@ fr-CA:
         one: presqu'un an
         other: presque %{count} ans
       half_a_minute: une demi-minute
-      less_than_x_minutes:
-        one: moins d'une minute
-        other: moins de %{count} minutes
-        zero: moins d'une minute
       less_than_x_seconds:
+        zero: moins d'une seconde
         one: moins d'une seconde
         other: moins de %{count} secondes
-        zero: moins d'une seconde
+      less_than_x_minutes:
+        zero: moins d'une minute
+        one: moins d'une minute
+        other: moins de %{count} minutes
       over_x_years:
         one: plus d'un an
         other: plus de %{count} ans
-      x_days:
-        one: 1 jour
-        other: "%{count} jours"
+      x_seconds:
+        one: 1 seconde
+        other: "%{count} secondes"
       x_minutes:
         one: 1 minute
         other: "%{count} minutes"
+      x_days:
+        one: 1 jour
+        other: "%{count} jours"
       x_months:
         one: 1 mois
         other: "%{count} mois"
       x_years:
         one: 1 an
         other: "%{count} ans"
-      x_seconds:
-        one: 1 seconde
-        other: "%{count} secondes"
     prompts:
-      day: Jour
-      hour: Heure
-      minute: Minute
-      month: Mois
       second: Seconde
+      minute: Minute
+      hour: Heure
+      day: Jour
+      month: Mois
       year: Année
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: doit être accepté(e)
       blank: doit être rempli(e)
-      present: doit être vide
       confirmation: ne concorde pas avec %{attribute}
       empty: doit être rempli(e)
       equal_to: doit être égal à %{count}
@@ -125,10 +126,12 @@ fr-CA:
       invalid: n'est pas valide
       less_than: doit être inférieur à %{count}
       less_than_or_equal_to: doit être inférieur ou égal à %{count}
-      model_invalid: "Validation échouée : %{errors}"
+      model_invalid: 'Validation échouée : %{errors}'
       not_a_number: n'est pas un nombre
       not_an_integer: doit être un nombre entier
       odd: doit être impair
+      other_than: doit être différent de %{count}
+      present: doit être vide
       required: doit exister
       taken: n'est pas disponible
       too_long:
@@ -140,7 +143,6 @@ fr-CA:
       wrong_length:
         one: ne fait pas la bonne longueur (doit comporter un seul caractère)
         other: ne fait pas la bonne longueur (doit comporter %{count} caractères)
-      other_than: doit être différent de %{count}
     template:
       body: 'Veuillez vérifier les champs suivants : '
       header:
@@ -190,12 +192,12 @@ fr-CA:
           byte:
             one: octet
             other: octets
+          eb: Eo
           gb: Go
           kb: ko
           mb: Mo
-          tb: To
           pb: Po
-          eb: Eo
+          tb: To
     percentage:
       format:
         delimiter: ''

--- a/rails/locale/fr-CH.yml
+++ b/rails/locale/fr-CH.yml
@@ -5,8 +5,10 @@ fr-CH:
       messages:
         record_invalid: 'La validation a échoué : %{errors}'
         restrict_dependent_destroy:
-          has_one: "Vous ne pouvez pas supprimer l'enregistrement car un(e) %{record} dépendant(e) existe"
-          has_many: "Vous ne pouvez pas supprimer l'enregistrement parce que les %{record} dépendants existent"
+          has_one: Vous ne pouvez pas supprimer l'enregistrement car un(e) %{record}
+            dépendant(e) existe
+          has_many: Vous ne pouvez pas supprimer l'enregistrement parce que les %{record}
+            dépendants existent
   date:
     abbr_day_names:
     - dim
@@ -17,7 +19,7 @@ fr-CH:
     - ven
     - sam
     abbr_month_names:
-    -
+    - 
     - jan.
     - fév.
     - mar.
@@ -43,7 +45,7 @@ fr-CH:
       long: "%e %B %Y"
       short: "%e %b"
     month_names:
-    -
+    - 
     - janvier
     - février
     - mars
@@ -75,45 +77,44 @@ fr-CH:
         one: presqu'un an
         other: presque %{count} ans
       half_a_minute: une demi-minute
-      less_than_x_minutes:
-        one: moins d'une minute
-        other: moins de %{count} minutes
-        zero: moins d'une minute
       less_than_x_seconds:
+        zero: moins d'une seconde
         one: moins d'une seconde
         other: moins de %{count} secondes
-        zero: moins d'une seconde
+      less_than_x_minutes:
+        zero: moins d'une minute
+        one: moins d'une minute
+        other: moins de %{count} minutes
       over_x_years:
         one: plus d'un an
         other: plus de %{count} ans
-      x_days:
-        one: 1 jour
-        other: "%{count} jours"
+      x_seconds:
+        one: 1 seconde
+        other: "%{count} secondes"
       x_minutes:
         one: 1 minute
         other: "%{count} minutes"
+      x_days:
+        one: 1 jour
+        other: "%{count} jours"
       x_months:
         one: 1 mois
         other: "%{count} mois"
       x_years:
         one: 1 an
         other: "%{count} ans"
-      x_seconds:
-        one: 1 seconde
-        other: "%{count} secondes"
     prompts:
-      day: Jour
-      hour: Heure
-      minute: Minute
-      month: Mois
       second: Seconde
+      minute: Minute
+      hour: Heure
+      day: Jour
+      month: Mois
       year: Année
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: doit être accepté(e)
       blank: doit être rempli(e)
-      present: doit être vide
       confirmation: ne concorde pas avec %{attribute}
       empty: doit être rempli(e)
       equal_to: doit être égal à %{count}
@@ -125,10 +126,12 @@ fr-CH:
       invalid: n'est pas valide
       less_than: doit être inférieur à %{count}
       less_than_or_equal_to: doit être inférieur ou égal à %{count}
-      model_invalid: "Validation échouée : %{errors}"
+      model_invalid: 'Validation échouée : %{errors}'
       not_a_number: n'est pas un nombre
       not_an_integer: doit être un nombre entier
       odd: doit être impair
+      other_than: doit être différent de %{count}
+      present: doit être vide
       required: doit exister
       taken: n'est pas disponible
       too_long:
@@ -140,7 +143,6 @@ fr-CH:
       wrong_length:
         one: ne fait pas la bonne longueur (doit comporter un seul caractère)
         other: ne fait pas la bonne longueur (doit comporter %{count} caractères)
-      other_than: doit être différent de %{count}
     template:
       body: 'Veuillez vérifier les champs suivants : '
       header:
@@ -190,12 +192,12 @@ fr-CH:
           byte:
             one: octet
             other: octets
+          eb: Eo
           gb: Go
           kb: ko
           mb: Mo
-          tb: To
           pb: Po
-          eb: Eo
+          tb: To
     percentage:
       format:
         delimiter: ''

--- a/rails/locale/fr-FR.yml
+++ b/rails/locale/fr-FR.yml
@@ -5,8 +5,10 @@ fr-FR:
       messages:
         record_invalid: 'La validation a échoué : %{errors}'
         restrict_dependent_destroy:
-          has_one: "Vous ne pouvez pas supprimer l'enregistrement car un(e) %{record} dépendant(e) existe"
-          has_many: "Vous ne pouvez pas supprimer l'enregistrement parce que les %{record} dépendants existent"
+          has_one: Vous ne pouvez pas supprimer l'enregistrement car un(e) %{record}
+            dépendant(e) existe
+          has_many: Vous ne pouvez pas supprimer l'enregistrement parce que les %{record}
+            dépendants existent
   date:
     abbr_day_names:
     - dim
@@ -17,7 +19,7 @@ fr-FR:
     - ven
     - sam
     abbr_month_names:
-    -
+    - 
     - jan.
     - fév.
     - mar.
@@ -40,10 +42,10 @@ fr-FR:
     - samedi
     formats:
       default: "%d/%m/%Y"
-      short: "%e %b"
       long: "%e %B %Y"
+      short: "%e %b"
     month_names:
-    -
+    - 
     - janvier
     - février
     - mars
@@ -75,45 +77,44 @@ fr-FR:
         one: presqu'un an
         other: presque %{count} ans
       half_a_minute: une demi-minute
-      less_than_x_minutes:
-        zero: moins d'une minute
-        one: moins d'une minute
-        other: moins de %{count} minutes
       less_than_x_seconds:
         zero: moins d'une seconde
         one: moins d'une seconde
         other: moins de %{count} secondes
+      less_than_x_minutes:
+        zero: moins d'une minute
+        one: moins d'une minute
+        other: moins de %{count} minutes
       over_x_years:
         one: plus d'un an
         other: plus de %{count} ans
-      x_days:
-        one: 1 jour
-        other: "%{count} jours"
+      x_seconds:
+        one: 1 seconde
+        other: "%{count} secondes"
       x_minutes:
         one: 1 minute
         other: "%{count} minutes"
+      x_days:
+        one: 1 jour
+        other: "%{count} jours"
       x_months:
         one: 1 mois
         other: "%{count} mois"
       x_years:
         one: 1 an
         other: "%{count} ans"
-      x_seconds:
-        one: 1 seconde
-        other: "%{count} secondes"
     prompts:
-      day: Jour
-      hour: Heure
-      minute: Minute
-      month: Mois
       second: Seconde
+      minute: Minute
+      hour: Heure
+      day: Jour
+      month: Mois
       year: Année
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: doit être accepté(e)
       blank: doit être rempli(e)
-      present: doit être vide
       confirmation: ne concorde pas avec %{attribute}
       empty: doit être rempli(e)
       equal_to: doit être égal à %{count}
@@ -125,10 +126,12 @@ fr-FR:
       invalid: n'est pas valide
       less_than: doit être inférieur à %{count}
       less_than_or_equal_to: doit être inférieur ou égal à %{count}
-      model_invalid: "Validation échouée : %{errors}"
+      model_invalid: 'Validation échouée : %{errors}'
       not_a_number: n'est pas un nombre
       not_an_integer: doit être un nombre entier
       odd: doit être impair
+      other_than: doit être différent de %{count}
+      present: doit être vide
       required: doit exister
       taken: n'est pas disponible
       too_long:
@@ -140,7 +143,6 @@ fr-FR:
       wrong_length:
         one: ne fait pas la bonne longueur (doit comporter un seul caractère)
         other: ne fait pas la bonne longueur (doit comporter %{count} caractères)
-      other_than: doit être différent de %{count}
     template:
       body: 'Veuillez vérifier les champs suivants : '
       header:
@@ -190,12 +192,12 @@ fr-FR:
           byte:
             one: octet
             other: octets
+          eb: Eo
           gb: Go
           kb: ko
           mb: Mo
-          tb: To
           pb: Po
-          eb: Eo
+          tb: To
     percentage:
       format:
         delimiter: ''

--- a/rails/locale/fr.yml
+++ b/rails/locale/fr.yml
@@ -5,8 +5,10 @@ fr:
       messages:
         record_invalid: 'La validation a échoué : %{errors}'
         restrict_dependent_destroy:
-          has_one: "Vous ne pouvez pas supprimer l'enregistrement car un(e) %{record} dépendant(e) existe"
-          has_many: "Vous ne pouvez pas supprimer l'enregistrement parce que les %{record} dépendants existent"
+          has_one: Vous ne pouvez pas supprimer l'enregistrement car un(e) %{record}
+            dépendant(e) existe
+          has_many: Vous ne pouvez pas supprimer l'enregistrement parce que les %{record}
+            dépendants existent
   date:
     abbr_day_names:
     - dim
@@ -17,7 +19,7 @@ fr:
     - ven
     - sam
     abbr_month_names:
-    -
+    - 
     - jan.
     - fév.
     - mar.
@@ -40,10 +42,10 @@ fr:
     - samedi
     formats:
       default: "%d/%m/%Y"
-      short: "%e %b"
       long: "%e %B %Y"
+      short: "%e %b"
     month_names:
-    -
+    - 
     - janvier
     - février
     - mars
@@ -75,45 +77,44 @@ fr:
         one: presqu'un an
         other: presque %{count} ans
       half_a_minute: une demi-minute
-      less_than_x_minutes:
-        zero: moins d'une minute
-        one: moins d'une minute
-        other: moins de %{count} minutes
       less_than_x_seconds:
         zero: moins d'une seconde
         one: moins d'une seconde
         other: moins de %{count} secondes
+      less_than_x_minutes:
+        zero: moins d'une minute
+        one: moins d'une minute
+        other: moins de %{count} minutes
       over_x_years:
         one: plus d'un an
         other: plus de %{count} ans
-      x_days:
-        one: 1 jour
-        other: "%{count} jours"
+      x_seconds:
+        one: 1 seconde
+        other: "%{count} secondes"
       x_minutes:
         one: 1 minute
         other: "%{count} minutes"
+      x_days:
+        one: 1 jour
+        other: "%{count} jours"
       x_months:
         one: 1 mois
         other: "%{count} mois"
       x_years:
         one: 1 an
         other: "%{count} ans"
-      x_seconds:
-        one: 1 seconde
-        other: "%{count} secondes"
     prompts:
-      day: Jour
-      hour: Heure
-      minute: Minute
-      month: Mois
       second: Seconde
+      minute: Minute
+      hour: Heure
+      day: Jour
+      month: Mois
       year: Année
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: doit être accepté(e)
       blank: doit être rempli(e)
-      present: doit être vide
       confirmation: ne concorde pas avec %{attribute}
       empty: doit être rempli(e)
       equal_to: doit être égal à %{count}
@@ -125,10 +126,12 @@ fr:
       invalid: n'est pas valide
       less_than: doit être inférieur à %{count}
       less_than_or_equal_to: doit être inférieur ou égal à %{count}
-      model_invalid: "Validation échouée : %{errors}"
+      model_invalid: 'Validation échouée : %{errors}'
       not_a_number: n'est pas un nombre
       not_an_integer: doit être un nombre entier
       odd: doit être impair
+      other_than: doit être différent de %{count}
+      present: doit être vide
       required: doit exister
       taken: n'est pas disponible
       too_long:
@@ -140,7 +143,6 @@ fr:
       wrong_length:
         one: ne fait pas la bonne longueur (doit comporter un seul caractère)
         other: ne fait pas la bonne longueur (doit comporter %{count} caractères)
-      other_than: doit être différent de %{count}
     template:
       body: 'Veuillez vérifier les champs suivants : '
       header:
@@ -190,12 +192,12 @@ fr:
           byte:
             one: octet
             other: octets
+          eb: Eo
           gb: Go
           kb: ko
           mb: Mo
-          tb: To
           pb: Po
-          eb: Eo
+          tb: To
     percentage:
       format:
         delimiter: ''

--- a/rails/locale/gl.yml
+++ b/rails/locale/gl.yml
@@ -65,30 +65,30 @@ gl:
         one: aproximadamente 1 ano
         other: "%{count} anos"
       half_a_minute: medio minuto
+      less_than_x_seconds:
+        zero: menos dun segundo
+        one: 1 segundo
+        few: poucos segundos
+        other: "%{count} segundos"
       less_than_x_minutes:
+        zero: menos dun minuto
         one: 1 minuto
         other: "%{count} minutos"
-        zero: menos dun minuto
-      less_than_x_seconds:
-        few: poucos segundos
-        one: 1 segundo
-        other: "%{count} segundos"
-        zero: menos dun segundo
       over_x_years:
         one: máis dun ano
         other: "%{count} anos"
-      x_days:
-        one: 1 día
-        other: "%{count} días"
-      x_minutes:
-        one: 1 minuto
-        other: "%{count} minuto"
-      x_months:
-        one: 1 mes
-        other: "%{count} meses"
       x_seconds:
         one: 1 segundo
         other: "%{count} segundos"
+      x_minutes:
+        one: 1 minuto
+        other: "%{count} minuto"
+      x_days:
+        one: 1 día
+        other: "%{count} días"
+      x_months:
+        one: 1 mes
+        other: "%{count} meses"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/he.yml
+++ b/rails/locale/he.yml
@@ -14,7 +14,7 @@ he:
     - ו
     - ש
     abbr_month_names:
-    -
+    - 
     - ינו
     - פבר
     - מרץ
@@ -40,7 +40,7 @@ he:
       long: "%e ב%B, %Y"
       short: "%e %b"
     month_names:
-    -
+    - 
     - ינואר
     - פברואר
     - מרץ
@@ -72,35 +72,35 @@ he:
         one: כמעט שנה
         other: כמעט %{count} שנים
       half_a_minute: חצי דקה
-      less_than_x_minutes:
-        one: פחות מדקה אחת
-        other: פחות מ- %{count} דקות
-        zero: פחות מדקה אחת
       less_than_x_seconds:
+        zero: פחות משניה אחת
         one: פחות משניה אחת
         other: פחות מ- %{count} שניות
-        zero: פחות משניה אחת
+      less_than_x_minutes:
+        zero: פחות מדקה אחת
+        one: פחות מדקה אחת
+        other: פחות מ- %{count} דקות
       over_x_years:
         one: מעל שנה אחת
         other: מעל %{count} שנים
-      x_days:
-        one: יום אחד
-        other: "%{count} ימים"
-      x_minutes:
-        one: דקה אחת
-        other: "%{count} דקות"
-      x_months:
-        one: חודש אחד
-        other: "%{count} חודשים"
       x_seconds:
         one: שניה אחת
         other: "%{count} שניות"
+      x_minutes:
+        one: דקה אחת
+        other: "%{count} דקות"
+      x_days:
+        one: יום אחד
+        other: "%{count} ימים"
+      x_months:
+        one: חודש אחד
+        other: "%{count} חודשים"
     prompts:
-      day: יום
-      hour: שעה
-      minute: דקה
-      month: חודש
       second: שניות
+      minute: דקה
+      hour: שעה
+      day: יום
+      month: חודש
       year: שנה
   errors:
     format: "%{attribute} %{message}"

--- a/rails/locale/hi-IN.yml
+++ b/rails/locale/hi-IN.yml
@@ -14,7 +14,7 @@ hi-IN:
     - शुक्र
     - शनि
     abbr_month_names:
-    -
+    - 
     - Jan
     - Feb
     - Mar
@@ -40,7 +40,7 @@ hi-IN:
       long: "%B %d, %Y"
       short: "%b %d"
     month_names:
-    -
+    - 
     - जनवरी
     - फरवरी
     - मार्च
@@ -72,33 +72,33 @@ hi-IN:
         one: लग - भग एक साल
         other: लग - भग %{count} साल
       half_a_minute: एक आधा मिनट
-      less_than_x_minutes:
-        one: एक मिनट से कम
-        other: "%{count} मिनट से कम"
       less_than_x_seconds:
         one: एक सेकंड से कम
         other: "%{count}  सेकंड से कम"
+      less_than_x_minutes:
+        one: एक मिनट से कम
+        other: "%{count} मिनट से कम"
       over_x_years:
         one: एक साल के ऊपर
         other: "%{count} साल के ऊपर"
-      x_days:
-        one: एक दिन
-        other: "%{count} दिन"
-      x_minutes:
-        one: एक मिनट
-        other: "%{count} मिनट"
-      x_months:
-        one: एक महीना
-        other: "%{count} महीना"
       x_seconds:
         one: एक सेकंड
         other: "%{count} सेकंड"
+      x_minutes:
+        one: एक मिनट
+        other: "%{count} मिनट"
+      x_days:
+        one: एक दिन
+        other: "%{count} दिन"
+      x_months:
+        one: एक महीना
+        other: "%{count} महीना"
     prompts:
-      day: दिन
-      hour: घंटा
-      minute: क्षण
-      month: माह
       second: सेकंड
+      minute: क्षण
+      hour: घंटा
+      day: दिन
+      month: माह
       year: वर्ष
   errors:
     format: "%{attribute} %{message}"

--- a/rails/locale/hi.yml
+++ b/rails/locale/hi.yml
@@ -14,7 +14,7 @@ hi:
     - शुक्र
     - शनि
     abbr_month_names:
-    -
+    - 
     - जन
     - फर
     - मार्च
@@ -40,7 +40,7 @@ hi:
       long: "%B %d, %Y"
       short: "%b %d"
     month_names:
-    -
+    - 
     - जनवरी
     - फरवरी
     - मार्च
@@ -72,33 +72,33 @@ hi:
         one: लगभग एक साल
         other: लगभग %{count} साल
       half_a_minute: एक आधा मिनट
-      less_than_x_minutes:
-        one: एक मिनट से कम
-        other: "%{count} मिनट से कम"
       less_than_x_seconds:
         one: एक सेकेंड से कम
         other: "%{count}  सेकेंड से कम"
+      less_than_x_minutes:
+        one: एक मिनट से कम
+        other: "%{count} मिनट से कम"
       over_x_years:
         one: एक साल के ऊपर
         other: "%{count} साल से अधिक"
-      x_days:
-        one: एक दिन
-        other: "%{count} दिन"
-      x_minutes:
-        one: एक मिनट
-        other: "%{count} मिनट"
-      x_months:
-        one: एक महीना
-        other: "%{count} महीना"
       x_seconds:
         one: एक सेकेंड
         other: "%{count} सेकेंड"
+      x_minutes:
+        one: एक मिनट
+        other: "%{count} मिनट"
+      x_days:
+        one: एक दिन
+        other: "%{count} दिन"
+      x_months:
+        one: एक महीना
+        other: "%{count} महीना"
     prompts:
-      day: दिन
-      hour: घंटा
-      minute: मिनट
-      month: माह
       second: सेकेंड
+      minute: मिनट
+      hour: घंटा
+      day: दिन
+      month: माह
       year: वर्ष
   errors:
     format: "%{attribute} %{message}"

--- a/rails/locale/hr.yml
+++ b/rails/locale/hr.yml
@@ -17,7 +17,7 @@ hr:
     - Pet
     - Sub
     abbr_month_names:
-    -
+    - 
     - Sij
     - Veǉ
     - Ožu
@@ -43,7 +43,7 @@ hr:
       long: "%e. %B %Y."
       short: "%e.%-m."
     month_names:
-    -
+    - 
     - Siječanj
     - Veljača
     - Ožujak
@@ -83,54 +83,53 @@ hr:
         many: skoro %{count} godina
         other: skoro %{count} godina
       half_a_minute: pola minute
-      less_than_x_minutes:
-        one: manje od %{count} minute
-        few: manje od %{count} minute
-        many: manje od %{count} minuta
-        other: manje od %{count} minuta
       less_than_x_seconds:
         one: manje od %{count} sekunde
         few: manje od %{count} sekunde
         many: manje od %{count} sekundi
         other: manje od %{count} sekundi
+      less_than_x_minutes:
+        one: manje od %{count} minute
+        few: manje od %{count} minute
+        many: manje od %{count} minuta
+        other: manje od %{count} minuta
       over_x_years:
         one: preko %{count} godine
         few: preko %{count} godine
         many: preko %{count} godina
         other: preko %{count} godina
-      x_days:
-        one: "%{count} dan"
-        few: "%{count} dana"
-        many: "%{count} dana"
-        other: "%{count} dana"
-      x_minutes:
-        one: "%{count} minuta"
-        few: "%{count} minute"
-        many: "%{count} minuta"
-        other: "%{count} minuta"
-      x_months:
-        one: "%{count} mjesec"
-        few: "%{count} mjeseca"
-        many: "%{count} mjeseci"
-        other: "%{count} mjeseci"
       x_seconds:
         one: "%{count} sekunda"
         few: "%{count} sekunde"
         many: "%{count} sekundi"
         other: "%{count} sekundi"
+      x_minutes:
+        one: "%{count} minuta"
+        few: "%{count} minute"
+        many: "%{count} minuta"
+        other: "%{count} minuta"
+      x_days:
+        one: "%{count} dan"
+        few: "%{count} dana"
+        many: "%{count} dana"
+        other: "%{count} dana"
+      x_months:
+        one: "%{count} mjesec"
+        few: "%{count} mjeseca"
+        many: "%{count} mjeseci"
+        other: "%{count} mjeseci"
     prompts:
-      day: Dan
-      hour: Sat
-      minute: Minuta
-      month: Mjesec
       second: Sekunde
+      minute: Minuta
+      hour: Sat
+      day: Dan
+      month: Mjesec
       year: Godina
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: mora biti prihvaćen
       blank: ne smije biti prazan
-      present: mora biti prazan
       confirmation: se ne slaže sa svojom potvrdom
       empty: ne smije biti prazan
       equal_to: mora biti jednak %{count}
@@ -145,6 +144,8 @@ hr:
       not_a_number: nije broj
       not_an_integer: nije cijeli broj
       odd: mora biti neparan
+      other_than: mora biti različit od %{count}
+      present: mora biti prazan
       taken: je već zauzet
       too_long:
         one: je predugačak (maksimum je %{count} znak)
@@ -161,7 +162,6 @@ hr:
         few: nije odgovarajuće duljine (treba biti %{count} znaka)
         many: nije odgovarajuće duljine (treba biti %{count} znakova)
         other: nije odgovarajuće duljine (treba biti %{count} znakova)
-      other_than: mora biti različit od %{count}
     template:
       body: 'Sljedeća polja su neispravno popunjena:'
       header:
@@ -196,11 +196,11 @@ hr:
       decimal_units:
         format: "%n %u"
         units:
-          thousand: Tisuća
-          million: Milijun
           billion: Milijarda
-          trillion: Bilijun
+          million: Milijun
           quadrillion: Bilijarda
+          thousand: Tisuća
+          trillion: Bilijun
           unit: ''
       format:
         delimiter: ''

--- a/rails/locale/hu.yml
+++ b/rails/locale/hu.yml
@@ -14,7 +14,7 @@ hu:
     - p.
     - szo.
     abbr_month_names:
-    -
+    - 
     - jan.
     - febr.
     - márc.
@@ -40,7 +40,7 @@ hu:
       long: "%Y. %B %e."
       short: "%b %e."
     month_names:
-    -
+    - 
     - január
     - február
     - március
@@ -72,33 +72,33 @@ hu:
         one: majdnem 1 éve
         other: majdnem %{count} éve
       half_a_minute: fél perce
-      less_than_x_minutes:
-        one: kevesebb, mint 1 perce
-        other: kevesebb, mint %{count} perce
       less_than_x_seconds:
         one: kevesebb, mint 1 másodperce
         other: kevesebb, mint %{count} másodperce
+      less_than_x_minutes:
+        one: kevesebb, mint 1 perce
+        other: kevesebb, mint %{count} perce
       over_x_years:
         one: több, mint 1 éve
         other: több, mint %{count} éve
-      x_days:
-        one: 1 napja
-        other: "%{count} napja"
-      x_minutes:
-        one: 1 perce
-        other: "%{count} perce"
-      x_months:
-        one: 1 hónapja
-        other: "%{count} hónapja"
       x_seconds:
         one: 1 másodperce
         other: "%{count} másodperce"
+      x_minutes:
+        one: 1 perce
+        other: "%{count} perce"
+      x_days:
+        one: 1 napja
+        other: "%{count} napja"
+      x_months:
+        one: 1 hónapja
+        other: "%{count} hónapja"
     prompts:
-      day: Nap
-      hour: Óra
-      minute: Perc
-      month: Hónap
       second: Másodperc
+      minute: Perc
+      hour: Óra
+      day: Nap
+      month: Hónap
       year: Év
   errors:
     format: "%{attribute} %{message}"

--- a/rails/locale/id.yml
+++ b/rails/locale/id.yml
@@ -5,7 +5,8 @@ id:
       messages:
         record_invalid: 'Validasi gagal: %{errors}'
         restrict_dependent_destroy:
-          has_one: Tidak bisa menghapus record karena terdapat satu %{record} yang bergantung
+          has_one: Tidak bisa menghapus record karena terdapat satu %{record} yang
+            bergantung
           has_many: Tidak bisa menghapus record karena terdapat %{record} yang bergantung
   date:
     abbr_day_names:
@@ -17,7 +18,7 @@ id:
     - Jum
     - Sab
     abbr_month_names:
-    -
+    - 
     - Jan
     - Feb
     - Mar
@@ -43,7 +44,7 @@ id:
       long: "%A, %d %B %Y"
       short: "%d.%m.%Y"
     month_names:
-    -
+    - 
     - Januari
     - Februari
     - Maret
@@ -75,42 +76,41 @@ id:
         one: hampir setahun
         other: hampir %{count} tahun
       half_a_minute: setengah menit
-      less_than_x_minutes:
-        one: kurang dari 1 menit
-        other: kurang dari  %{count} menit
-        zero: kurang dari 1 menit
       less_than_x_seconds:
+        zero: kurang dari 1 detik
         one: kurang dari 1 detik
         other: kurang dari %{count} detik
-        zero: kurang dari 1 detik
+      less_than_x_minutes:
+        zero: kurang dari 1 menit
+        one: kurang dari 1 menit
+        other: kurang dari  %{count} menit
       over_x_years:
         one: lebih dari setahun
         other: lebih dari %{count} tahun
-      x_days:
-        one: sehari
-        other: "%{count} hari"
-      x_minutes:
-        one: satu menit
-        other: "%{count} menit"
-      x_months:
-        one: sebulan
-        other: "%{count} bulan"
       x_seconds:
         one: satu detik
         other: "%{count} detik"
+      x_minutes:
+        one: satu menit
+        other: "%{count} menit"
+      x_days:
+        one: sehari
+        other: "%{count} hari"
+      x_months:
+        one: sebulan
+        other: "%{count} bulan"
     prompts:
-      day: Hari
-      hour: Jam
-      minute: Menit
-      month: Bulan
       second: Detik
+      minute: Menit
+      hour: Jam
+      day: Hari
+      month: Bulan
       year: Tahun
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: harus diterima
       blank: tidak boleh kosong
-      present: harus kosong
       confirmation: tidak sesuai dengan %{attribute}
       empty: tidak boleh kosong
       equal_to: harus sama dengan %{count}
@@ -122,10 +122,12 @@ id:
       invalid: tidak valid
       less_than: harus lebih kecil dari %{count}
       less_than_or_equal_to: harus sama atau lebih kecil dari %{count}
-      model_invalid: "Validasi gagal: %{errors}"
+      model_invalid: 'Validasi gagal: %{errors}'
       not_a_number: bukan angka
       not_an_integer: harus bilangan bulat
       odd: harus ganjil
+      other_than: harus selain %{count}
+      present: harus kosong
       required: harus ada
       taken: sudah digunakan
       too_long:
@@ -137,7 +139,6 @@ id:
       wrong_length:
         one: jumlah karakter salah (seharusnya 1 karakter)
         other: jumlah karakter salah (seharusnya %{count} karakter)
-      other_than: harus selain %{count}
     template:
       body: 'Ada masalah dengan field berikut:'
       header:
@@ -159,7 +160,7 @@ id:
         separator: ","
         significant: false
         strip_insignificant_zeros: false
-        unit: "Rp"
+        unit: Rp
     format:
       delimiter: "."
       precision: 3

--- a/rails/locale/is.yml
+++ b/rails/locale/is.yml
@@ -17,7 +17,7 @@ is:
     - fös
     - lau
     abbr_month_names:
-    -
+    - 
     - jan
     - feb
     - mar
@@ -43,7 +43,7 @@ is:
       long: "%e. %B %Y"
       short: "%e. %b"
     month_names:
-    -
+    - 
     - janúar
     - febrúar
     - mars
@@ -75,40 +75,39 @@ is:
         one: næstum 1 ár
         other: næstum %{count} ár
       half_a_minute: hálf mínúta
-      less_than_x_minutes:
-        one: minna en 1 mínúta
-        other: minna en %{count} mínútur
       less_than_x_seconds:
         one: minna en 1 sekúnda
         other: minna en %{count} sekúndur
+      less_than_x_minutes:
+        one: minna en 1 mínúta
+        other: minna en %{count} mínútur
       over_x_years:
         one: meira en 1 ár
         other: meira en %{count} ár
-      x_days:
-        one: 1 dagur
-        other: "%{count} dagar"
-      x_minutes:
-        one: 1 mínúta
-        other: "%{count} mínútur"
-      x_months:
-        one: 1 mánuður
-        other: "%{count} mánuðir"
       x_seconds:
         one: 1 sekúnda
         other: "%{count} sekúndur"
+      x_minutes:
+        one: 1 mínúta
+        other: "%{count} mínútur"
+      x_days:
+        one: 1 dagur
+        other: "%{count} dagar"
+      x_months:
+        one: 1 mánuður
+        other: "%{count} mánuðir"
     prompts:
-      day: Dagur
-      hour: Klukkustund
-      minute: Mínúta
-      month: Mánuður
       second: Sekúnda
+      minute: Mínúta
+      hour: Klukkustund
+      day: Dagur
+      month: Mánuður
       year: Ár
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: þarf að vera tekið gilt
       blank: má ekki vera autt
-      present: verður að vera autt
       confirmation: er ekki jafngilt staðfestingunni
       empty: má ekki vera tómt
       equal_to: þarf að vera jafngilt %{count}
@@ -123,6 +122,8 @@ is:
       not_a_number: er ekki tala
       not_an_integer: þarf að vera heiltala
       odd: þarf að vera oddatala
+      other_than: verður að vera annað en %{count}
+      present: verður að vera autt
       taken: er þegar í notkun
       too_long:
         one: er of langt (má mest vera 1 stafur)
@@ -133,7 +134,6 @@ is:
       wrong_length:
         one: er af rangri lengd (má mest vera 1 stafur)
         other: er af rangri lengd (má mest vera %{count} stafir)
-      other_than: verður að vera annað en %{count}
     template:
       body: 'Villur fundust í eftirfarandi dálkum:'
       header:

--- a/rails/locale/it-CH.yml
+++ b/rails/locale/it-CH.yml
@@ -14,7 +14,7 @@ it-CH:
     - Ven
     - Sab
     abbr_month_names:
-    -
+    - 
     - Gen
     - Feb
     - Mar
@@ -40,7 +40,7 @@ it-CH:
       long: "%d %B %Y"
       short: "%d %b"
     month_names:
-    -
+    - 
     - Gennaio
     - Febbraio
     - Marzo
@@ -72,33 +72,33 @@ it-CH:
         one: circa 1 anno
         other: circa %{count} anni
       half_a_minute: mezzo minuto
-      less_than_x_minutes:
-        one: meno di un minuto
-        other: meno di %{count} minuti
       less_than_x_seconds:
         one: meno di un secondo
         other: meno di %{count} secondi
+      less_than_x_minutes:
+        one: meno di un minuto
+        other: meno di %{count} minuti
       over_x_years:
         one: oltre un anno
         other: oltre %{count} anni
-      x_days:
-        one: 1 giorno
-        other: "%{count} giorni"
-      x_minutes:
-        one: 1 minuto
-        other: "%{count} minuti"
-      x_months:
-        one: 1 mese
-        other: "%{count} mesi"
       x_seconds:
         one: 1 secondo
         other: "%{count} secondi"
+      x_minutes:
+        one: 1 minuto
+        other: "%{count} minuti"
+      x_days:
+        one: 1 giorno
+        other: "%{count} giorni"
+      x_months:
+        one: 1 mese
+        other: "%{count} mesi"
     prompts:
-      day: Giorno
-      hour: Ora
-      minute: Minuto
-      month: Mese
       second: Secondi
+      minute: Minuto
+      hour: Ora
+      day: Giorno
+      month: Mese
       year: Anno
   errors:
     format: "%{attribute} %{message}"

--- a/rails/locale/it.yml
+++ b/rails/locale/it.yml
@@ -5,8 +5,10 @@ it:
       messages:
         record_invalid: 'Validazione fallita: %{errors}'
         restrict_dependent_destroy:
-          has_one: Il record non può essere cancellato perchè esiste un %{record} dipendente
-          has_many: Il record non può essere cancellato perchè esistono %{record} dipendenti
+          has_one: Il record non può essere cancellato perchè esiste un %{record}
+            dipendente
+          has_many: Il record non può essere cancellato perchè esistono %{record}
+            dipendenti
   date:
     abbr_day_names:
     - dom
@@ -17,7 +19,7 @@ it:
     - ven
     - sab
     abbr_month_names:
-    -
+    - 
     - gen
     - feb
     - mar
@@ -43,7 +45,7 @@ it:
       long: "%d %B %Y"
       short: "%d %b"
     month_names:
-    -
+    - 
     - gennaio
     - febbraio
     - marzo
@@ -75,43 +77,42 @@ it:
         one: circa 1 anno
         other: circa %{count} anni
       half_a_minute: mezzo minuto
-      less_than_x_minutes:
-        one: meno di un minuto
-        other: meno di %{count} minuti
       less_than_x_seconds:
         one: meno di un secondo
         other: meno di %{count} secondi
+      less_than_x_minutes:
+        one: meno di un minuto
+        other: meno di %{count} minuti
       over_x_years:
         one: oltre un anno
         other: oltre %{count} anni
-      x_days:
-        one: 1 giorno
-        other: "%{count} giorni"
+      x_seconds:
+        one: 1 secondo
+        other: "%{count} secondi"
       x_minutes:
         one: 1 minuto
         other: "%{count} minuti"
+      x_days:
+        one: 1 giorno
+        other: "%{count} giorni"
       x_months:
         one: 1 mese
         other: "%{count} mesi"
       x_years:
         one: 1 anno
         other: "%{count} anni"
-      x_seconds:
-        one: 1 secondo
-        other: "%{count} secondi"
     prompts:
-      day: Giorno
-      hour: Ora
-      minute: Minuto
-      month: Mese
       second: Secondi
+      minute: Minuto
+      hour: Ora
+      day: Giorno
+      month: Mese
       year: Anno
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: deve essere accettata
       blank: non può essere lasciato in bianco
-      present: deve essere lasciato in bianco
       confirmation: non coincide con %{attribute}
       empty: non può essere vuoto
       equal_to: deve essere uguale a %{count}
@@ -126,6 +127,8 @@ it:
       not_a_number: non è un numero
       not_an_integer: non è un numero intero
       odd: deve essere dispari
+      other_than: devono essere di numero diverso da %{count}
+      present: deve essere lasciato in bianco
       required: deve esistere
       taken: è già presente
       too_long:
@@ -137,7 +140,6 @@ it:
       wrong_length:
         one: è della lunghezza sbagliata (deve essere di 1 carattere)
         other: è della lunghezza sbagliata (deve essere di %{count} caratteri)
-      other_than: devono essere di numero diverso da %{count}
     template:
       body: 'Ricontrolla i seguenti campi:'
       header:

--- a/rails/locale/ja.yml
+++ b/rails/locale/ja.yml
@@ -3,7 +3,7 @@ ja:
   activerecord:
     errors:
       messages:
-        record_invalid: "バリデーションに失敗しました: %{errors}"
+        record_invalid: 'バリデーションに失敗しました: %{errors}'
         restrict_dependent_destroy:
           has_one: "%{record}が存在しているので削除できません"
           has_many: "%{record}が存在しているので削除できません"
@@ -17,7 +17,7 @@ ja:
     - 金
     - 土
     abbr_month_names:
-    -
+    - 
     - 1月
     - 2月
     - 3月
@@ -43,7 +43,7 @@ ja:
       long: "%Y年%m月%d日(%a)"
       short: "%m/%d"
     month_names:
-    -
+    - 
     - 1月
     - 2月
     - 3月
@@ -75,43 +75,42 @@ ja:
         one: 1年弱
         other: "%{count}年弱"
       half_a_minute: 30秒前後
-      less_than_x_minutes:
-        one: 1分以内
-        other: "%{count}分未満"
       less_than_x_seconds:
         one: 1秒以内
         other: "%{count}秒未満"
+      less_than_x_minutes:
+        one: 1分以内
+        other: "%{count}分未満"
       over_x_years:
         one: 1年以上
         other: "%{count}年以上"
-      x_days:
-        one: 1日
-        other: "%{count}日"
+      x_seconds:
+        one: 1秒
+        other: "%{count}秒"
       x_minutes:
         one: 1分
         other: "%{count}分"
+      x_days:
+        one: 1日
+        other: "%{count}日"
       x_months:
         one: 1ヶ月
         other: "%{count}ヶ月"
       x_years:
         one: 1年
         other: "%{count}年"
-      x_seconds:
-        one: 1秒
-        other: "%{count}秒"
     prompts:
-      day: 日
-      hour: 時
-      minute: 分
-      month: 月
       second: 秒
+      minute: 分
+      hour: 時
+      day: 日
+      month: 月
       year: 年
   errors:
     format: "%{attribute}%{message}"
     messages:
       accepted: を受諾してください
       blank: を入力してください
-      present: は入力しないでください
       confirmation: と%{attribute}の入力が一致しません
       empty: を入力してください
       equal_to: は%{count}にしてください
@@ -123,16 +122,17 @@ ja:
       invalid: は不正な値です
       less_than: は%{count}より小さい値にしてください
       less_than_or_equal_to: は%{count}以下の値にしてください
-      model_invalid: "バリデーションに失敗しました: %{errors}"
+      model_invalid: 'バリデーションに失敗しました: %{errors}'
       not_a_number: は数値で入力してください
       not_an_integer: は整数で入力してください
       odd: は奇数にしてください
+      other_than: は%{count}以外の値にしてください
+      present: は入力しないでください
       required: を入力してください
       taken: はすでに存在します
       too_long: は%{count}文字以内で入力してください
       too_short: は%{count}文字以上で入力してください
       wrong_length: は%{count}文字で入力してください
-      other_than: は%{count}以外の値にしてください
     template:
       body: 次の項目を確認してください
       header:
@@ -180,12 +180,12 @@ ja:
         format: "%n%u"
         units:
           byte: バイト
+          eb: EB
           gb: GB
           kb: KB
           mb: MB
-          tb: TB
           pb: PB
-          eb: EB
+          tb: TB
     percentage:
       format:
         delimiter: ''
@@ -195,9 +195,9 @@ ja:
         delimiter: ''
   support:
     array:
-      last_word_connector: 、
-      two_words_connector: 、
-      words_connector: 、
+      last_word_connector: "、"
+      two_words_connector: "、"
+      words_connector: "、"
   time:
     am: 午前
     formats:

--- a/rails/locale/ka.yml
+++ b/rails/locale/ka.yml
@@ -3,7 +3,7 @@ ka:
   activerecord:
     errors:
       messages:
-        record_invalid: "დადასტურება წარუმატებელია: %{errors}"
+        record_invalid: 'დადასტურება წარუმატებელია: %{errors}'
   date:
     abbr_day_names:
     - კვ
@@ -14,7 +14,7 @@ ka:
     - პარ
     - შაბ
     abbr_month_names:
-    -
+    - 
     - იანვ
     - თებ
     - მარტი
@@ -40,7 +40,7 @@ ka:
       long: "%d %B %Y"
       short: "%d %b"
     month_names:
-    -
+    - 
     - იანვარი
     - თებერვალი
     - მარტი
@@ -72,43 +72,42 @@ ka:
         one: თითქმის 1 წელი
         other: თითქმის %{count} წელი
       half_a_minute: ნახევარი წუთი
-      less_than_x_minutes:
-        one: 1 წუთზე ნაკლები
-        other: "%{count} წუთზე ნაკლები"
       less_than_x_seconds:
         one: 1 წამზე ნაკლები
         other: "%{count} წამზე ნაკლები"
+      less_than_x_minutes:
+        one: 1 წუთზე ნაკლები
+        other: "%{count} წუთზე ნაკლები"
       over_x_years:
         one: 1 წელზე მეტი
         other: "%{count} წელზე მეტი"
-      x_days:
-        one: 1 დღე
-        other: "%{count} დღე"
+      x_seconds:
+        one: 1 წამი
+        other: "%{count} წამი"
       x_minutes:
         one: 1 წუთი
         other: "%{count} წუთი"
+      x_days:
+        one: 1 დღე
+        other: "%{count} დღე"
       x_months:
         one: 1 თვე
         other: "%{count} თვე"
       x_years:
         one: 1 წელი
         other: "%{count} წელი"
-      x_seconds:
-        one: 1 წამი
-        other: "%{count} წამი"
     prompts:
-      day: დღე
-      hour: საათი
-      minute: წუთი
-      month: თვე
       second: წამი
+      minute: წუთი
+      hour: საათი
+      day: დღე
+      month: თვე
       year: წელი
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: უნდა იყოს დადასტურებული
       blank: არ შეიძლება იყოს ცარიელი
-      present: უნდა იყოს ცარიელი
       confirmation: ველი %{attribute}-ს არ ემთხვევა
       empty: არ შეიძლება იყოს ცარიელი
       equal_to: უნდა უდრიდეს %{count}-ს
@@ -120,10 +119,12 @@ ka:
       invalid: არასწორია
       less_than: უნდა იყოს %{count}-ზე ნაკლები
       less_than_or_equal_to: უნდა იყოს %{count}-ზე ნაკლები ან ტოლი
-      model_invalid: "დადასტურება წარუმატებელია: %{errors}"
+      model_invalid: 'დადასტურება წარუმატებელია: %{errors}'
       not_a_number: არ არის რიცხვი
       not_an_integer: არ არის მთელი რიცხვი
       odd: უნდა იყოს კენტი
+      other_than: უნდა განსხვავდებოდეს %{count}-გან
+      present: უნდა იყოს ცარიელი
       required: უნდა არსებობდეს
       taken: უკვე დაკავებულია
       too_long:
@@ -135,13 +136,11 @@ ka:
       wrong_length:
         one: არის არასწორი სიგრძის (უნდა იყოს ზუსტად 1 სიბმოლო)
         other: არის არასწორი სიგრძის (უნდა იყოს ზუსტად %{count} სიბმოლო)
-      other_than: უნდა განსხვავდებოდეს %{count}-გან
     template:
       body: 'შეიქმნა პრობლემები შემდეგ ველებთან დაკავშირებით:'
       header:
         one: "%{model}-ს შენახვა ვერ განხორციელდა 1 შეცდომის გამო"
         other: "%{model}-ს შენახვა ვერ განხორციელდა %{count} შეცდომის გამო"
-
   helpers:
     select:
       prompt: გთხოვთ აირჩიოთ
@@ -158,7 +157,7 @@ ka:
         separator: ","
         significant: false
         strip_insignificant_zeros: false
-        unit: "ლ"
+        unit: ლ
     format:
       delimiter: " "
       precision: 3

--- a/rails/locale/km.yml
+++ b/rails/locale/km.yml
@@ -3,7 +3,7 @@ km:
   activerecord:
     errors:
       messages:
-        record_invalid: 'មិនមានសុពលភាព៖ %{errors}'
+        record_invalid: មិនមានសុពលភាព៖ %{errors}
         restrict_dependent_destroy:
           has_one: មិនអាចលុបបានទេពីព្រោះមាន %{record} នៅឡើយ
           has_many: មិនអាចលុបបានទេពីព្រោះមាន %{record} នៅឡើយ
@@ -17,7 +17,7 @@ km:
     - សុ
     - ស
     abbr_month_names:
-    -
+    - 
     - មករា
     - កុម្ភៈ
     - មិនា
@@ -39,11 +39,11 @@ km:
     - សុក្រ
     - សៅរ៍
     formats:
-      long: "ថ្ងៃ%A ទី%e ខែ%B ឆ្នាំ%Y"
       default: "%d %B %Y"
+      long: ថ្ងៃ%A ទី%e ខែ%B ឆ្នាំ%Y
       short: "%d %b"
     month_names:
-    -
+    - 
     - មករា
     - កុម្ភៈ
     - មិនា
@@ -62,31 +62,30 @@ km:
     - :year
   datetime:
     distance_in_words:
-      x_days: "%{count} ថ្ងៃ"
-      x_minutes: "%{count} នាទី"
-      x_months: "%{count} ខែ"
-      x_seconds: "%{count} វិនាទី"
       about_x_hours: ប្រមាណ %{count} ម៉ោង
       about_x_months: ប្រមាណ %{count} ខែ
       about_x_years: ប្រមាណ %{count} ឆ្នាំ
       almost_x_years: ជិត %{count} ឆ្នាំ
       half_a_minute: កន្លះនាទី
-      less_than_x_minutes: តិចជាង %{count} នាទី
       less_than_x_seconds: តិចជាង %{count} វិនាទី
+      less_than_x_minutes: តិចជាង %{count} នាទី
       over_x_years: លើសពី %{count} ឆ្នាំ
+      x_seconds: "%{count} វិនាទី"
+      x_minutes: "%{count} នាទី"
+      x_days: "%{count} ថ្ងៃ"
+      x_months: "%{count} ខែ"
     prompts:
-      day: ថ្ងៃ
-      hour: ម៉ោង
-      minute: នាទី
-      month: ខែ
       second: វិនាទី
+      minute: នាទី
+      hour: ម៉ោង
+      day: ថ្ងៃ
+      month: ខែ
       year: ឆ្នាំ
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: ត្រូវតែយល់ព្រម
       blank: មិនអាចរំលង
-      present: ត្រូវតែរំលង
       confirmation: ផ្ទៀងផ្ទាត់មិនត្រូវនឹង %{attribute}
       empty: មិនអាចរំលង
       equal_to: ត្រូវតែស្មើ %{count}
@@ -101,11 +100,12 @@ km:
       not_a_number: មិនមែនជាលេខទេ
       not_an_integer: ត្រូវតែជាចំនួនគត់
       odd: ត្រូវតែជាចំនួនសេស
+      other_than: ត្រូវតែខុសពី %{count}
+      present: ត្រូវតែរំលង
       taken: មានរួចហើយ
       too_long: វែងពេក (យ៉ាងច្រើន %{count} តួ)
       too_short: ខ្លីពេក (យ៉ាងតិច %{count} តួ)
       wrong_length: ប្រវែងមិនត្រូវ (គួរតែមាន %{count} តួ)
-      other_than: ត្រូវតែខុសពី %{count}
     template:
       body: 'សូមពិនិត្យមើលកំហុសនៅខាងក្រោម:'
       header: មានកំហុស %{count} ដែលបានបញ្ឈប់ការរក្សាទុក %{model}នេះ
@@ -125,7 +125,7 @@ km:
         separator: "."
         significant: false
         strip_insignificant_zeros: false
-        unit: ៛
+        unit: "៛"
     format:
       delimiter: ","
       precision: 3
@@ -164,4 +164,4 @@ km:
       default: "%a %d %b %Y %H:%M:%S %z"
       long: "%d %B %Y %H:%M"
       short: "%d %b %H:%M"
-    pm: ​ល្ងាច
+    pm: "​ល្ងាច"

--- a/rails/locale/kn.yml
+++ b/rails/locale/kn.yml
@@ -14,7 +14,7 @@ kn:
     - ಶುಕ್ರ
     - ಶನಿ
     abbr_month_names:
-    -
+    - 
     - Jan
     - Feb
     - Mar
@@ -40,7 +40,7 @@ kn:
       long: "%B %d, %Y"
       short: "%b %d"
     month_names:
-    -
+    - 
     - ಜನವರಿ
     - ಫೆಬ್ರವರಿ
     - ಮಾರ್ಚ್
@@ -72,33 +72,33 @@ kn:
         one: ಸರಿಸುಮಾರು ಒಂದು ವರುಷ
         other: ಸರಿಸುಮಾರು %{count} ವರುಷಗಳು
       half_a_minute: ಒಂದು ಅರ್ಧ ನಿಮಿಷ
-      less_than_x_minutes:
-        one: ಒಂದು ನಿಮಿಷಕ್ಕೂ ಕಡಿಮೆ
-        other: "%{count} ನಿಮಿಷಕ್ಕಿಂತ ಕಡಿಮೆ"
       less_than_x_seconds:
         one: ಒಂದು ಸೆಕೆಂಡಿಗೂ ಕಡಿಮೆ
         other: "%{count} ಸೆಕೆಂಡಿಗಿಂತ ಕಡಿಮೆ"
+      less_than_x_minutes:
+        one: ಒಂದು ನಿಮಿಷಕ್ಕೂ ಕಡಿಮೆ
+        other: "%{count} ನಿಮಿಷಕ್ಕಿಂತ ಕಡಿಮೆ"
       over_x_years:
         one: ಒಂದು ವರುಷಕ್ಕಿಂತ ಹೆಚ್ಚು
         other: "%{count} ವರುಷಗಳಿಗಿಂತ ಹೆಚ್ಚು"
-      x_days:
-        one: 1 ದಿನ
-        other: "%{count} ದಿನಗಳು"
-      x_minutes:
-        one: 1 ನಿಮಿಷ
-        other: "%{count} ನಿಮಿಷಗಳು"
-      x_months:
-        one: 1 ತಿಂಗಳು
-        other: "%{count} ತಿಂಗಳುಗಳು"
       x_seconds:
         one: 1 ಸೆಕೆಂಡ್
         other: "%{count} ಸೆಕೆಂಡುಗಳು"
+      x_minutes:
+        one: 1 ನಿಮಿಷ
+        other: "%{count} ನಿಮಿಷಗಳು"
+      x_days:
+        one: 1 ದಿನ
+        other: "%{count} ದಿನಗಳು"
+      x_months:
+        one: 1 ತಿಂಗಳು
+        other: "%{count} ತಿಂಗಳುಗಳು"
     prompts:
-      day: ದಿನ
-      hour: ಗಂಟೆ
-      minute: ನಿಮಿಷ
-      month: ತಿಂಗಳು
       second: ಸೆಕೆಂಡು
+      minute: ನಿಮಿಷ
+      hour: ಗಂಟೆ
+      day: ದಿನ
+      month: ತಿಂಗಳು
       year: ವರುಷ
   errors:
     format: "%{attribute} %{message}"

--- a/rails/locale/ko.yml
+++ b/rails/locale/ko.yml
@@ -17,7 +17,7 @@ ko:
     - 금
     - 토
     abbr_month_names:
-    -
+    - 
     - 1월
     - 2월
     - 3월
@@ -43,7 +43,7 @@ ko:
       long: "%Y년 %m월 %d일 (%a)"
       short: "%m/%d"
     month_names:
-    -
+    - 
     - 1월
     - 2월
     - 3월
@@ -75,43 +75,42 @@ ko:
         one: 일 년 이하
         other: "%{count}년 이하"
       half_a_minute: 30초
-      less_than_x_minutes:
-        one: 일 분 이하
-        other: "%{count}분 이하"
       less_than_x_seconds:
         one: 일 초 이하
         other: "%{count}초 이하"
+      less_than_x_minutes:
+        one: 일 분 이하
+        other: "%{count}분 이하"
       over_x_years:
         one: 일 년 이상
         other: "%{count}년 이상"
-      x_days:
-        one: 하루
-        other: "%{count}일"
+      x_seconds:
+        one: 일 초
+        other: "%{count}초"
       x_minutes:
         one: 일 분
         other: "%{count}분"
+      x_days:
+        one: 하루
+        other: "%{count}일"
       x_months:
         one: 한 달
         other: "%{count}달"
       x_years:
         one: 일 년
         other: "%{count}년"
-      x_seconds:
-        one: 일 초
-        other: "%{count}초"
     prompts:
-      day: 일
-      hour: 시
-      minute: 분
-      month: 월
       second: 초
+      minute: 분
+      hour: 시
+      day: 일
+      month: 월
       year: 년
   errors:
     format: "%{message}"
     messages:
       accepted: "%{attribute}을(를) 반드시 확인해야 합니다"
       blank: "%{attribute}에 내용을 입력해 주세요"
-      present: "%{attribute}은(는) 비어있어야 합니다"
       confirmation: "%{attribute}은(는) 서로 일치해야 합니다"
       empty: "%{attribute}에 내용을 입력해 주세요"
       equal_to: "%{attribute}은(는) %{count}과 같아야 합니다"
@@ -127,14 +126,15 @@ ko:
       not_a_number: "%{attribute}에 숫자를 입력해 주세요"
       not_an_integer: "%{attribute}에 정수를 입력해 주세요"
       odd: "%{attribute}에 홀수를 입력해 주세요"
+      other_than: "%{attribute}은(는) %{count}와(과) 달라야 합니다"
+      present: "%{attribute}은(는) 비어있어야 합니다"
       required: "%{attribute}은(는) 반드시 있어야 합니다"
       taken: "%{attribute}은(는) 이미 존재합니다"
       too_long: "%{attribute}은(는) %{count}자를 넘을 수 없습니다"
       too_short: "%{attribute}은(는) 적어도 %{count}자를 넘어야 합니다"
       wrong_length: "%{attribute}은(는) %{count}자여야 합니다"
-      other_than: "%{attribute}은(는) %{count}와(과) 달라야 합니다"
     template:
-      body: '아래 문제를 확인해 주세요.'
+      body: 아래 문제를 확인해 주세요.
       header:
         one: 한 개의 오류로 인해 %{model}을(를) 저장할 수 없습니다
         other: "%{count}개의 오류로 인해 %{model}을(를) 저장할 수 없습니다"

--- a/rails/locale/lb.yml
+++ b/rails/locale/lb.yml
@@ -1,11 +1,14 @@
+---
 lb:
   activerecord:
     errors:
       messages:
-        record_invalid: ! 'Validatioun feelgeschlo: %{errors}'
+        record_invalid: 'Validatioun feelgeschlo: %{errors}'
         restrict_dependent_destroy:
-          has_one: "Den Enregistrement kann net geläscht gi wëll et en dovun ofhängegt %{record} gëtt"
-          has_many: "Den Enregistrement kann net geläscht gi wëll et dovun ofhängegt %{record} gëtt"
+          has_one: Den Enregistrement kann net geläscht gi wëll et en dovun ofhängegt
+            %{record} gëtt
+          has_many: Den Enregistrement kann net geläscht gi wëll et dovun ofhängegt
+            %{record} gëtt
   date:
     abbr_day_names:
     - Son
@@ -16,7 +19,7 @@ lb:
     - Fre
     - Sam
     abbr_month_names:
-    -
+    - 
     - Jan
     - Feb
     - Mäe
@@ -38,11 +41,11 @@ lb:
     - Freideg
     - Samschdeg
     formats:
-      default: ! '%d.%m.%Y'
-      long: ! '%e. %B %Y'
-      short: ! '%e %b'
+      default: "%d.%m.%Y"
+      long: "%e. %B %Y"
+      short: "%e %b"
     month_names:
-    -
+    - 
     - Januar
     - Februar
     - Mäerz
@@ -74,41 +77,40 @@ lb:
         one: bal ee Joer
         other: bal %{count} Joer
       half_a_minute: eng hallef Minutt
-      less_than_x_minutes:
-        one: manner wéi eng Minutt
-        other: manner wéi %{count} Minutten
       less_than_x_seconds:
         one: manner wéi eng Sekonn
         other: manner wéi %{count} Sekonnen
+      less_than_x_minutes:
+        one: manner wéi eng Minutt
+        other: manner wéi %{count} Minutten
       over_x_years:
         one: méi wéi ee Joer
         other: méi wéi %{count} Joer
-      x_days:
-        one: 1 Dag
-        other: ! '%{count} Deeg'
-      x_minutes:
-        one: 1 Minutt
-        other: ! '%{count} Minutten'
-      x_months:
-        one: 1 Mount
-        other: ! '%{count} Méint'
       x_seconds:
         one: 1 Sekonn
-        other: ! '%{count} Sekonnen'
+        other: "%{count} Sekonnen"
+      x_minutes:
+        one: 1 Minutt
+        other: "%{count} Minutten"
+      x_days:
+        one: 1 Dag
+        other: "%{count} Deeg"
+      x_months:
+        one: 1 Mount
+        other: "%{count} Méint"
     prompts:
-      day: Dag
-      hour: Stonn
-      minute: Minutt
-      month: Mount
       second: Sekonnen
+      minute: Minutt
+      hour: Stonn
+      day: Dag
+      month: Mount
       year: Joer
   errors:
-    format: ! '%{attribute} %{message}'
+    format: "%{attribute} %{message}"
     messages:
       accepted: muss akzeptéiert ginn
       blank: däerf net eidel sinn
-      present: muss eidel sinn
-      confirmation: ! "stëmmt net mat %{attribute} iwwerenee"
+      confirmation: stëmmt net mat %{attribute} iwwerenee
       empty: däerf net eidel sinn
       equal_to: muss d'selwecht si wéi %{count}
       even: muss gerued sinn
@@ -122,6 +124,8 @@ lb:
       not_a_number: ass keng Zuel
       not_an_integer: muss eng ganz Zuel sinn
       odd: muss ongerued sinn
+      other_than: muss anescht si wéi %{count}
+      present: muss eidel sinn
       taken: gouf scho geholl
       too_long:
         one: ass ze laang (Maximal 1 Zeechen)
@@ -132,12 +136,11 @@ lb:
       wrong_length:
         one: huet déi falsch Längt (muss genee een Zeeche sinn)
         other: huet déi falsch Längt (musse genee %{count} Zeeche sinn)
-      other_than: "muss anescht si wéi %{count}"
     template:
-      body: ! 'Et gouf Problemer mat dëse Felder:'
+      body: 'Et gouf Problemer mat dëse Felder:'
       header:
         one: 1 Feeler verhënnert d'Späichere vu(n) %{model}
-        other: ! '%{count} Feeler verhënneren d''Späichere vu(n) %{model}'
+        other: "%{count} Feeler verhënneren d'Späichere vu(n) %{model}"
   helpers:
     select:
       prompt: Sicht w.e.g. eraus
@@ -148,22 +151,22 @@ lb:
   number:
     currency:
       format:
-        delimiter: ! ','
-        format: ! '%n %u'
+        delimiter: ","
+        format: "%n %u"
         precision: 2
-        separator: .
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
-        unit: €
+        unit: "€"
     format:
-      delimiter: ! ','
+      delimiter: ","
       precision: 2
-      separator: .
+      separator: "."
       significant: false
       strip_insignificant_zeros: false
     human:
       decimal_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           billion: Milliard
           million: Millioun
@@ -179,7 +182,7 @@ lb:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: ! '%n %u'
+        format: "%n %u"
         units:
           byte:
             one: Byte
@@ -197,13 +200,13 @@ lb:
         delimiter: ''
   support:
     array:
-      last_word_connector: ! ', an '
-      two_words_connector: ! ' an '
-      words_connector: ! ', '
+      last_word_connector: ", an "
+      two_words_connector: " an "
+      words_connector: ", "
   time:
     am: moies
     formats:
-      default: ! '%A, %d. %B %Y, %H:%M Auer'
-      long: ! '%A, %d. %B %Y, %H:%M Auer'
-      short: ! '%d. %b %H:%M'
+      default: "%A, %d. %B %Y, %H:%M Auer"
+      long: "%A, %d. %B %Y, %H:%M Auer"
+      short: "%d. %b %H:%M"
     pm: mëttes

--- a/rails/locale/lo.yml
+++ b/rails/locale/lo.yml
@@ -14,7 +14,7 @@ lo:
     - ສຸກ
     - ເສົາ
     abbr_month_names:
-    -
+    - 
     - ມ.ກ
     - ກ.ພ
     - ມ.ນ
@@ -40,7 +40,7 @@ lo:
       long: "%e %B %Y"
       short: "%e %b"
     month_names:
-    -
+    - 
     - ມັງກອນ
     - ກຸມພາ
     - ມີນາ
@@ -88,13 +88,6 @@ lo:
         many: 'ເກືອບ %{count} ປີ '
         other: 'ເກືອບ %{count} ປີ '
       half_a_minute: 'ເຄິ່ງນາທີ '
-      less_than_x_minutes:
-        zero: 'ນ້ອຍກວ່າ %{count} ນາທີ '
-        one: 'ນ້ອຍກວ່າ 1 ນາທີ '
-        two: 'ນ້ອຍກວ່າ %{count} ນາທີ '
-        few: 'ນ້ອຍກວ່າ %{count} ນາທີ '
-        many: 'ນ້ອຍກວ່າ %{count} ນາທີ '
-        other: 'ນ້ອຍກວ່າ %{count} ນາທີ '
       less_than_x_seconds:
         zero: 'ນ້ອຍກວ່າ %{count} ວິນາທີ '
         one: 'ນ້ອຍກວ່າ 1 ວິນາທີ '
@@ -102,6 +95,13 @@ lo:
         few: 'ນ້ອຍກວ່າ %{count} ວິນາທີ '
         many: 'ນ້ອຍກວ່າ %{count} ວິນາທີ '
         other: 'ນ້ອຍກວ່າ %{count} ວິນາທີ '
+      less_than_x_minutes:
+        zero: 'ນ້ອຍກວ່າ %{count} ນາທີ '
+        one: 'ນ້ອຍກວ່າ 1 ນາທີ '
+        two: 'ນ້ອຍກວ່າ %{count} ນາທີ '
+        few: 'ນ້ອຍກວ່າ %{count} ນາທີ '
+        many: 'ນ້ອຍກວ່າ %{count} ນາທີ '
+        other: 'ນ້ອຍກວ່າ %{count} ນາທີ '
       over_x_years:
         zero: 'ຫຼາຍກວ່າ %{count} ປີ '
         one: 'ຫຼາຍກວ່າ 1 ປີ '
@@ -109,27 +109,6 @@ lo:
         few: 'ຫຼາຍກວ່າ %{count} ປີ '
         many: 'ຫຼາຍກວ່າ %{count} ປີ '
         other: 'ຫຼາຍກວ່າ %{count} ປີ '
-      x_days:
-        zero: "%{count} ມື້ "
-        one: '1 ມື້ '
-        two: "%{count} ມື້ "
-        few: "%{count} ມື້ "
-        many: "%{count} ມື້ "
-        other: "%{count} ມື້ "
-      x_minutes:
-        zero: "%{count} ນາທີ "
-        one: '1 ນາທີ '
-        two: "%{count} ນາທີ "
-        few: "%{count} ນາທີ "
-        many: "%{count} ນາທີ "
-        other: "%{count} ນາທີ "
-      x_months:
-        zero: "%{count} ເດືອນ"
-        one: 1 ເດືອນ
-        two: "%{count} ເດືອນ"
-        few: "%{count} ເດືອນ"
-        many: "%{count} ເດືອນ"
-        other: "%{count} ເດືອນ"
       x_seconds:
         zero: "%{count} ວິນາທີ "
         one: '1 ວິນາທີ '
@@ -137,12 +116,33 @@ lo:
         few: "%{count} ວິນາທີ "
         many: "%{count} ວິນາທີ "
         other: "%{count} ວິນາທີ "
+      x_minutes:
+        zero: "%{count} ນາທີ "
+        one: '1 ນາທີ '
+        two: "%{count} ນາທີ "
+        few: "%{count} ນາທີ "
+        many: "%{count} ນາທີ "
+        other: "%{count} ນາທີ "
+      x_days:
+        zero: "%{count} ມື້ "
+        one: '1 ມື້ '
+        two: "%{count} ມື້ "
+        few: "%{count} ມື້ "
+        many: "%{count} ມື້ "
+        other: "%{count} ມື້ "
+      x_months:
+        zero: "%{count} ເດືອນ"
+        one: 1 ເດືອນ
+        two: "%{count} ເດືອນ"
+        few: "%{count} ເດືອນ"
+        many: "%{count} ເດືອນ"
+        other: "%{count} ເດືອນ"
     prompts:
-      day: ວັນ
-      hour: ຊົ່ວໂມງ
-      minute: ນາທີ
-      month: ເດືອນ
       second: ວິນາທີ
+      minute: ນາທີ
+      hour: ຊົ່ວໂມງ
+      day: ວັນ
+      month: ເດືອນ
       year: ປີ
   errors:
     format: "%{attribute} %{message}"
@@ -230,9 +230,9 @@ lo:
       two_words_connector: 'ແລະ '
       words_connector: ", "
   time:
-    am: 'ເຊົ້າ'
+    am: ເຊົ້າ
     formats:
       default: "%a %d %b %Y %H:%M:%S %z"
       long: "%d %B %Y %H:%M น."
       short: "%d %b %H:%M น."
-    pm: 'ແລງ'
+    pm: ແລງ

--- a/rails/locale/lt.yml
+++ b/rails/locale/lt.yml
@@ -17,7 +17,7 @@ lt:
     - Pen
     - Šeš
     abbr_month_names:
-    -
+    - 
     - Sau
     - Vas
     - Kov
@@ -43,7 +43,7 @@ lt:
       long: "%B %d, %Y"
       short: "%b %d"
     month_names:
-    -
+    - 
     - sausio
     - vasario
     - kovo
@@ -79,47 +79,46 @@ lt:
         few: beveik %{count} metai
         other: beveik %{count} metų
       half_a_minute: pusė minutės
-      less_than_x_minutes:
-        one: mažiau nei %{count} minutė
-        few: mažiau nei %{count} minutės
-        other: mažiau nei %{count} minučių
       less_than_x_seconds:
         one: mažiau nei %{count} sekundė
         few: mažiau nei %{count} sekundės
         other: mažiau nei %{count} sekundžių
+      less_than_x_minutes:
+        one: mažiau nei %{count} minutė
+        few: mažiau nei %{count} minutės
+        other: mažiau nei %{count} minučių
       over_x_years:
         one: virš %{count} metų
         few: virš %{count} metų
         other: virš %{count} metų
-      x_days:
-        one: "%{count} diena"
-        few: "%{count} dienos"
-        other: "%{count} dienų"
-      x_minutes:
-        one: "%{count} minutė"
-        few: "%{count} minutės"
-        other: "%{count} minučių"
-      x_months:
-        one: "%{count} mėnesis"
-        few: "%{count} mėnesiai"
-        other: "%{count} mėnesių"
       x_seconds:
         one: "%{count} sekundė"
         few: "%{count} sekundės"
         other: "%{count} sekundžių"
+      x_minutes:
+        one: "%{count} minutė"
+        few: "%{count} minutės"
+        other: "%{count} minučių"
+      x_days:
+        one: "%{count} diena"
+        few: "%{count} dienos"
+        other: "%{count} dienų"
+      x_months:
+        one: "%{count} mėnesis"
+        few: "%{count} mėnesiai"
+        other: "%{count} mėnesių"
     prompts:
-      day: Diena
-      hour: Valanda
-      minute: Minutė
-      month: Mėnuo
       second: Sekundės
+      minute: Minutė
+      hour: Valanda
+      day: Diena
+      month: Mėnuo
       year: Metai
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: turi būti patvirtintas
       blank: negali būti tuščias
-      present: turi būti tuščias
       confirmation: neteisingai pakartotas
       empty: negali būti tuščias
       equal_to: turi būti lygus %{count}
@@ -134,6 +133,8 @@ lt:
       not_a_number: ne skaičius
       not_an_integer: privalo būti sveikas skaičius
       odd: turi būti nelyginis
+      other_than: privalo būti kitoks nei %{count}
+      present: turi būti tuščias
       taken: jau užimtas
       too_long:
         one: per ilgas (daugiausiai %{count} simbolis)
@@ -144,7 +145,6 @@ lt:
         few: per trumpas (mažiausiai %{count} simboliai)
         other: per trumpas (mažiausiai %{count} simbolių)
       wrong_length: neteisingo ilgio (turi būti %{count} simboliai)
-      other_than: privalo būti kitoks nei %{count}
     template:
       body: 'Šiuose laukuose yra klaidų:'
       header:

--- a/rails/locale/lv.yml
+++ b/rails/locale/lv.yml
@@ -14,7 +14,7 @@ lv:
     - Pk.
     - S.
     abbr_month_names:
-    -
+    - 
     - Janv
     - Febr
     - Marts
@@ -40,7 +40,7 @@ lv:
       long: "%Y. gada %e. %B"
       short: "%e. %B"
     month_names:
-    -
+    - 
     - Janvāris
     - Februāris
     - Marts
@@ -76,40 +76,40 @@ lv:
         one: gandrīz %{count} gads
         other: gandrīz %{count} gadi
       half_a_minute: pusminūte
-      less_than_x_minutes:
-        zero: mazāk par %{count} minūtēm
-        one: mazāk par %{count} minūti
-        other: mazāk par %{count} minūtēm
       less_than_x_seconds:
         zero: mazāk par %{count} sekundēm
         one: mazāk par %{count} sekundi
         other: mazāk par %{count} sekundēm
+      less_than_x_minutes:
+        zero: mazāk par %{count} minūtēm
+        one: mazāk par %{count} minūti
+        other: mazāk par %{count} minūtēm
       over_x_years:
         zero: vairāk kā %{count} gadi
         one: vairāk kā %{count} gads
         other: vairāk kā %{count} gadi
-      x_days:
-        zero: "%{count} dienas"
-        one: "%{count} diena"
-        other: "%{count} dienas"
-      x_minutes:
-        zero: "%{count} minūtes"
-        one: "%{count} minūte"
-        other: "%{count} minūtes"
-      x_months:
-        zero: "%{count} mēneši"
-        one: "%{count} mēnesis"
-        other: "%{count} mēneši"
       x_seconds:
         zero: "%{count} sekundes"
         one: "%{count} sekunde"
         other: "%{count} sekundes"
+      x_minutes:
+        zero: "%{count} minūtes"
+        one: "%{count} minūte"
+        other: "%{count} minūtes"
+      x_days:
+        zero: "%{count} dienas"
+        one: "%{count} diena"
+        other: "%{count} dienas"
+      x_months:
+        zero: "%{count} mēneši"
+        one: "%{count} mēnesis"
+        other: "%{count} mēneši"
     prompts:
-      day: diena
-      hour: stunda
-      minute: minūte
-      month: mēnesis
       second: sekunde
+      minute: minūte
+      hour: stunda
+      day: diena
+      month: mēnesis
       year: gads
   errors:
     format: "%{attribute} %{message}"

--- a/rails/locale/mk.yml
+++ b/rails/locale/mk.yml
@@ -14,7 +14,7 @@ mk:
     - Пет
     - Саб
     abbr_month_names:
-    -
+    - 
     - Јан
     - Фев
     - Мар
@@ -40,7 +40,7 @@ mk:
       long: "%B %e, %Y"
       short: "%e %b"
     month_names:
-    -
+    - 
     - Јануари
     - Февруари
     - Март
@@ -72,33 +72,33 @@ mk:
         one: скоро %{count} година
         other: скоро %{count} години
       half_a_minute: пола минута
-      less_than_x_minutes:
-        one: помалку од %{count} минута
-        other: помалку од %{count} минути
       less_than_x_seconds:
         one: помалку од %{count} секунда
         other: помалку од %{count} секунди
+      less_than_x_minutes:
+        one: помалку од %{count} минута
+        other: помалку од %{count} минути
       over_x_years:
         one: над %{count} година
         other: над %{count} години
-      x_days:
-        one: "%{count} ден"
-        other: "%{count} денови"
-      x_minutes:
-        one: "%{count} минута"
-        other: "%{count} минути"
-      x_months:
-        one: "%{count} месец"
-        other: "%{count} месеци"
       x_seconds:
         one: "%{count} секунда"
         other: "%{count} секунди"
+      x_minutes:
+        one: "%{count} минута"
+        other: "%{count} минути"
+      x_days:
+        one: "%{count} ден"
+        other: "%{count} денови"
+      x_months:
+        one: "%{count} месец"
+        other: "%{count} месеци"
     prompts:
-      day: Ден
-      hour: Час
-      minute: Минута
-      month: Месец
       second: Секунди
+      minute: Минута
+      hour: Час
+      day: Ден
+      month: Месец
       year: Година
   errors:
     format: "%{attribute} %{message}"

--- a/rails/locale/ml.yml
+++ b/rails/locale/ml.yml
@@ -3,7 +3,7 @@ ml:
   activerecord:
     errors:
       messages:
-        record_invalid: "Validation failed: %{errors}"
+        record_invalid: 'Validation failed: %{errors}'
         restrict_dependent_destroy:
           has_one: "%{record} ആയി ബന്ദം ഉള്ളതിനാൽ നീക്കം ചെയ്യാൻ പറ്റില്ല"
           has_many: "%{record} ആയി ബന്ദം ഉള്ളതിനാൽ നീക്കം ചെയ്യാൻ പറ്റില്ല"
@@ -17,7 +17,7 @@ ml:
     - വെ.
     - ശ.
     abbr_month_names:
-    -
+    - 
     - ജനു.
     - ഫെബ്ര.
     - മാർ.
@@ -43,7 +43,7 @@ ml:
       long: "%d %B, %Y"
       short: "%b %d"
     month_names:
-    -
+    - 
     - ജനുവരി
     - ഫെബ്രുവരി
     - മാർച്ച്
@@ -64,51 +64,50 @@ ml:
     distance_in_words:
       about_x_hours:
         one: എകദേശം 1 മണിക്കൂർ
-        other: "എകദേശം %{count} മണിക്കൂർ"
+        other: എകദേശം %{count} മണിക്കൂർ
       about_x_months:
         one: എകദേശം 1 മാസം
-        other: "എകദേശം %{count} മാസം"
+        other: എകദേശം %{count} മാസം
       about_x_years:
         one: എകദേശം 1 വർഷം
-        other: "എകദേശം %{count} വർഷം"
+        other: എകദേശം %{count} വർഷം
       almost_x_years:
         one: ഏതാണ്ട്  1 വർഷം
-        other: "ഏതാണ്ട്  %{count} വർഷം"
+        other: ഏതാണ്ട്  %{count} വർഷം
       half_a_minute: അര സൂക്ഷ്മ
-      less_than_x_minutes:
-        one: ഒരു മിനുറ്റിനു ഉള്ളിൽ
-        other: "%{count} മിനുറ്റിനു ഉള്ളിൽ"
       less_than_x_seconds:
         one: ഒരു നിമിഷത്തിനു ഉള്ളിൽ
         other: "%{count} നിമിഷത്തിനു ഉള്ളിൽ"
+      less_than_x_minutes:
+        one: ഒരു മിനുറ്റിനു ഉള്ളിൽ
+        other: "%{count} മിനുറ്റിനു ഉള്ളിൽ"
       over_x_years:
         one: ഒരു വര്ഷത്തിനു മേലെ
         other: "%{count} വര്ഷത്തിനു മേലെ"
-      x_days:
-        one: 1 ദിവസം
-        other: "%{count} ദിവസങ്ങൾ"
-      x_minutes:
-        one: 1 മിനിറ്റ്
-        other: "%{count} മിനിറ്റ്"
-      x_months:
-        one: 1 മാസം
-        other: "%{count} മാസം"
       x_seconds:
         one: 1 നിമിഷം
         other: "%{count} നിമിഷം"
+      x_minutes:
+        one: 1 മിനിറ്റ്
+        other: "%{count} മിനിറ്റ്"
+      x_days:
+        one: 1 ദിവസം
+        other: "%{count} ദിവസങ്ങൾ"
+      x_months:
+        one: 1 മാസം
+        other: "%{count} മാസം"
     prompts:
-      day: ദിവസം
-      hour: മണിക്കൂർ
-      minute: സുക്ഷ്മ
-      month: സുക്ഷ്മ
       second: നിമിഷം
+      minute: സുക്ഷ്മ
+      hour: മണിക്കൂർ
+      day: ദിവസം
+      month: സുക്ഷ്മ
       year: വർഷം
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: സ്വീകരികേണ്ടത്  അത്യാവശ്യം ആണ്
       blank: ഒഴിവായി കിടക്കുവാൻ പാടുള്ളതല്ല
-      present: ഒഴിവായി ഇരിക്കണം
       confirmation: "%{attribute} ആയി സാമ്യം ഇല്ല"
       empty: ഒഴിവായി കിടക്കുവാൻ പാടുള്ളതല്ല
       equal_to: "%{count} ആയി സാമ്യം വേണം"
@@ -120,22 +119,23 @@ ml:
       invalid: അസാധുവാണ്
       less_than: "%{count} നേകാൾ ചെറുതായിരിക്കണം"
       less_than_or_equal_to: "%{count} നു തുല്യമോ അല്ലെങ്കിൽ ചെറുതോ ആയിരിക്കണം"
-      model_invalid: "മൂല്യനിർണ്ണയം പരാജയപ്പെട്ടു: %{errors}"
+      model_invalid: 'മൂല്യനിർണ്ണയം പരാജയപ്പെട്ടു: %{errors}'
       not_a_number: ഒരു അക്കം അല്ല
       not_an_integer: ഒരു അക്കം ആയിരിക്കണം
       odd: ഒട്ടസന്ഘ്യ ആയിരിക്കണം
+      other_than: must be other than %{count}
+      present: ഒഴിവായി ഇരിക്കണം
       required: എന്തായാലും ഉണ്ടായിരിക്കണം
       taken: ഇതിനു മുൻപേ ഉപയോഗിച്ചിരിക്കുന്നു
       too_long:
         one: വളരെ വലുതാണ് (പരമാവധി 1 പ്രതീകം)
-        other: "വളരെ വലുതാണ് (പരമാവധി %{count} പ്രതീകങ്ങൾ)"
+        other: വളരെ വലുതാണ് (പരമാവധി %{count} പ്രതീകങ്ങൾ)
       too_short:
         one: വളരെ ചെറുതാണ് (ഏറ്റവും കുറഞ്ഞത്‌  1 പ്രതീകം)
-        other: "വളരെ ചെറുതാണ് (ഏറ്റവും കുറഞ്ഞത്‌ %{count} പ്രതീകങ്ങൾ)"
+        other: വളരെ ചെറുതാണ് (ഏറ്റവും കുറഞ്ഞത്‌ %{count} പ്രതീകങ്ങൾ)
       wrong_length:
         one: തെറ്റായ നീളം ആണ്  (1 പ്രതീകം ആയിരിക്കണം)
-        other: "തെറ്റായ നീളം ആണ്  (%{count} പ്രതീകങ്ങൾ ആയിരിക്കണം)"
-      other_than: "must be other than %{count}"
+        other: തെറ്റായ നീളം ആണ്  (%{count} പ്രതീകങ്ങൾ ആയിരിക്കണം)
     template:
       body: 'താഴെ പറഞ്ഞവയിൽ തെറ്റുകൾ ഉണ്ട്:'
       header:

--- a/rails/locale/mn.yml
+++ b/rails/locale/mn.yml
@@ -14,7 +14,7 @@ mn:
     - Ба
     - Бя
     abbr_month_names:
-    -
+    - 
     - 1 сар
     - 2 сар
     - 3 сар
@@ -40,7 +40,7 @@ mn:
       long: "%Y %B %d"
       short: "%y-%m-%d"
     month_names:
-    -
+    - 
     - 1 сар
     - 2 сар
     - 3 сар
@@ -72,33 +72,33 @@ mn:
         one: бараг 1 жил
         other: бараг %{count} жил
       half_a_minute: хагас минут
-      less_than_x_minutes:
-        one: 1 минутаас бага
-        other: "%{count} минутаас бага"
       less_than_x_seconds:
         one: 1 секундээс бага
         other: "%{count} секундээс бага"
+      less_than_x_minutes:
+        one: 1 минутаас бага
+        other: "%{count} минутаас бага"
       over_x_years:
         one: 1 жилээс илүү
         other: "%{count} жилээс илүү"
-      x_days:
-        one: 1 өдөр
-        other: "%{count} өдөр"
-      x_minutes:
-        one: 1 минут
-        other: "%{count} минут"
-      x_months:
-        one: 1 сар
-        other: "%{count} сар"
       x_seconds:
         one: 1 секунд
         other: "%{count} секунд"
+      x_minutes:
+        one: 1 минут
+        other: "%{count} минут"
+      x_days:
+        one: 1 өдөр
+        other: "%{count} өдөр"
+      x_months:
+        one: 1 сар
+        other: "%{count} сар"
     prompts:
-      day: Өдөр
-      hour: Цаг
-      minute: Минут
-      month: Сар
       second: Секунд
+      minute: Минут
+      hour: Цаг
+      day: Өдөр
+      month: Сар
       year: Жил
   errors:
     format: "%{attribute} %{message}"

--- a/rails/locale/mr-IN.yml
+++ b/rails/locale/mr-IN.yml
@@ -17,7 +17,7 @@ mr-IN:
     - शनि
     - रवि
     abbr_month_names:
-    -
+    - 
     - जाने
     - फेब्रु
     - मार्च
@@ -43,7 +43,7 @@ mr-IN:
       long: "%B %d, %Y"
       short: "%b %d"
     month_names:
-    -
+    - 
     - जानेवारी
     - फेब्रुवारी
     - मार्च
@@ -75,40 +75,39 @@ mr-IN:
         one: जवळजवळ एक वर्ष
         other: जवळजवळ %{count} वर्ष
       half_a_minute: अर्धा मिनिट
-      less_than_x_minutes:
-        one: एका मिनिटापेक्षा कमी
-        other: "%{count} मिनिटापेक्षा कमी"
       less_than_x_seconds:
         one: एक सेकंद पेक्षा कमी
         other: "%{count} सेकंद पेक्षा कमी"
+      less_than_x_minutes:
+        one: एका मिनिटापेक्षा कमी
+        other: "%{count} मिनिटापेक्षा कमी"
       over_x_years:
         one: एका वर्षापेक्षा जास्त काळ
         other: "%{count} वर्षापेक्षा जास्त काळ"
-      x_days:
-        one: एक दिवस
-        other: "%{count} दिवस"
-      x_minutes:
-        one: एक मिनिट
-        other: "%{count} मिनिट"
-      x_months:
-        one: एक महिना
-        other: "%{count} महिना"
       x_seconds:
         one: एक सेकंद
         other: "%{count} सेकंद"
+      x_minutes:
+        one: एक मिनिट
+        other: "%{count} मिनिट"
+      x_days:
+        one: एक दिवस
+        other: "%{count} दिवस"
+      x_months:
+        one: एक महिना
+        other: "%{count} महिना"
     prompts:
-      day: दिवस
-      hour: तास
-      minute: मिनिट
-      month: महिना
       second: सेकंद
+      minute: मिनिट
+      hour: तास
+      day: दिवस
+      month: महिना
       year: वर्ष
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: मान्य केले पाहिजे
       blank: रिक्त ठेवता येणार नाही
-      present: रिक्त असणे आवश्यक आहे
       confirmation: "%{attribute} जुळत नाही"
       empty: रिक्त असू शकत नाही
       equal_to: "%{count} समान असणे आवश्यक"
@@ -123,6 +122,8 @@ mr-IN:
       not_a_number: क्रमांक नाही
       not_an_integer: पूर्णांक असणे आवश्यक आहे
       odd: विषम संख्या असणे आवश्यक आहे
+      other_than: "%{count} पेक्षा इतर असणे आवश्यक आहे"
+      present: रिक्त असणे आवश्यक आहे
       taken: यापूर्वीच घेतले गेले आहे
       too_long:
         one: खूप लांब आहे (जास्तीत जास्त एक वर्ण परवानगी आहे)
@@ -133,7 +134,6 @@ mr-IN:
       wrong_length:
         one: लांबी चुक आहे (एक वर्ण असणे आवश्यक आहे)
         other: लांबी चुक आहे (%{count} वर्ण असणे आवश्यक आहे)
-      other_than: "%{count} पेक्षा इतर असणे आवश्यक आहे"
     template:
       body: 'खालील फील्ड सह समस्या होते:'
       header:

--- a/rails/locale/ms.yml
+++ b/rails/locale/ms.yml
@@ -14,7 +14,7 @@ ms:
     - Jum
     - Sab
     abbr_month_names:
-    -
+    - 
     - Jan
     - Feb
     - Mac
@@ -40,7 +40,7 @@ ms:
       long: "%d %B, %Y"
       short: "%d %b"
     month_names:
-    -
+    - 
     - Januari
     - Febuari
     - Mac
@@ -72,33 +72,33 @@ ms:
         one: hampir 1 tahun
         other: hampir %{count} tahun
       half_a_minute: setengah minit
-      less_than_x_minutes:
-        one: kurang dari satu minit
-        other: kurang dari %{count} minit
       less_than_x_seconds:
         one: kurang dari satu saat
         other: kurang dari %{count} saat
+      less_than_x_minutes:
+        one: kurang dari satu minit
+        other: kurang dari %{count} minit
       over_x_years:
         one: lebih 1 tahun
         other: lebih %{count} tahun
-      x_days:
-        one: 1 hari
-        other: "%{count} hari"
-      x_minutes:
-        one: 1 minit
-        other: "%{count} minit"
-      x_months:
-        one: 1 bulan
-        other: "%{count} bulan"
       x_seconds:
         one: 1 saat
         other: "%{count} saat"
+      x_minutes:
+        one: 1 minit
+        other: "%{count} minit"
+      x_days:
+        one: 1 hari
+        other: "%{count} hari"
+      x_months:
+        one: 1 bulan
+        other: "%{count} bulan"
     prompts:
-      day: Hari
-      hour: Jam
-      minute: Minit
-      month: Bulan
       second: Saat
+      minute: Minit
+      hour: Jam
+      day: Hari
+      month: Bulan
       year: Tahun
   errors:
     format: "%{attribute} %{message}"

--- a/rails/locale/nb.yml
+++ b/rails/locale/nb.yml
@@ -17,7 +17,7 @@ nb:
     - fre
     - lør
     abbr_month_names:
-    -
+    - 
     - jan
     - feb
     - mar
@@ -43,7 +43,7 @@ nb:
       long: "%e. %B %Y"
       short: "%e. %b"
     month_names:
-    -
+    - 
     - januar
     - februar
     - mars
@@ -75,43 +75,42 @@ nb:
         one: nesten 1 år
         other: nesten %{count} år
       half_a_minute: et halvt minutt
-      less_than_x_minutes:
-        one: mindre enn 1 minutt
-        other: mindre enn %{count} minutter
       less_than_x_seconds:
         one: mindre enn 1 sekund
         other: mindre enn %{count} sekunder
+      less_than_x_minutes:
+        one: mindre enn 1 minutt
+        other: mindre enn %{count} minutter
       over_x_years:
         one: over 1 år
         other: over %{count} år
-      x_days:
-        one: 1 dag
-        other: "%{count} dager"
+      x_seconds:
+        one: 1 sekund
+        other: "%{count} sekunder"
       x_minutes:
         one: 1 minutt
         other: "%{count} minutter"
+      x_days:
+        one: 1 dag
+        other: "%{count} dager"
       x_months:
         one: 1 måned
         other: "%{count} måneder"
       x_years:
         one: 1 år
         other: "%{count} år"
-      x_seconds:
-        one: 1 sekund
-        other: "%{count} sekunder"
     prompts:
-      day: dag
-      hour: time
-      minute: minutt
-      month: måned
       second: sekund
+      minute: minutt
+      hour: time
+      day: dag
+      month: måned
       year: år
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: må være akseptert
       blank: kan ikke være blank
-      present: må være blank
       confirmation: er ikke lik %{attribute}
       empty: kan ikke være tom
       equal_to: må være lik %{count}
@@ -123,16 +122,17 @@ nb:
       invalid: er ugyldig
       less_than: må være mindre enn %{count}
       less_than_or_equal_to: må være mindre enn eller lik %{count}
-      model_invalid: "Det oppstod feil: %{errors}"
+      model_invalid: 'Det oppstod feil: %{errors}'
       not_a_number: er ikke et tall
       not_an_integer: er ikke et heltall
       odd: må være oddetall
+      other_than: kan ikke være nøyaktig %{count}
+      present: må være blank
       required: må eksistere
       taken: er allerede i bruk
       too_long: er for lang (maksimum %{count} tegn)
       too_short: er for kort (minimum %{count} tegn)
       wrong_length: er av feil lengde (maksimum %{count} tegn)
-      other_than: kan ikke være nøyaktig %{count}
     template:
       body: 'Det oppstod problemer med følgende felt:'
       header:

--- a/rails/locale/ne.yml
+++ b/rails/locale/ne.yml
@@ -5,8 +5,8 @@ ne:
       messages:
         record_invalid: 'मान्य भएन: %{errors}'
         restrict_dependent_destroy:
-          has_one: "रेकर्ड मेटाउन सक्दैन किनभने एउटा निर्भर %{record} अवस्थित छ"
-          has_many: "रेकर्ड मेटाउन सक्दैन किनभने धेरै निर्भर %{record} अवस्थित छन"
+          has_one: रेकर्ड मेटाउन सक्दैन किनभने एउटा निर्भर %{record} अवस्थित छ
+          has_many: रेकर्ड मेटाउन सक्दैन किनभने धेरै निर्भर %{record} अवस्थित छन
   date:
     abbr_day_names:
     - आईत
@@ -17,7 +17,7 @@ ne:
     - शुक्र
     - शनि
     abbr_month_names:
-    -
+    - 
     - जन.
     - फेब्रु.
     - मार्च
@@ -43,7 +43,7 @@ ne:
       long: "%B %d, %Y"
       short: "%b %d"
     month_names:
-    -
+    - 
     - जनवरी
     - फेब्रुवरी
     - मार्च
@@ -75,33 +75,33 @@ ne:
         one: झण्डै 1 बर्ष
         other: झण्डै %{count} बर्ष
       half_a_minute: आधा मिनेट
-      less_than_x_minutes:
-        one: 1 मिनेटभन्दा कम्ति
-        other: "%{count} मिनेटभन्दा कम्ति"
       less_than_x_seconds:
         one: 1 सेकेण्डभन्दा कम्ति
         other: "%{count} सेकेण्डभन्दा कम्ति"
+      less_than_x_minutes:
+        one: 1 मिनेटभन्दा कम्ति
+        other: "%{count} मिनेटभन्दा कम्ति"
       over_x_years:
         one: 1 बर्षभन्दा बढी
         other: "%{count} बर्षभन्दा बेसी"
-      x_days:
-        one: 1 दिन
-        other: "%{count} दिन"
-      x_minutes:
-        one: 1 मिनेट
-        other: "%{count} मिनेट"
-      x_months:
-        one: 1 महिना
-        other: "%{count} महिना"
       x_seconds:
         one: 1 सेकेण्ड
         other: "%{count} सेकेण्ड"
+      x_minutes:
+        one: 1 मिनेट
+        other: "%{count} मिनेट"
+      x_days:
+        one: 1 दिन
+        other: "%{count} दिन"
+      x_months:
+        one: 1 महिना
+        other: "%{count} महिना"
     prompts:
-      day: दिन
-      hour: घण्टा
-      minute: मिनेट
-      month: महिना
       second: सेकेण्ड
+      minute: मिनेट
+      hour: घण्टा
+      day: दिन
+      month: महिना
       year: बर्ष
   errors:
     format: "%{attribute} %{message}"
@@ -153,7 +153,7 @@ ne:
         separator: "."
         significant: false
         strip_insignificant_zeros: false
-        unit: "रू"
+        unit: रू
     format:
       delimiter: ","
       precision: 3

--- a/rails/locale/nl.yml
+++ b/rails/locale/nl.yml
@@ -17,7 +17,7 @@ nl:
     - vr
     - za
     abbr_month_names:
-    -
+    - 
     - jan
     - feb
     - mrt
@@ -43,7 +43,7 @@ nl:
       long: "%e %B %Y"
       short: "%e %b"
     month_names:
-    -
+    - 
     - januari
     - februari
     - maart
@@ -75,43 +75,42 @@ nl:
         one: bijna een jaar
         other: bijna %{count} jaar
       half_a_minute: een halve minuut
-      less_than_x_minutes:
-        one: minder dan een minuut
-        other: minder dan %{count} minuten
       less_than_x_seconds:
         one: minder dan een seconde
         other: minder dan %{count} seconden
+      less_than_x_minutes:
+        one: minder dan een minuut
+        other: minder dan %{count} minuten
       over_x_years:
         one: meer dan een jaar
         other: meer dan %{count} jaar
-      x_days:
-        one: 1 dag
-        other: "%{count} dagen"
+      x_seconds:
+        one: 1 seconde
+        other: "%{count} seconden"
       x_minutes:
         one: 1 minuut
         other: "%{count} minuten"
+      x_days:
+        one: 1 dag
+        other: "%{count} dagen"
       x_months:
         one: 1 maand
         other: "%{count} maanden"
       x_years:
         one: 1 jaar
         other: "%{count} jaar"
-      x_seconds:
-        one: 1 seconde
-        other: "%{count} seconden"
     prompts:
-      day: dag
-      hour: uur
-      minute: minuut
-      month: maand
       second: seconde
+      minute: minuut
+      hour: uur
+      day: dag
+      month: maand
       year: jaar
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: moet worden geaccepteerd
       blank: moet opgegeven zijn
-      present: moet leeg zijn
       confirmation: komt niet overeen met %{attribute}
       empty: moet opgegeven zijn
       equal_to: moet gelijk zijn aan %{count}
@@ -123,10 +122,12 @@ nl:
       invalid: is ongeldig
       less_than: moet minder zijn dan %{count}
       less_than_or_equal_to: moet minder dan of gelijk zijn aan %{count}
-      model_invalid: "Validatie mislukt: %{errors}"
+      model_invalid: 'Validatie mislukt: %{errors}'
       not_a_number: is geen getal
       not_an_integer: moet een geheel getal zijn
       odd: moet oneven zijn
+      other_than: moet anders zijn dan %{count}
+      present: moet leeg zijn
       required: moet bestaan
       taken: is al in gebruik
       too_long:
@@ -138,7 +139,6 @@ nl:
       wrong_length:
         one: heeft onjuiste lengte (moet 1 teken lang zijn)
         other: heeft onjuiste lengte (moet %{count} tekens lang zijn)
-      other_than: moet anders zijn dan %{count}
     template:
       body: 'Er zijn problemen met de volgende velden:'
       header:

--- a/rails/locale/nn.yml
+++ b/rails/locale/nn.yml
@@ -17,7 +17,7 @@ nn:
     - fre
     - lau
     abbr_month_names:
-    -
+    - 
     - jan
     - feb
     - mar
@@ -43,7 +43,7 @@ nn:
       long: "%e. %B %Y"
       short: "%e. %b"
     month_names:
-    -
+    - 
     - januar
     - februar
     - mars
@@ -73,40 +73,39 @@ nn:
         other: rundt %{count} år
       almost_x_years: nesten %{count} år
       half_a_minute: eit halvt minutt
-      less_than_x_minutes:
-        one: mindre enn 1 minutt
-        other: mindre enn %{count} minutt
       less_than_x_seconds:
         one: mindre enn 1 sekund
         other: mindre enn %{count} sekund
+      less_than_x_minutes:
+        one: mindre enn 1 minutt
+        other: mindre enn %{count} minutt
       over_x_years:
         one: over 1 år
         other: over %{count} år
-      x_days:
-        one: 1 dag
-        other: "%{count} dagar"
-      x_minutes:
-        one: 1 minutt
-        other: "%{count} minutt"
-      x_months:
-        one: 1 månad
-        other: "%{count} månader"
       x_seconds:
         one: 1 sekund
         other: "%{count} sekund"
+      x_minutes:
+        one: 1 minutt
+        other: "%{count} minutt"
+      x_days:
+        one: 1 dag
+        other: "%{count} dagar"
+      x_months:
+        one: 1 månad
+        other: "%{count} månader"
     prompts:
-      day: Dag
-      hour: Time
-      minute: Minutt
-      month: Månad
       second: Sekund
+      minute: Minutt
+      hour: Time
+      day: Dag
+      month: Månad
       year: År
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: må vera akseptert
       blank: kan ikkje vera blank
-      present: må vera blank
       confirmation: er ikkje lik %{attribute}
       empty: kan ikkje vera tom
       equal_to: må vera lik %{count}
@@ -122,12 +121,13 @@ nn:
       not_a_number: er ikkje eit tal
       not_an_integer: er ikkje eit heiltal
       odd: må vera oddetal
+      other_than: må vera noko anna enn %{count}
+      present: må vera blank
       required: må eksistera
       taken: er allereie i bruk
       too_long: er for lang (maksimum %{count} teikn)
       too_short: er for kort (minimum %{count} teikn)
       wrong_length: har feil lengde (maksimum %{count} teikn)
-      other_than: må vera noko anna enn %{count}
     template:
       body: 'det oppstod problem i følgjande felt:'
       header: kunne ikkje lagra %{model} grunna %{count} feil.

--- a/rails/locale/oc.yml
+++ b/rails/locale/oc.yml
@@ -3,10 +3,10 @@ oc:
   activerecord:
     errors:
       messages:
-        record_invalid: 'La validacion a fracassat : %{errors}'
+        record_invalid: La validacion a fracassat : %{errors}
         restrict_dependent_destroy:
-          has_one: "Podètz pas suprimir l’enregistrament perque i a una dependéncia"
-          has_many: "Podètz pas suprimir l’enregistrament perque i a %{record} dependéncias"
+          has_one: Podètz pas suprimir l’enregistrament perque i a una dependéncia
+          has_many: Podètz pas suprimir l’enregistrament perque i a %{record} dependéncias
   date:
     abbr_day_names:
     - dg
@@ -17,7 +17,7 @@ oc:
     - dv
     - ds
     abbr_month_names:
-    -
+    - 
     - gen
     - feb
     - març
@@ -75,43 +75,42 @@ oc:
         one: quasi un an
         other: quasi %{count} ans
       half_a_minute: mièja minuta
-      less_than_x_minutes:
-        one: mens d’una minuta
-        other: mens de %{count} minutas
       less_than_x_seconds:
         one: mens d’una segonda
         other: mens de %{count} segondas
+      less_than_x_minutes:
+        one: mens d’una minuta
+        other: mens de %{count} minutas
       over_x_years:
         one: mai d’un an
         other: mai de %{count} ans
-      x_days:
-        one: un jorn
-        other: "%{count} jorns"
+      x_seconds:
+        one: una segonda
+        other: "%{count} segondas"
       x_minutes:
         one: una minuta
         other: "%{count} minutas"
+      x_days:
+        one: un jorn
+        other: "%{count} jorns"
       x_months:
         one: un mes
         other: "%{count} meses"
       x_years:
         one: un an
-        other: "%{count} ans" 
-      x_seconds:
-        one: una segonda
-        other: "%{count} segondas"
+        other: "%{count} ans"
     prompts:
-      day: jorn
-      hour: ora
-      minute: minuta
-      month: mes
       second: segonda
+      minute: minuta
+      hour: ora
+      day: jorn
+      month: mes
       year: an
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: deu èsser acceptat
       blank: deu èsser garnit
-      present: deu èsser void
       confirmation: correspond pas a %{attribute}
       empty: pòt pas èsser void
       equal_to: deu èsser egal a %{count}
@@ -123,10 +122,12 @@ oc:
       invalid: es pas valid
       less_than: deu èsser inferior a %{count}
       less_than_or_equal_to: deu èsser inferior o egal a %{count}
-      model_invalid: "Validacion fracassada : %{errors}"
+      model_invalid: Validacion fracassada : %{errors}
       not_a_number: es pas un nombre
       not_an_integer: deu èsser un nombre entièr
       odd: deu èsser un nombre impar
+      other_than: deu èsser diferent de %{count}
+      present: deu èsser void
       required: deu existir
       taken: es pas disponible
       too_long:
@@ -138,9 +139,8 @@ oc:
       wrong_length:
         one: a pas la bona longor (un caractèr solament)
         other: a pas la bona longor (%{count} caractèrs exactament)
-      other_than: deu èsser diferent de %{count}
     template:
-      body: "I a agut de problèmas amb los camps seguents : "
+      body: I a agut de problèmas amb los camps seguents : 
       header:
         one: Impossible d’enregistrar aqueste/a %{model} perque i a 1 error
         other: Impossible d’enregistrar aqueste/a %{model} perque i a %{count} errors
@@ -194,7 +194,7 @@ oc:
           tb: To
     percentage:
       format:
-        delimiter: '%n%'
+        delimiter: "%n%"
     precision:
       format:
         delimiter: ''
@@ -206,7 +206,7 @@ oc:
   time:
     am: am
     formats:
-      default: "Lo %e %b de %Y a %Ho%M %Ss"
-      long: "Lo %a %e %b de %Y a %Ho%M"
+      default: Lo %e %b de %Y a %Ho%M %Ss
+      long: Lo %a %e %b de %Y a %Ho%M
       short: "%e %b %Ho%M"
     pm: pm

--- a/rails/locale/or.yml
+++ b/rails/locale/or.yml
@@ -14,7 +14,7 @@ or:
     - ଶୁକ୍ର
     - ଶନି
     abbr_month_names:
-    -
+    - 
     - ଜାନୁ
     - ଫେବରୁ
     - ମାର
@@ -40,7 +40,7 @@ or:
       long: "%B %d, %Y"
       short: "%b %d"
     month_names:
-    -
+    - 
     - ଜାନୁୟାରୀ
     - ଫେବୃୟାରୀ
     - ମାର୍ଚ଼
@@ -72,33 +72,33 @@ or:
         one: ଅଳ୍ପ ଉଣ 1 ବର୍ଷ
         other: ଅଳ୍ପ ଉଣ %{count} ବର୍ଷ
       half_a_minute: ଦେଢ ମିନଟ୍
-      less_than_x_minutes:
-        one: 1 ମିନଟ ବାକ
-        other: "%{count} ମିନଟ ବାକ"
       less_than_x_seconds:
         one: 1 ସେକଣ୍ଢ ବାକ
         other: "%{count} ସେକଣ୍ଢ ବାକ"
+      less_than_x_minutes:
+        one: 1 ମିନଟ ବାକ
+        other: "%{count} ମିନଟ ବାକ"
       over_x_years:
         one: 1 ବର୍ଷରୁ ଅଧିକ
         other: "%{count} ବର୍ଷରୁ ଅଧିକ"
-      x_days:
-        one: 1  ଦିନ
-        other: "%{count} ଦିନ"
-      x_minutes:
-        one: 1 ମିନଟ
-        other: "%{count} ମିନଟ"
-      x_months:
-        one: 1 ମାସ
-        other: "%{count} ମାସ"
       x_seconds:
         one: 1 ସେକଣ୍ଢ
         other: "%{count} ସେକଣ୍ଢ"
+      x_minutes:
+        one: 1 ମିନଟ
+        other: "%{count} ମିନଟ"
+      x_days:
+        one: 1  ଦିନ
+        other: "%{count} ଦିନ"
+      x_months:
+        one: 1 ମାସ
+        other: "%{count} ମାସ"
     prompts:
-      day: ଦିନ
-      hour: ଘଣ୍ତ
-      minute: ମିନଟ
-      month: ମାସ
       second: ସେକଣ୍ଢ
+      minute: ମିନଟ
+      hour: ଘଣ୍ତ
+      day: ଦିନ
+      month: ମାସ
       year: ବର୍ଷ
   errors:
     format: "%{attribute} %{message}"

--- a/rails/locale/pa.yml
+++ b/rails/locale/pa.yml
@@ -17,7 +17,7 @@ pa:
     - ਸ਼ੁੱਕਰ
     - ਸ਼ਨਿੱਚਰ
     abbr_month_names:
-    -
+    - 
     - ਜਨ
     - ਫ਼ਰ
     - ਮਾਰਚ
@@ -43,7 +43,7 @@ pa:
       long: "%B %d, %Y"
       short: "%b %d"
     month_names:
-    -
+    - 
     - ਜਨਵਰੀ
     - ਫ਼ਰਵਰੀ
     - ਮਾਰਚ
@@ -75,40 +75,39 @@ pa:
         one: ਤਕਰੀਬਨ 1 ਸਾਲ
         other: ਤਕਰੀਬਨ %{count} ਸਾਲ
       half_a_minute: ਅੱਧਾ ਮਿੰਟ
-      less_than_x_minutes:
-        one: 1 ਮਿੰਟ ਤੋਂ ਘੱਟ
-        other: "%{count} ਮਿੰਟਾਂ ਤੋਂ ਘੱਟ"
       less_than_x_seconds:
         one: 1 ਸਕਿੰਟ ਤੋਂ ਘੱਟ
         other: "%{count} ਸਕਿੰਟਾਂ ਤੋਂ ਘੱਟ"
+      less_than_x_minutes:
+        one: 1 ਮਿੰਟ ਤੋਂ ਘੱਟ
+        other: "%{count} ਮਿੰਟਾਂ ਤੋਂ ਘੱਟ"
       over_x_years:
         one: 1 ਸਾਲ ਤੋਂ ਵੱਧ
         other: "%{count} ਸਾਲਾਂ ਤੋਂ ਵੱਧ"
-      x_days:
-        one: 1 ਦਿਨ
-        other: "%{count} ਦਿਨ"
-      x_minutes:
-        one: 1 ਮਿੰਟ
-        other: "%{count} ਮਿੰਟ"
-      x_months:
-        one: 1 ਮਹੀਨਾ
-        other: "%{count} ਮਹੀਨੇ"
       x_seconds:
         one: 1 ਸਕਿੰਟ
         other: "%{count} ਸਕਿੰਟ"
+      x_minutes:
+        one: 1 ਮਿੰਟ
+        other: "%{count} ਮਿੰਟ"
+      x_days:
+        one: 1 ਦਿਨ
+        other: "%{count} ਦਿਨ"
+      x_months:
+        one: 1 ਮਹੀਨਾ
+        other: "%{count} ਮਹੀਨੇ"
     prompts:
-      day: ਦਿਨ
-      hour: ਘੰਟਾ
-      minute: ਮਿੰਟ
-      month: ਮਹੀਨਾ
       second: ਸਕਿੰਟ
+      minute: ਮਿੰਟ
+      hour: ਘੰਟਾ
+      day: ਦਿਨ
+      month: ਮਹੀਨਾ
       year: ਸਾਲ
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: ਜਰੂਰ ਮੰਜੂਰ ਹੋਵੇ
       blank: ਖਾਲੀ ਨਹੀਂ ਹੋ ਸਕਦਾ
-      present: ਜਰੂਰ ਖਾਲੀ ਹੋਵੇ
       confirmation: "%{attribute} ਨਹੀਂ ਰਲਦੇ"
       empty: ਖਾਲੀ ਨਹੀਂ ਹੋ ਸਕਦਾ
       equal_to: "%{count} ਦੇ ਬਰਾਬਰ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ"
@@ -123,6 +122,8 @@ pa:
       not_a_number: ਸੰਖਿਆ ਨਹੀਂ ਹੈ
       not_an_integer: ਜਰੂਰੀ ਹੈ ਕੇ ਪੂਰਨ ਅੰਕ ਹੋਵੇ
       odd: ਜਰੂਰੀ ਹੈ ਕੇ ਕਲ਼ੀ ਹੋਵੇ
+      other_than: "%{count} ਦੀ ਜਗ੍ਹਾ ਹੋਰ ਹੋਣੀ ਚਾਹੀਦੀ ਹੈ"
+      present: ਜਰੂਰ ਖਾਲੀ ਹੋਵੇ
       taken: ਪਹਿਲਾਂ ਹੀ ਮੱਲਿਆ ਹੋਇਆ ਹੈ
       too_long:
         one: ਲੰਬਾਈ ਜ਼ਿਆਦਾ ਹੈ (ਵੱਧ ਤੋਂ ਵੱਧ 1 ਅੱਖਰ)
@@ -133,7 +134,6 @@ pa:
       wrong_length:
         one: ਲੰਬਾਈ ਗਲਤ ਹੈ (1 ਅੱਖਰ ਹੋਣੀ ਚਾਹੀਦੀ ਹੈ)
         other: ਲੰਬਾਈ ਗਲਤ ਹੈ (%{count} ਅੱਖਰ ਹੋਣੀ ਚਾਹੀਦੀ ਹੈ)
-      other_than: "%{count} ਦੀ ਜਗ੍ਹਾ ਹੋਰ ਹੋਣੀ ਚਾਹੀਦੀ ਹੈ"
     template:
       body: 'ਹੇਠਲੇ ਖੇਤਰਾਂ ਵਿੱਚ ਗਲਤੀਆਂ ਹਨ:'
       header:

--- a/rails/locale/pl.yml
+++ b/rails/locale/pl.yml
@@ -5,8 +5,8 @@ pl:
       messages:
         record_invalid: 'Negatywne sprawdzenie poprawności: %{errors}'
         restrict_dependent_destroy:
-          has_many: Nie może zostać usunięte, gdyż istnieją zależne od niego %{record}
           has_one: Nie może zostać usunięte, gdyż istnieje zależny od niego %{record}
+          has_many: Nie może zostać usunięte, gdyż istnieją zależne od niego %{record}
   date:
     abbr_day_names:
     - nie
@@ -17,7 +17,7 @@ pl:
     - pią
     - sob
     abbr_month_names:
-    -
+    - 
     - sty
     - lut
     - mar
@@ -43,7 +43,7 @@ pl:
       long: "%B %d, %Y"
       short: "%d %b"
     month_names:
-    -
+    - 
     - styczeń
     - luty
     - marzec
@@ -63,67 +63,67 @@ pl:
   datetime:
     distance_in_words:
       about_x_hours:
+        one: około godziny
         few: około %{count} godziny
         many: około %{count} godzin
-        one: około godziny
         other: około %{count} godzin
       about_x_months:
+        one: około miesiąca
         few: około %{count} miesiące
         many: około %{count} miesięcy
-        one: około miesiąca
         other: około %{count} miesięcy
       about_x_years:
+        one: około rok
         few: około %{count} lata
         many: około %{count} lat
-        one: około rok
         other: około %{count} lat
       almost_x_years:
+        one: prawie rok
         few: prawie %{count} lata
         many: prawie %{count} lat
-        one: prawie rok
         other: prawie %{count} lat
       half_a_minute: pół minuty
-      less_than_x_minutes:
-        few: mniej niż %{count} minuty
-        many: mniej niż %{count} minut
-        one: mniej niż minutę
-        other: mniej niż %{count} minut
       less_than_x_seconds:
+        one: mniej niż sekundę
         few: mniej niż %{count} sekundy
         many: mniej niż %{count} sekund
-        one: mniej niż sekundę
         other: mniej niż %{count} sekund
+      less_than_x_minutes:
+        one: mniej niż minutę
+        few: mniej niż %{count} minuty
+        many: mniej niż %{count} minut
+        other: mniej niż %{count} minut
       over_x_years:
+        one: ponad rok
         few: ponad %{count} lata
         many: ponad %{count} lat
-        one: ponad rok
         other: ponad %{count} lat
-      x_days:
-        few: "%{count} dni"
-        many: "%{count} dni"
-        one: 1 dzień
-        other: "%{count} dni"
-      x_minutes:
-        few: "%{count} minuty"
-        many: "%{count} minut"
-        one: 1 minuta
-        other: "%{count} minut"
-      x_months:
-        few: "%{count} miesiące"
-        many: "%{count} miesięcy"
-        one: 1 miesiąc
-        other: "%{count} miesięcy"
       x_seconds:
+        one: 1 sekunda
         few: "%{count} sekundy"
         many: "%{count} sekund"
-        one: 1 sekunda
         other: "%{count} sekund"
+      x_minutes:
+        one: 1 minuta
+        few: "%{count} minuty"
+        many: "%{count} minut"
+        other: "%{count} minut"
+      x_days:
+        one: 1 dzień
+        few: "%{count} dni"
+        many: "%{count} dni"
+        other: "%{count} dni"
+      x_months:
+        one: 1 miesiąc
+        few: "%{count} miesiące"
+        many: "%{count} miesięcy"
+        other: "%{count} miesięcy"
     prompts:
-      day: Dzień
-      hour: Godzina
-      minute: Minuta
-      month: Miesiąc
       second: Sekundy
+      minute: Minuta
+      hour: Godzina
+      day: Dzień
+      month: Miesiąc
       year: Rok
   errors:
     format: "%{attribute} %{message}"
@@ -144,31 +144,31 @@ pl:
       not_a_number: nie jest liczbą
       not_an_integer: musi być liczbą całkowitą
       odd: musi być nieparzyste
+      other_than: musi być inna niż %{count}
       present: musi być puste
       required: musi istnieć
       taken: zostało już zajęte
       too_long:
+        one: jest za długie (maksymalnie jeden znak)
         few: jest za długie (maksymalnie %{count} znaki)
         many: jest za długie (maksymalnie %{count} znaków)
-        one: jest za długie (maksymalnie jeden znak)
         other: jest za długie (maksymalnie %{count} znaków)
       too_short:
+        one: jest za krótkie (przynajmniej jeden znak)
         few: jest za krótkie (przynajmniej %{count} znaki)
         many: jest za krótkie (przynajmniej %{count} znaków)
-        one: jest za krótkie (przynajmniej jeden znak)
         other: jest za krótkie (przynajmniej %{count} znaków)
       wrong_length:
+        one: ma nieprawidłową długość (powinna wynosić jeden znak)
         few: ma nieprawidłową długość (powinna wynosić %{count} znaki)
         many: ma nieprawidłową długość (powinna wynosić %{count} znaków)
-        one: ma nieprawidłową długość (powinna wynosić jeden znak)
         other: ma nieprawidłową długość (powinna wynosić %{count} znaków)
-      other_than: musi być inna niż %{count}
     template:
       body: 'Błędy dotyczą następujących pól:'
       header:
+        one: "%{model} nie został zachowany z powodu jednego błędu"
         few: "%{model} nie został zachowany z powodu %{count} błędów"
         many: "%{model} nie został zachowany z powodu %{count} błędów"
-        one: "%{model} nie został zachowany z powodu jednego błędu"
         other: "%{model} nie został zachowany z powodu %{count} błędów"
   helpers:
     select:
@@ -212,9 +212,9 @@ pl:
         format: "%n %u"
         units:
           byte:
+            one: bajt
             few: bajty
             many: bajtów
-            one: bajt
             other: bajty
           gb: GB
           kb: KB

--- a/rails/locale/pt-BR.yml
+++ b/rails/locale/pt-BR.yml
@@ -17,7 +17,7 @@ pt-BR:
     - Sex
     - Sáb
     abbr_month_names:
-    -
+    - 
     - Jan
     - Fev
     - Mar
@@ -43,7 +43,7 @@ pt-BR:
       long: "%d de %B de %Y"
       short: "%d de %B"
     month_names:
-    -
+    - 
     - Janeiro
     - Fevereiro
     - Março
@@ -75,43 +75,42 @@ pt-BR:
         one: quase 1 ano
         other: quase %{count} anos
       half_a_minute: meio minuto
-      less_than_x_minutes:
-        one: menos de um minuto
-        other: menos de %{count} minutos
       less_than_x_seconds:
         one: menos de 1 segundo
         other: menos de %{count} segundos
+      less_than_x_minutes:
+        one: menos de um minuto
+        other: menos de %{count} minutos
       over_x_years:
         one: mais de 1 ano
         other: mais de %{count} anos
-      x_days:
-        one: 1 dia
-        other: "%{count} dias"
+      x_seconds:
+        one: 1 segundo
+        other: "%{count} segundos"
       x_minutes:
         one: 1 minuto
         other: "%{count} minutos"
+      x_days:
+        one: 1 dia
+        other: "%{count} dias"
       x_months:
         one: 1 mês
         other: "%{count} meses"
       x_years:
         one: 1 ano
         other: "%{count} anos"
-      x_seconds:
-        one: 1 segundo
-        other: "%{count} segundos"
     prompts:
-      day: Dia
-      hour: Hora
-      minute: Minuto
-      month: Mês
       second: Segundo
+      minute: Minuto
+      hour: Hora
+      day: Dia
+      month: Mês
       year: Ano
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: deve ser aceito
       blank: não pode ficar em branco
-      present: deve ficar em branco
       confirmation: não é igual a %{attribute}
       empty: não pode ficar vazio
       equal_to: deve ser igual a %{count}
@@ -127,6 +126,8 @@ pt-BR:
       not_a_number: não é um número
       not_an_integer: não é um número inteiro
       odd: deve ser ímpar
+      other_than: deve ser diferente de %{count}
+      present: deve ficar em branco
       required: é obrigatório(a)
       taken: já está em uso
       too_long:
@@ -138,7 +139,6 @@ pt-BR:
       wrong_length:
         one: não possui o tamanho esperado (1 caracter)
         other: não possui o tamanho esperado (%{count} caracteres)
-      other_than: deve ser diferente de %{count}
     template:
       body: 'Por favor, verifique o(s) seguinte(s) campo(s):'
       header:
@@ -186,7 +186,7 @@ pt-BR:
             other: trilhões
           unit: ''
       format:
-        delimiter: ""
+        delimiter: ''
         precision: 3
         significant: true
         strip_insignificant_zeros: true
@@ -196,12 +196,12 @@ pt-BR:
           byte:
             one: Byte
             other: Bytes
+          eb: EB
           gb: GB
           kb: KB
           mb: MB
-          tb: TB
           pb: PB
-          eb: EB
+          tb: TB
     percentage:
       format:
         delimiter: "."

--- a/rails/locale/pt.yml
+++ b/rails/locale/pt.yml
@@ -5,8 +5,8 @@ pt:
       messages:
         record_invalid: 'A validação falhou: %{errors}'
         restrict_dependent_destroy:
-          has_many: Não pode ser eliminado por existirem dependências de %{record}
           has_one: Não pode ser eliminado por existir uma dependência de %{record}
+          has_many: Não pode ser eliminado por existirem dependências de %{record}
   date:
     abbr_day_names:
     - Dom
@@ -17,7 +17,7 @@ pt:
     - Sex
     - Sáb
     abbr_month_names:
-    -
+    - 
     - Jan
     - Fev
     - Mar
@@ -43,7 +43,7 @@ pt:
       long: "%d de %B de %Y"
       short: "%d de %B"
     month_names:
-    -
+    - 
     - Janeiro
     - Fevereiro
     - Março
@@ -75,36 +75,36 @@ pt:
         one: quase 1 ano
         other: quase %{count} anos
       half_a_minute: meio minuto
-      less_than_x_minutes:
-        one: menos de um minuto
-        other: menos de %{count} minutos
       less_than_x_seconds:
         one: menos de 1 segundo
         other: menos de %{count} segundos
+      less_than_x_minutes:
+        one: menos de um minuto
+        other: menos de %{count} minutos
       over_x_years:
         one: mais de 1 ano
         other: mais de %{count} anos
-      x_days:
-        one: 1 dia
-        other: "%{count} dias"
-      x_minutes:
-        one: 1 minuto
-        other: "%{count} minutos"
-      x_months:
-        one: 1 mês
-        other: "%{count} meses"
       x_seconds:
         one: 1 segundo
         other: "%{count} segundos"
+      x_minutes:
+        one: 1 minuto
+        other: "%{count} minutos"
+      x_days:
+        one: 1 dia
+        other: "%{count} dias"
+      x_months:
+        one: 1 mês
+        other: "%{count} meses"
       x_years:
         one: 1 ano
         other: "%{count} anos"
     prompts:
-      day: Dia
-      hour: Hora
-      minute: Minuto
-      month: Mês
       second: Segundo
+      minute: Minuto
+      hour: Hora
+      day: Dia
+      month: Mês
       year: Ano
   errors:
     format: "%{attribute} %{message}"
@@ -136,8 +136,8 @@ pt:
     template:
       body: 'Por favor, verifique os seguintes campos:'
       header:
-        one: '1 erro impediu guardar este %{model}'
-        other: '%{count} erros impediram guardar este %{model}'
+        one: 1 erro impediu guardar este %{model}
+        other: "%{count} erros impediram guardar este %{model}"
   helpers:
     select:
       prompt: Por favor seleccione
@@ -190,12 +190,12 @@ pt:
           byte:
             one: Byte
             other: Bytes
+          eb: EB
           gb: GB
           kb: KB
           mb: MB
-          tb: TB
           pb: PB
-          eb: EB
+          tb: TB
     percentage:
       format:
         delimiter: ''

--- a/rails/locale/rm.yml
+++ b/rails/locale/rm.yml
@@ -77,13 +77,6 @@ rm:
         many: circa %{count} onns
         other: circa %{count} onns
       half_a_minute: ina mesa minuta
-      less_than_x_minutes:
-        zero: main che %{count} minutas
-        one: main ch’ina minuta
-        two: main che %{count} minutas
-        few: main che %{count} minutas
-        many: main che %{count} minutas
-        other: main che %{count} minutas
       less_than_x_seconds:
         zero: main che %{count} secundas
         one: main ch’ina secunda
@@ -91,6 +84,13 @@ rm:
         few: main che %{count} secundas
         many: main che %{count} secundas
         other: main che %{count} secundas
+      less_than_x_minutes:
+        zero: main che %{count} minutas
+        one: main ch’ina minuta
+        two: main che %{count} minutas
+        few: main che %{count} minutas
+        many: main che %{count} minutas
+        other: main che %{count} minutas
       over_x_years:
         zero: dapli che %{count} onns
         one: dapli ch'in onn
@@ -98,27 +98,6 @@ rm:
         few: dapli che %{count} onns
         many: dapli che %{count} onns
         other: dapli che %{count} onns
-      x_days:
-        zero: "%{count} dis"
-        one: in di
-        two: "%{count} dis"
-        few: "%{count} dis"
-        many: "%{count} dis"
-        other: "%{count} dis"
-      x_minutes:
-        zero: "%{count} minutas"
-        one: 1 minuta
-        two: "%{count} minutas"
-        few: "%{count} minutas"
-        many: "%{count} minutas"
-        other: "%{count} minutas"
-      x_months:
-        zero: "%{count} mais"
-        one: in mais
-        two: "%{count} mais"
-        few: "%{count} mais"
-        many: "%{count} mais"
-        other: "%{count} mais"
       x_seconds:
         zero: "%{count} secundas"
         one: ina secunda
@@ -126,12 +105,33 @@ rm:
         few: "%{count} secundas"
         many: "%{count} secundas"
         other: "%{count} secundas"
+      x_minutes:
+        zero: "%{count} minutas"
+        one: 1 minuta
+        two: "%{count} minutas"
+        few: "%{count} minutas"
+        many: "%{count} minutas"
+        other: "%{count} minutas"
+      x_days:
+        zero: "%{count} dis"
+        one: in di
+        two: "%{count} dis"
+        few: "%{count} dis"
+        many: "%{count} dis"
+        other: "%{count} dis"
+      x_months:
+        zero: "%{count} mais"
+        one: in mais
+        two: "%{count} mais"
+        few: "%{count} mais"
+        many: "%{count} mais"
+        other: "%{count} mais"
     prompts:
-      day: dis
-      hour: uras
-      minute: minutas
-      month: mais
       second: secundas
+      minute: minutas
+      hour: uras
+      day: dis
+      month: mais
       year: onns
   errors:
     format: "%{attribute} %{message}"

--- a/rails/locale/ro.yml
+++ b/rails/locale/ro.yml
@@ -14,7 +14,7 @@ ro:
     - Vin
     - Sâm
     abbr_month_names:
-    -
+    - 
     - Ian
     - Feb
     - Mar
@@ -40,7 +40,7 @@ ro:
       long: "%d %B %Y"
       short: "%d %b"
     month_names:
-    -
+    - 
     - Ianuarie
     - Februarie
     - Martie
@@ -76,40 +76,40 @@ ro:
         few: aproape %{count} ani
         other: aproape %{count} ani
       half_a_minute: jumătate de minut
-      less_than_x_minutes:
-        one: mai puțin de un minut
-        few: mai puțin de %{count} minute
-        other: mai puțin de %{count} minute
       less_than_x_seconds:
         one: mai puțin de o secundă
         few: mai puțin de %{count} secunde
         other: mai puțin de %{count} secunde
+      less_than_x_minutes:
+        one: mai puțin de un minut
+        few: mai puțin de %{count} minute
+        other: mai puțin de %{count} minute
       over_x_years:
         one: mai mult de un an
         few: mai mult de %{count} ani
         other: mai mult de %{count} ani
-      x_days:
-        one: 1 zi
-        few: "%{count} zile"
-        other: "%{count} zile"
-      x_minutes:
-        one: 1 minut
-        few: "%{count} minute"
-        other: "%{count} minute"
-      x_months:
-        one: 1 lună
-        few: "%{count} luni"
-        other: "%{count} luni"
       x_seconds:
         one: 1 secundă
         few: "%{count} secunde"
         other: "%{count} secunde"
+      x_minutes:
+        one: 1 minut
+        few: "%{count} minute"
+        other: "%{count} minute"
+      x_days:
+        one: 1 zi
+        few: "%{count} zile"
+        other: "%{count} zile"
+      x_months:
+        one: 1 lună
+        few: "%{count} luni"
+        other: "%{count} luni"
     prompts:
-      day: Ziua
-      hour: Ora
-      minute: Minutul
-      month: Luna
       second: Secunda
+      minute: Minutul
+      hour: Ora
+      day: Ziua
+      month: Luna
       year: Anul
   errors:
     format: "%{attribute} %{message}"

--- a/rails/locale/ru.yml
+++ b/rails/locale/ru.yml
@@ -17,7 +17,7 @@ ru:
     - Пт
     - Сб
     abbr_month_names:
-    -
+    - 
     - янв.
     - февр.
     - марта
@@ -43,7 +43,7 @@ ru:
       long: "%-d %B %Y"
       short: "%-d %b"
     month_names:
-    -
+    - 
     - января
     - февраля
     - марта
@@ -63,19 +63,19 @@ ru:
   datetime:
     distance_in_words:
       about_x_hours:
+        one: около %{count} часа
         few: около %{count} часов
         many: около %{count} часов
-        one: около %{count} часа
         other: около %{count} часа
       about_x_months:
+        one: около %{count} месяца
         few: около %{count} месяцев
         many: около %{count} месяцев
-        one: около %{count} месяца
         other: около %{count} месяца
       about_x_years:
+        one: около %{count} года
         few: около %{count} лет
         many: около %{count} лет
-        one: около %{count} года
         other: около %{count} лет
       almost_x_years:
         one: почти 1 год
@@ -83,59 +83,58 @@ ru:
         many: почти %{count} лет
         other: почти %{count} лет
       half_a_minute: меньше минуты
-      less_than_x_minutes:
-        few: меньше %{count} минут
-        many: меньше %{count} минут
-        one: меньше %{count} минуты
-        other: меньше %{count} минуты
       less_than_x_seconds:
+        one: меньше %{count} секунды
         few: меньше %{count} секунд
         many: меньше %{count} секунд
-        one: меньше %{count} секунды
         other: меньше %{count} секунды
+      less_than_x_minutes:
+        one: меньше %{count} минуты
+        few: меньше %{count} минут
+        many: меньше %{count} минут
+        other: меньше %{count} минуты
       over_x_years:
+        one: больше %{count} года
         few: больше %{count} лет
         many: больше %{count} лет
-        one: больше %{count} года
         other: больше %{count} лет
-      x_days:
-        few: "%{count} дня"
-        many: "%{count} дней"
-        one: "%{count} день"
-        other: "%{count} дня"
-      x_minutes:
-        few: "%{count} минуты"
-        many: "%{count} минут"
-        one: "%{count} минуту"
-        other: "%{count} минуты"
-      x_months:
-        few: "%{count} месяца"
-        many: "%{count} месяцев"
-        one: "%{count} месяц"
-        other: "%{count} месяца"
-      x_years:
-        few: "%{count} года"
-        many: "%{count} лет"
-        one: "%{count} год"
-        other: "%{count} года"
       x_seconds:
+        one: "%{count} секунду"
         few: "%{count} секунды"
         many: "%{count} секунд"
-        one: "%{count} секунду"
         other: "%{count} секунды"
+      x_minutes:
+        one: "%{count} минуту"
+        few: "%{count} минуты"
+        many: "%{count} минут"
+        other: "%{count} минуты"
+      x_days:
+        one: "%{count} день"
+        few: "%{count} дня"
+        many: "%{count} дней"
+        other: "%{count} дня"
+      x_months:
+        one: "%{count} месяц"
+        few: "%{count} месяца"
+        many: "%{count} месяцев"
+        other: "%{count} месяца"
+      x_years:
+        one: "%{count} год"
+        few: "%{count} года"
+        many: "%{count} лет"
+        other: "%{count} года"
     prompts:
-      day: День
-      hour: Часов
-      minute: Минут
-      month: Месяц
       second: Секунд
+      minute: Минут
+      hour: Часов
+      day: День
+      month: Месяц
       year: Год
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: нужно подтвердить
       blank: не может быть пустым
-      present: нужно оставить пустым
       confirmation: не совпадает со значением поля %{attribute}
       empty: не может быть пустым
       equal_to: может иметь лишь значение, равное %{count}
@@ -151,30 +150,31 @@ ru:
       not_a_number: не является числом
       not_an_integer: не является целым числом
       odd: может иметь лишь четное значение
+      other_than: должно отличаться от %{count}
+      present: нужно оставить пустым
       required: не может отсутствовать
       taken: уже существует
       too_long:
+        one: слишком большой длины (не может быть больше чем %{count} символ)
         few: слишком большой длины (не может быть больше чем %{count} символа)
         many: слишком большой длины (не может быть больше чем %{count} символов)
-        one: слишком большой длины (не может быть больше чем %{count} символ)
         other: слишком большой длины (не может быть больше чем %{count} символа)
       too_short:
+        one: недостаточной длины (не может быть меньше %{count} символа)
         few: недостаточной длины (не может быть меньше %{count} символов)
         many: недостаточной длины (не может быть меньше %{count} символов)
-        one: недостаточной длины (не может быть меньше %{count} символа)
         other: недостаточной длины (не может быть меньше %{count} символа)
       wrong_length:
+        one: неверной длины (может быть длиной ровно %{count} символ)
         few: неверной длины (может быть длиной ровно %{count} символа)
         many: неверной длины (может быть длиной ровно %{count} символов)
-        one: неверной длины (может быть длиной ровно %{count} символ)
         other: неверной длины (может быть длиной ровно %{count} символа)
-      other_than: должно отличаться от %{count}
     template:
       body: 'Проблемы возникли со следующими полями:'
       header:
+        one: "%{model}: сохранение не удалось из-за %{count} ошибки"
         few: "%{model}: сохранение не удалось из-за %{count} ошибок"
         many: "%{model}: сохранение не удалось из-за %{count} ошибок"
-        one: "%{model}: сохранение не удалось из-за %{count} ошибки"
         other: "%{model}: сохранение не удалось из-за %{count} ошибки"
   helpers:
     select:
@@ -204,29 +204,29 @@ ru:
         format: "%n %u"
         units:
           billion:
+            one: миллиард
             few: миллиардов
             many: миллиардов
-            one: миллиард
             other: миллиардов
           million:
+            one: миллион
             few: миллионов
             many: миллионов
-            one: миллион
             other: миллионов
           quadrillion:
+            one: квадриллион
             few: квадриллионов
             many: квадриллионов
-            one: квадриллион
             other: квадриллионов
           thousand:
+            one: тысяча
             few: тысяч
             many: тысяч
-            one: тысяча
             other: тысяч
           trillion:
+            one: триллион
             few: триллионов
             many: триллионов
-            one: триллион
             other: триллионов
           unit: ''
       format:
@@ -238,16 +238,16 @@ ru:
         format: "%n %u"
         units:
           byte:
+            one: байт
             few: байта
             many: байт
-            one: байт
             other: байта
+          eb: ЭБ
           gb: ГБ
           kb: КБ
           mb: МБ
-          tb: ТБ
           pb: ПБ
-          eb: ЭБ
+          tb: ТБ
     percentage:
       format:
         delimiter: ''

--- a/rails/locale/sk.yml
+++ b/rails/locale/sk.yml
@@ -14,7 +14,7 @@ sk:
     - Pi
     - So
     abbr_month_names:
-    -
+    - 
     - Jan
     - Feb
     - Mar
@@ -40,7 +40,7 @@ sk:
       long: "%d. %B %Y"
       short: "%d %b"
     month_names:
-    -
+    - 
     - Január
     - Február
     - Marec
@@ -76,40 +76,40 @@ sk:
         few: takmer %{count} rokmi
         other: takmer %{count} rokmi
       half_a_minute: pol minútou
-      less_than_x_minutes:
-        one: necelou minútou
-        few: necelými %{count} minútami
-        other: necelými %{count} minútami
       less_than_x_seconds:
         one: necelou sekundou
         few: necelými %{count} sekundami
         other: necelými %{count} sekundami
+      less_than_x_minutes:
+        one: necelou minútou
+        few: necelými %{count} minútami
+        other: necelými %{count} minútami
       over_x_years:
         one: viac ako rokom
         few: viac ako %{count} rokmi
         other: viac ako %{count} rokmi
-      x_days:
-        one: dňom
-        few: "%{count} dňami"
-        other: "%{count} dňami"
-      x_minutes:
-        one: minútou
-        few: "%{count} minútami"
-        other: "%{count} minútami"
-      x_months:
-        one: mesiacom
-        few: "%{count} mesiacmi"
-        other: "%{count} mesiacmi"
       x_seconds:
         one: sekundou
         few: "%{count} sekundami"
         other: "%{count} sekundami"
+      x_minutes:
+        one: minútou
+        few: "%{count} minútami"
+        other: "%{count} minútami"
+      x_days:
+        one: dňom
+        few: "%{count} dňami"
+        other: "%{count} dňami"
+      x_months:
+        one: mesiacom
+        few: "%{count} mesiacmi"
+        other: "%{count} mesiacmi"
     prompts:
-      day: Deň
-      hour: Hodina
-      minute: Minúta
-      month: Mesiac
       second: Sekunda
+      minute: Minúta
+      hour: Hodina
+      day: Deň
+      month: Mesiac
       year: Rok
   errors:
     format: "%{attribute} %{message}"

--- a/rails/locale/sl.yml
+++ b/rails/locale/sl.yml
@@ -14,7 +14,7 @@ sl:
     - pet
     - sob
     abbr_month_names:
-    -
+    - 
     - jan
     - feb
     - mar
@@ -40,7 +40,7 @@ sl:
       long: "%d. %b %Y"
       short: "%d. %b"
     month_names:
-    -
+    - 
     - januar
     - februar
     - marec
@@ -60,67 +60,67 @@ sl:
   datetime:
     distance_in_words:
       about_x_hours:
-        few: okoli %{count} ure
         one: okoli 1 ura
-        other: okoli %{count} ur
         two: okoli 2 uri
+        few: okoli %{count} ure
+        other: okoli %{count} ur
       about_x_months:
-        few: okoli %{count} mesece
         one: okoli 1 mesec
-        other: okoli %{count} mesecev
         two: okoli 2 meseca
+        few: okoli %{count} mesece
+        other: okoli %{count} mesecev
       about_x_years:
-        few: okoli %{count} leta
         one: okoli 1 leto
-        other: okoli %{count} let
         two: okoli 2 leti
+        few: okoli %{count} leta
+        other: okoli %{count} let
       almost_x_years:
-        few: skoraj %{count} leta
         one: skoraj 1 leto
-        other: skoraj %{count} let
         two: skoraj 2 leti
+        few: skoraj %{count} leta
+        other: skoraj %{count} let
       half_a_minute: pol minute
-      less_than_x_minutes:
-        few: manj kot %{count} minute
-        one: manj kot ena minuta
-        other: manj kot %{count} minut
-        two: manj kot dve minuti
       less_than_x_seconds:
-        few: manj kot %{count} sekunde
         one: manj kot 1 sekunda
-        other: manj kot %{count} sekund
         two: manj kot 2 sekundi
+        few: manj kot %{count} sekunde
+        other: manj kot %{count} sekund
+      less_than_x_minutes:
+        one: manj kot ena minuta
+        two: manj kot dve minuti
+        few: manj kot %{count} minute
+        other: manj kot %{count} minut
       over_x_years:
-        few: več kot %{count} leta
         one: več kot 1 leto
-        other: več kot %{count} let
         two: več kot 2 leti
-      x_days:
-        few: "%{count} dnevi"
-        one: 1 dan
-        other: "%{count} dni"
-        two: 2 dneva
-      x_minutes:
-        few: "%{count} minute"
-        one: 1 minuta
-        other: "%{count} minut"
-        two: 2 minuti
-      x_months:
-        few: "%{count} mesece"
-        one: 1 mesec
-        other: "%{count} mesecev"
-        two: 2 meseca
+        few: več kot %{count} leta
+        other: več kot %{count} let
       x_seconds:
-        few: "%{count} sekunde"
         one: 1 sekunda
-        other: "%{count} sekund"
         two: 2 sekundi
+        few: "%{count} sekunde"
+        other: "%{count} sekund"
+      x_minutes:
+        one: 1 minuta
+        two: 2 minuti
+        few: "%{count} minute"
+        other: "%{count} minut"
+      x_days:
+        one: 1 dan
+        two: 2 dneva
+        few: "%{count} dnevi"
+        other: "%{count} dni"
+      x_months:
+        one: 1 mesec
+        two: 2 meseca
+        few: "%{count} mesece"
+        other: "%{count} mesecev"
     prompts:
-      day: Dan
-      hour: Ura
-      minute: Minute
-      month: Mesec
       second: Sekunde
+      minute: Minute
+      hour: Ura
+      day: Dan
+      month: Mesec
       year: Leto
   errors:
     format: "%{attribute} %{message}"
@@ -147,10 +147,10 @@ sl:
     template:
       body: 'Napačno izpolnjena polja:'
       header:
-        few: "%{count} napake preprečujejo, da bi shranili %{model}"
         one: Ena napaka preprečuje, da bi shranili %{model}
-        other: "%{count} napak preprečuje, da bi shranili %{model}"
         two: Dve napaki preprečujeta, da bi shranili %{model}
+        few: "%{count} napake preprečujejo, da bi shranili %{model}"
+        other: "%{count} napak preprečuje, da bi shranili %{model}"
   number:
     currency:
       format:

--- a/rails/locale/sq.yml
+++ b/rails/locale/sq.yml
@@ -1,11 +1,13 @@
+---
 sq:
   activerecord:
     errors:
       messages:
-        record_invalid: "Validimi dështoi: %{errors}"
+        record_invalid: 'Validimi dështoi: %{errors}'
         restrict_dependent_destroy:
-          has_one: "Nuk mund të fshini rekordin për shkak se një %{record} i varur ekziston"
-          has_many: "Nuk mund të fshini rekordin për shkak se %{record} të varura ekzistojnë"
+          has_one: Nuk mund të fshini rekordin për shkak se një %{record} i varur
+            ekziston
+          has_many: Nuk mund të fshini rekordin për shkak se %{record} të varura ekzistojnë
   date:
     abbr_day_names:
     - E Diel
@@ -16,7 +18,7 @@ sq:
     - E Premte
     - E Shtunë
     abbr_month_names:
-    -
+    - 
     - Janar
     - Shkurt
     - Mars
@@ -42,7 +44,7 @@ sq:
       long: "%d %B, %Y"
       short: "%d %b"
     month_names:
-    -
+    - 
     - Janar
     - Shkurt
     - Mars
@@ -74,40 +76,39 @@ sq:
         one: gati 1 vit
         other: gati %{count} vite
       half_a_minute: gjysëm minute
-      less_than_x_minutes:
-        one: më pak se një minutë
-        other: më pak se %{count} minuta
       less_than_x_seconds:
         one: më pak se 1 sekond
         other: më pak se %{count} sekonda
+      less_than_x_minutes:
+        one: më pak se një minutë
+        other: më pak se %{count} minuta
       over_x_years:
         one: mbi 1 vit
         other: mbi %{count} vite
-      x_days:
-        one: 1 ditë
-        other: "%{count} ditë"
+      x_seconds:
+        one: 1 sekond
+        other: "%{count} sekonda"
       x_minutes:
         one: 1 minutë
         other: "%{count} minuta"
+      x_days:
+        one: 1 ditë
+        other: "%{count} ditë"
       x_months:
         one: 1 muaj
         other: "%{count} muaj"
-      x_seconds:
-        one: 1 sekond
-        other: "%{count} sekonda"  
     prompts:
-      day: Ditë
-      hour: Orë
-      minute: Minutë
-      month: Muaj
       second: Sekond
+      minute: Minutë
+      hour: Orë
+      day: Ditë
+      month: Muaj
       year: Vit
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: duhet të pranohet
       blank: nuk mund të jetë bosh
-      present: duhet të jetë bosh
       confirmation: nuk përputhet me %{attribute}
       empty: nuk mund të jetë bosh
       equal_to: duhet të përputhet me %{count}
@@ -119,10 +120,12 @@ sq:
       invalid: është e palejuar
       less_than: duhet të jetë më pak se %{count}
       less_than_or_equal_to: duhet të jetë më pak ose i barabartë me %{count}
-      model_invalid: "Validimi dështoi: %{errors}"
+      model_invalid: 'Validimi dështoi: %{errors}'
       not_a_number: nuk është numër
       not_an_integer: duhet të jetë numër
       odd: duhet të jetë tek
+      other_than: duhet të jetë më shumë se %{count}
+      present: duhet të jetë bosh
       required: duhet të ekzistojë
       taken: është marrë tashmë
       too_long:
@@ -134,7 +137,6 @@ sq:
       wrong_length:
         one: është gjatësia e gabuar (duhet të jetë 1 shkronjë)
         other: është gjatësia e gabuar (duhet të jetë %{count} shkronja)
-      other_than: duhet të jetë më shumë se %{count}
     template:
       body: 'Kishte probleme me formën e mëposhtme:'
       header:
@@ -156,7 +158,7 @@ sq:
         separator: "."
         significant: false
         strip_insignificant_zeros: false
-        unit: "LEK"
+        unit: LEK
     format:
       delimiter: ","
       precision: 3

--- a/rails/locale/sr.yml
+++ b/rails/locale/sr.yml
@@ -17,7 +17,7 @@ sr:
     - Пет
     - Суб
     abbr_month_names:
-    -
+    - 
     - Јан
     - Феб
     - Мар
@@ -43,7 +43,7 @@ sr:
       long: "%B %e, %Y"
       short: "%e %b"
     month_names:
-    -
+    - 
     - Јануар
     - Фабруар
     - Март
@@ -83,54 +83,53 @@ sr:
         many: скоро %{count} година
         other: скоро %{count} година
       half_a_minute: пола минуте
+      less_than_x_seconds:
+        one: мање од %{count} секунд
+        few: мање од %{count} секунде
+        many: мање од %{count} секунди
+        other: мање од %{count} секунди
       less_than_x_minutes:
         one: мање од %{count} минут
         few: мање од %{count} минута
         many: мање од %{count} минута
         other: мање од %{count} минута
-      less_than_x_seconds:
-        few: мање од %{count} секунде
-        one: мање од %{count} секунд
-        many: мање од %{count} секунди
-        other: мање од %{count} секунди
       over_x_years:
         one: преко %{count} године
         few: преко %{count} године
         many: преко %{count} година
         other: преко %{count} година
-      x_days:
-        one: "%{count} дан"
-        few: "%{count} дана"
-        many: "%{count} дана"
-        other: "%{count} дана"
-      x_minutes:
-        one: "%{count} минут"
-        few: "%{count} минута"
-        many: "%{count} минута"
-        other: "%{count} минута"
-      x_months:
-        one: "%{count} месец"
-        few: "%{count} месеца"
-        many: "%{count} месеци"
-        other: "%{count} месеци"
       x_seconds:
         one: "%{count} секунда"
         few: "%{count} секунде"
         many: "%{count} секунди"
         other: "%{count} секунди"
+      x_minutes:
+        one: "%{count} минут"
+        few: "%{count} минута"
+        many: "%{count} минута"
+        other: "%{count} минута"
+      x_days:
+        one: "%{count} дан"
+        few: "%{count} дана"
+        many: "%{count} дана"
+        other: "%{count} дана"
+      x_months:
+        one: "%{count} месец"
+        few: "%{count} месеца"
+        many: "%{count} месеци"
+        other: "%{count} месеци"
     prompts:
-      day: Дан
-      hour: Сат
-      minute: Минут
-      month: Месец
       second: Секунд
+      minute: Минут
+      hour: Сат
+      day: Дан
+      month: Месец
       year: Година
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: мора бити прихваћено
       blank: не сме бити празан
-      present: мора бити празан
       confirmation: се не слаже са потврдом
       empty: не сме бити празан
       equal_to: мора бити једнак %{count}
@@ -146,6 +145,8 @@ sr:
       not_a_number: није број
       not_an_integer: није цео број
       odd: мора бити непаран
+      other_than: мора бити различит од %{count}
+      present: мора бити празан
       required: мора постојати
       taken: је већ заузет
       too_long:
@@ -163,7 +164,6 @@ sr:
         few: није одговарајуће дужине (треба бити %{count} знака)
         many: није одговарајуће дужине (треба бити %{count} знакова)
         other: није одговарајуће дужине (треба бити %{count} знакова)
-      other_than: мора бити различит од %{count}
     template:
       body: 'Молим Вас да проверите следећа поља:'
       header:
@@ -198,11 +198,11 @@ sr:
       decimal_units:
         format: "%n %u"
         units:
-          thousand: Хиљаду
-          million: Милион
           billion: Милијарда
-          trillion: Трилион
+          million: Милион
           quadrillion: Квадрилион
+          thousand: Хиљаду
+          trillion: Трилион
           unit: ''
       format:
         delimiter: ''

--- a/rails/locale/sv-SE.yml
+++ b/rails/locale/sv-SE.yml
@@ -17,7 +17,7 @@ sv-SE:
     - fre
     - lör
     abbr_month_names:
-    -
+    - 
     - jan
     - feb
     - mar
@@ -43,7 +43,7 @@ sv-SE:
       long: "%e %B %Y"
       short: "%e %b"
     month_names:
-    -
+    - 
     - januari
     - februari
     - mars
@@ -75,43 +75,42 @@ sv-SE:
         one: nästan ett år
         other: nästan %{count} år
       half_a_minute: en halv minut
-      less_than_x_minutes:
-        one: mindre än en minut
-        other: mindre än %{count} minuter
       less_than_x_seconds:
         one: mindre än en sekund
         other: mindre än %{count} sekunder
+      less_than_x_minutes:
+        one: mindre än en minut
+        other: mindre än %{count} minuter
       over_x_years:
         one: mer än ett år
         other: mer än %{count} år
-      x_days:
-        one: en dag
-        other: "%{count} dagar"
+      x_seconds:
+        one: en sekund
+        other: "%{count} sekunder"
       x_minutes:
         one: en minut
         other: "%{count} minuter"
+      x_days:
+        one: en dag
+        other: "%{count} dagar"
       x_months:
         one: en månad
         other: "%{count} månader"
       x_years:
         one: ett år
         other: "%{count} år"
-      x_seconds:
-        one: en sekund
-        other: "%{count} sekunder"
     prompts:
-      day: Dag
-      hour: Timme
-      minute: Minut
-      month: Månad
       second: Sekund
+      minute: Minut
+      hour: Timme
+      day: Dag
+      month: Månad
       year: År
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: måste vara accepterad
       blank: måste anges
-      present: får inte anges
       confirmation: stämmer inte överens
       empty: får ej vara tom
       equal_to: måste vara lika med %{count}
@@ -123,16 +122,17 @@ sv-SE:
       invalid: har fel format
       less_than: måste vara mindre än %{count}
       less_than_or_equal_to: måste vara mindre än eller lika med %{count}
-      model_invalid: "Validering misslyckades: %{errors}"
+      model_invalid: 'Validering misslyckades: %{errors}'
       not_a_number: är inte ett nummer
       not_an_integer: måste vara ett heltal
       odd: måste vara udda
+      other_than: måste vara annat än %{count}
+      present: får inte anges
       required: måste finnas
       taken: används redan
       too_long: är för lång (maximum är %{count} tecken)
       too_short: är för kort (minimum är %{count} tecken)
       wrong_length: har fel längd (ska vara %{count} tecken)
-      other_than: måste vara annat än %{count}
     template:
       body: 'Det var problem med följande fält:'
       header:
@@ -148,7 +148,7 @@ sv-SE:
   number:
     currency:
       format:
-        delimiter: ' '
+        delimiter: " "
         format: "%n %u"
         precision: 2
         separator: ","
@@ -156,7 +156,7 @@ sv-SE:
         strip_insignificant_zeros: false
         unit: kr
     format:
-      delimiter: ' '
+      delimiter: " "
       precision: 2
       separator: ","
       significant: false

--- a/rails/locale/sv.yml
+++ b/rails/locale/sv.yml
@@ -17,7 +17,7 @@ sv:
     - fre
     - lör
     abbr_month_names:
-    -
+    - 
     - jan
     - feb
     - mar
@@ -43,7 +43,7 @@ sv:
       long: "%e %B %Y"
       short: "%e %b"
     month_names:
-    -
+    - 
     - januari
     - februari
     - mars
@@ -75,43 +75,42 @@ sv:
         one: nästan ett år
         other: nästan %{count} år
       half_a_minute: en halv minut
-      less_than_x_minutes:
-        one: mindre än en minut
-        other: mindre än %{count} minuter
       less_than_x_seconds:
         one: mindre än en sekund
         other: mindre än %{count} sekunder
+      less_than_x_minutes:
+        one: mindre än en minut
+        other: mindre än %{count} minuter
       over_x_years:
         one: mer än ett år
         other: mer än %{count} år
-      x_days:
-        one: en dag
-        other: "%{count} dagar"
+      x_seconds:
+        one: en sekund
+        other: "%{count} sekunder"
       x_minutes:
         one: en minut
         other: "%{count} minuter"
+      x_days:
+        one: en dag
+        other: "%{count} dagar"
       x_months:
         one: en månad
         other: "%{count} månader"
       x_years:
         one: ett år
         other: "%{count} år"
-      x_seconds:
-        one: en sekund
-        other: "%{count} sekunder"
     prompts:
-      day: Dag
-      hour: Timme
-      minute: Minut
-      month: Månad
       second: Sekund
+      minute: Minut
+      hour: Timme
+      day: Dag
+      month: Månad
       year: År
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: måste vara accepterad
       blank: måste anges
-      present: får inte anges
       confirmation: stämmer inte överens
       empty: får ej vara tom
       equal_to: måste vara lika med %{count}
@@ -123,16 +122,17 @@ sv:
       invalid: har fel format
       less_than: måste vara mindre än %{count}
       less_than_or_equal_to: måste vara mindre än eller lika med %{count}
-      model_invalid: "Validering misslyckades: %{errors}"
+      model_invalid: 'Validering misslyckades: %{errors}'
       not_a_number: är inte ett nummer
       not_an_integer: måste vara ett heltal
       odd: måste vara udda
+      other_than: måste vara annat än %{count}
+      present: får inte anges
       required: måste finnas
       taken: används redan
       too_long: är för lång (maximum är %{count} tecken)
       too_short: är för kort (minimum är %{count} tecken)
       wrong_length: har fel längd (ska vara %{count} tecken)
-      other_than: måste vara annat än %{count}
     template:
       body: 'Det var problem med följande fält:'
       header:
@@ -148,7 +148,7 @@ sv:
   number:
     currency:
       format:
-        delimiter: ' '
+        delimiter: " "
         format: "%n %u"
         precision: 2
         separator: ","
@@ -156,7 +156,7 @@ sv:
         strip_insignificant_zeros: false
         unit: kr
     format:
-      delimiter: ' '
+      delimiter: " "
       precision: 2
       separator: ","
       significant: false

--- a/rails/locale/sw.yml
+++ b/rails/locale/sw.yml
@@ -14,7 +14,7 @@ sw:
     - Ij
     - J1
     abbr_month_names:
-    -
+    - 
     - Jan
     - Feb
     - Mac
@@ -40,7 +40,7 @@ sw:
       long: "%e %B, %Y"
       short: "%e %b"
     month_names:
-    -
+    - 
     - Mwezi wa kwanza
     - Mwezi wa pili
     - Mwezi wa tatu
@@ -72,33 +72,33 @@ sw:
         one: karibia mwaka
         other: karibia miaka %{count}
       half_a_minute: nusu dakika
-      less_than_x_minutes:
-        one: chini ya dakika 1
-        other: chini ya dakika %{count}
       less_than_x_seconds:
         one: chini ya sekunde 1
         other: chini ya sekunde %{count}
+      less_than_x_minutes:
+        one: chini ya dakika 1
+        other: chini ya dakika %{count}
       over_x_years:
         one: zaidi ya mwaka 1
         other: zaidi ya miaka %{count}
-      x_days:
-        one: siku 1
-        other: siku %{count}
-      x_minutes:
-        one: dakika 1
-        other: dakika %{count}
-      x_months:
-        one: mwezi 1
-        other: miezi %{count}
       x_seconds:
         one: sekunde 1
         other: sekunde %{count}
+      x_minutes:
+        one: dakika 1
+        other: dakika %{count}
+      x_days:
+        one: siku 1
+        other: siku %{count}
+      x_months:
+        one: mwezi 1
+        other: miezi %{count}
     prompts:
-      day: Siku
-      hour: Saa
-      minute: Dakika
-      month: Mwezi
       second: Sekunde
+      minute: Dakika
+      hour: Saa
+      day: Siku
+      month: Mwezi
       year: Mwaka
   errors:
     format: "%{attribute} %{message}"

--- a/rails/locale/ta.yml
+++ b/rails/locale/ta.yml
@@ -17,7 +17,7 @@ ta:
     - வெள்ளி
     - சனி
     abbr_month_names:
-    -
+    - 
     - ஜன
     - பிப்
     - மார்ச்
@@ -43,7 +43,7 @@ ta:
       long: "%B %d, %Y"
       short: "%b %d"
     month_names:
-    -
+    - 
     - ஜனவரி
     - பிப்ரவரி
     - மார்ச்
@@ -75,40 +75,39 @@ ta:
         one: கிட்டத்தட்ட 1  ஆண்டு
         other: கிட்டத்தட்ட %{count}  ஆண்டுகள்
       half_a_minute: அரை நிமிடம்
-      less_than_x_minutes:
-        one: ஒரு நிமிடத்திற்கும் குறைவாக
-        other: குறைவாக %{count} நிமிடங்கள்
       less_than_x_seconds:
         one: ஒரு வினாடிக்கும் குறைவாக
         other: குறைவாக %{count} வினாடிகள்
+      less_than_x_minutes:
+        one: ஒரு நிமிடத்திற்கும் குறைவாக
+        other: குறைவாக %{count} நிமிடங்கள்
       over_x_years:
         one: ஒரு  ஆண்டிற்கு மேலாக
         other: "%{count}  ஆண்டிற்கு மேலாக"
-      x_days:
-        one: 1 நாள்
-        other: "%{count} நாட்கள்"
-      x_minutes:
-        one: 1 நிமிடம்
-        other: "%{count} நிமிடங்கள்"
-      x_months:
-        one: 1 மாதம்
-        other: "%{count} மாதங்கள்"
       x_seconds:
         one: 1 வினாடி
         other: "%{count} விநாடிகள்"
+      x_minutes:
+        one: 1 நிமிடம்
+        other: "%{count} நிமிடங்கள்"
+      x_days:
+        one: 1 நாள்
+        other: "%{count} நாட்கள்"
+      x_months:
+        one: 1 மாதம்
+        other: "%{count} மாதங்கள்"
     prompts:
-      day: நாள்
-      hour: மணி
-      minute: நிமிடம்
-      month: மாதம்
       second: விநாடிகள்
+      minute: நிமிடம்
+      hour: மணி
+      day: நாள்
+      month: மாதம்
       year: ஆண்டு
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: ஏற்கப்பட வேண்டும்
       blank: காலியாக இருக்க முடியாது
-      present: காலியாக இருக்க வேண்டும்
       confirmation: "%{attribute}  பொருந்தவில்லை"
       empty: வெறுமையாக இருக்க முடியாது
       equal_to: "%{count} சமமாக இருக்க வேண்டும்"
@@ -123,6 +122,8 @@ ta:
       not_a_number: ஒரு எண் அல்ல
       not_an_integer: ஒரு முழு எண்ணாக இருக்க வேண்டும்
       odd: ஒற்றைப்படை இருக்க வேண்டும்
+      other_than: "%{count} தவிர வேறு இருக்க வேண்டும்"
+      present: காலியாக இருக்க வேண்டும்
       taken: ஏற்கனவே எடுத்துகொள்ள பட்டது
       too_long:
         one: மிக நீளமாக உள்ளது (அதிகபட்சமாக ஒரு எழுத்து)
@@ -133,7 +134,6 @@ ta:
       wrong_length:
         one: தவறான நீளம் (1 எழுத்து இருக்கவேண்டும்)
         other: தவறான நீளம் (%{count} எழுத்துக்கள் இருக்கவேண்டும்)
-      other_than: "%{count} தவிர வேறு இருக்க வேண்டும்"
     template:
       body: 'பின்வரும் புலங்களில் பிரச்சினைகள் உள்ளது:'
       header:

--- a/rails/locale/te.yml
+++ b/rails/locale/te.yml
@@ -1,14 +1,12 @@
-# Telugu translations for Ruby on Rails
-# by Ravi Teja Dandu(raviteja499@gmail.com)
 ---
 te:
   activerecord:
     errors:
       messages:
-        record_invalid: "ధ్రువీకరన విఫలమైనది: %{errors}"
+        record_invalid: 'ధ్రువీకరన విఫలమైనది: %{errors}'
         restrict_dependent_destroy:
-          has_one: "రికార్డ్ను తొలగించలేరు, ఎందుకంటే ఒక ఆధారపడిన %{record} ఉంది"
-          has_many: "రికార్డ్ను తొలగించలేరు, ఎందుకంటే ఆధారపడిన %{record} ఉంది"
+          has_one: రికార్డ్ను తొలగించలేరు, ఎందుకంటే ఒక ఆధారపడిన %{record} ఉంది
+          has_many: రికార్డ్ను తొలగించలేరు, ఎందుకంటే ఆధారపడిన %{record} ఉంది
   date:
     abbr_day_names:
     - ఆది
@@ -19,7 +17,7 @@ te:
     - శుక్ర
     - శని
     abbr_month_names:
-    -
+    - 
     - Jan
     - Feb
     - Mar
@@ -45,7 +43,7 @@ te:
       long: "%B %d, %Y"
       short: "%b %d"
     month_names:
-    -
+    - 
     - జనవరి
     - ఫిబ్రవరి
     - మార్చి
@@ -77,43 +75,42 @@ te:
         one: దాదాపు ఒక సంవత్సరం
         other: దాదాపు %{count} సంవత్సరాలు
       half_a_minute: అర నిమిషం
-      less_than_x_minutes:
-        one: ఒక నిమిషం కన్నా తక్కువ
-        other: "%{count} నిమిషాల కన్నా తక్కువ"
       less_than_x_seconds:
         one: ఒక క్షణం కన్నా తక్కువ
         other: "%{count} క్షణాలు కన్నా తక్కువ"
+      less_than_x_minutes:
+        one: ఒక నిమిషం కన్నా తక్కువ
+        other: "%{count} నిమిషాల కన్నా తక్కువ"
       over_x_years:
         one: ఒక సంవత్సరం పైగా
         other: "%{count} సంవత్సరాల పైగా"
-      x_days:
-        one: ఒక రోజు
-        other: "%{count} రోజులు"
+      x_seconds:
+        one: ఒక క్షణం
+        other: "%{count} క్షణాలు"
       x_minutes:
         one: ఒక నిమిషం
         other: "%{count} నిమిషాలు"
+      x_days:
+        one: ఒక రోజు
+        other: "%{count} రోజులు"
       x_months:
         one: ఒక నెల
         other: "%{count} నెలలు"
       x_years:
         one: ఒక సంవత్సరం
         other: "%{count} సంవత్సరాలు"
-      x_seconds:
-        one: ఒక క్షణం
-        other: "%{count} క్షణాలు"
     prompts:
-      day: రోజు
-      hour: గంట
-      minute: నిమిషం
-      month: నెల
       second: క్షణాలు
+      minute: నిమిషం
+      hour: గంట
+      day: రోజు
+      month: నెల
       year: సంవత్సరం
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: అంగీకరించి ఉండాలి
       blank: ఖాళీగా ఉండకూడదు
-      present: ఖాళీగా ఉండాలి
       confirmation: "%{attribute} సరిపోలడం లేదు"
       empty: శూన్యంగా ఉండకూడదు
       equal_to: "%{count}కు సమానంగా ఉండాలి"
@@ -125,10 +122,12 @@ te:
       invalid: చెల్లనిది
       less_than: "%{count} కంటే తక్కువ ఉండాలి"
       less_than_or_equal_to: "%{count} నాలుగు కంటే తక్కువగా లేదా సమానంగా ఉండాలి"
-      model_invalid: "ధృవీకరణ విఫలమైంది: %{errors}"
+      model_invalid: 'ధృవీకరణ విఫలమైంది: %{errors}'
       not_a_number: సంఖ్య కాదు
       not_an_integer: పూర్ణాంకంగా ఉండాలి
       odd: బేసి సంఖ్య అయి ఉండాలి
+      other_than: "%{count} కన్నా వేరు ఉండాలి"
+      present: ఖాళీగా ఉండాలి
       required: ఉనికిలో ఉండాలి
       taken: ఇప్పటికే తీసుకోబడింది
       too_long:
@@ -140,7 +139,6 @@ te:
       wrong_length:
         one: తప్పు పొడవు (ఒక అక్షరం ఉండాలి)
         other: తప్పు పొడవు (%{count} అక్షరాలు ఉండాలి)
-      other_than: "%{count} కన్నా వేరు ఉండాలి"
     template:
       body: 'కింది రంగాలలో సమస్యలు ఉన్నాయి:'
       header:

--- a/rails/locale/th.yml
+++ b/rails/locale/th.yml
@@ -14,7 +14,7 @@ th:
     - ศ
     - ส
     abbr_month_names:
-    -
+    - 
     - ม.ค.
     - ก.พ.
     - มี.ค.
@@ -40,7 +40,7 @@ th:
       long: "%d %B %Y"
       short: "%d %b"
     month_names:
-    -
+    - 
     - มกราคม
     - กุมภาพันธ์
     - มีนาคม
@@ -64,19 +64,19 @@ th:
       about_x_years: ประมาณ %{count} ปี
       almost_x_years: เกือบ %{count} ปี
       half_a_minute: ครึ่งนาที
-      less_than_x_minutes: น้อยกว่า %{count} นาที
       less_than_x_seconds: น้อยกว่า %{count} วินาที
+      less_than_x_minutes: น้อยกว่า %{count} นาที
       over_x_years: มากกว่า %{count} ปี
-      x_days: "%{count} วัน"
-      x_minutes: "%{count} นาที"
-      x_months: "%{count} เดือน"
       x_seconds: "%{count} วินาที"
+      x_minutes: "%{count} นาที"
+      x_days: "%{count} วัน"
+      x_months: "%{count} เดือน"
     prompts:
-      day: วัน
-      hour: ชั่วโมง
-      minute: นาที
-      month: เดือน
       second: วินาที
+      minute: นาที
+      hour: ชั่วโมง
+      day: วัน
+      month: เดือน
       year: ปี
   errors:
     format: "%{attribute} %{message}"

--- a/rails/locale/tl.yml
+++ b/rails/locale/tl.yml
@@ -5,18 +5,6 @@ tl:
       messages:
         record_invalid: 'Nabigo ang pagpapatunay: %{errors}'
   date:
-    formats:
-      default: "%d/%m/%Y"
-      short: ika-%d ng %b
-      long: ika-%d ng %B, %Y
-    day_names:
-    - Linggo
-    - Lunes
-    - Martes
-    - Miyerkules
-    - Huwebes
-    - Biyernes
-    - Sabado
     abbr_day_names:
     - Lin
     - Lun
@@ -25,22 +13,8 @@ tl:
     - Huw
     - Biy
     - Sab
-    month_names:
-    -
-    - Enero
-    - Pebrero
-    - Marso
-    - Abril
-    - Mayo
-    - Hunyo
-    - Hulyo
-    - Agosto
-    - Setyembre
-    - Oktubre
-    - Nobyembre
-    - Disyembre
     abbr_month_names:
-    -
+    - 
     - Ene
     - Peb
     - Mar
@@ -53,45 +27,146 @@ tl:
     - Okt
     - Nob
     - Dis
+    day_names:
+    - Linggo
+    - Lunes
+    - Martes
+    - Miyerkules
+    - Huwebes
+    - Biyernes
+    - Sabado
+    formats:
+      default: "%d/%m/%Y"
+      long: ika-%d ng %B, %Y
+      short: ika-%d ng %b
+    month_names:
+    - 
+    - Enero
+    - Pebrero
+    - Marso
+    - Abril
+    - Mayo
+    - Hunyo
+    - Hulyo
+    - Agosto
+    - Setyembre
+    - Oktubre
+    - Nobyembre
+    - Disyembre
     order:
     - :year
     - :month
     - :day
-  time:
-    formats:
-      default: "%A, ika-%d ng %B ng %Y %H:%M:%S %z"
-      short: "%d ng %b %H:%M"
-      long: ika-%d ng %B ng %Y %H:%M
-    am: AM
-    pm: PM
-  support:
-    array:
-      words_connector: ","
-      two_words_connector: at
-      last_word_connector: ", at"
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: humigit-kumulang isang oras
+        other: humigit-kumulang %{count} oras
+      about_x_months:
+        one: humigit-kumulang isang buwan
+        other: humigit-kumulang %{count} buwan
+      about_x_years:
+        one: humigit-kumulang isang taon
+        other: humigit-kumulang %{count} taon
+      almost_x_years:
+        one: halos isang taon
+        other: halos %{count} taon
+      half_a_minute: kalahating minuto
+      less_than_x_seconds:
+        one: mas mababa sa isang segundo
+        other: mas mababa sa %{count} segundo
+      less_than_x_minutes:
+        one: mas mababa sa isang minuto
+        other: mas mababa sa %{count} minuto
+      over_x_years:
+        one: higit sa isang taon
+        other: higit %{count} taon
+      x_seconds:
+        one: isang segundo
+        other: "%{count} segundo"
+      x_minutes:
+        one: isang minuto
+        other: "%{count} minuto"
+      x_days:
+        one: isang araw
+        other: "%{count} araw"
+      x_months:
+        one: isang buwan
+        other: "%{count} buwan"
+    prompts:
+      second: segundo
+      minute: minuto
+      hour: oras
+      day: araw
+      month: buwan
+      year: taon
+  errors:
+    format: "%{attribute} ay %{message}"
+    messages:
+      accepted: dapat na tanggapin
+      blank: hindi maaaring walang laman
+      confirmation: hindi tumutugma ang pagpapatunay
+      empty: hindi maaaring walang laman
+      equal_to: dapat na katumba sa %{count}
+      even: dapat maging even
+      exclusion: nakalaan na
+      greater_than: dapat na mas higit sa %{count}
+      greater_than_or_equal_to: dapat na mas higit sa o katumbas ng %{count}
+      inclusion: hindi kasama sa listahan
+      invalid: hindi wasto
+      less_than: dapat na mas mababa sa %{count}
+      less_than_or_equal_to: dapat na mas mababa sa o katumbas ng %{count}
+      not_a_number: hindi isang numero
+      not_an_integer: dapat na isang integer
+      odd: dapat maging odd
+      taken: ginagamit na
+      too_long:
+        one: masyadong mahaba (pinakamadami ay %{count} character)
+        other: masyadong mahaba (pinakamadami ay %{count} character)
+      too_short:
+        one: masyadong maikli (pinakakonti ay %{count} character)
+        other: masyadong maikli (pinakakonti ay %{count} character)
+      wrong_length:
+        one: ang maling haba (ito ay dapat eksaktong %{count} character)
+        other: ang maling haba (ito ay dapat eksaktong %{count} character)
+    template:
+      body: 'May mga problema sa mga sumusunod na patlang:'
+      header:
+        one: hindi maaaring i-save ang %{model} na ito dahil sa isang error
+        other: hindi maaaring i-save ang %{model} na ito dahil sa %{count} error
+  helpers:
+    select:
+      prompt: Mangyaring pumili
+    submit:
+      create: lumikha ng %{model}
+      submit: isumite ang %{model}
+      update: i-update ang %{model}
   number:
-    format:
-      separator: "."
-      delimiter: ","
-      precision: 3
-      significant: false
-      strip_insignificant_zeros: false
     currency:
       format:
-        format: "%n %u"
-        unit: "₱"
-        separator: "."
         delimiter: ","
+        format: "%n %u"
         precision: 2
+        separator: "."
         significant: false
         strip_insignificant_zeros: false
-    percentage:
-      format:
-        delimiter: ''
-    precision:
-      format:
-        delimiter: ''
+        unit: "₱"
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
     human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: bilyon
+          million: milyon
+          quadrillion: kuwadrilyon
+          thousand: libo
+          trillion: trilyon
+          unit: ''
       format:
         delimiter: ''
         precision: 1
@@ -103,100 +178,25 @@ tl:
           byte:
             one: Byte
             other: Bytes
+          gb: GB
           kb: KB
           mb: MB
-          gb: GB
           tb: TB
-      decimal_units:
-        format: "%n %u"
-        units:
-          unit: ''
-          thousand: libo
-          million: milyon
-          billion: bilyon
-          trillion: trilyon
-          quadrillion: kuwadrilyon
-  datetime:
-    distance_in_words:
-      half_a_minute: kalahating minuto
-      less_than_x_seconds:
-        one: mas mababa sa isang segundo
-        other: mas mababa sa %{count} segundo
-      x_seconds:
-        one: isang segundo
-        other: "%{count} segundo"
-      less_than_x_minutes:
-        one: mas mababa sa isang minuto
-        other: mas mababa sa %{count} minuto
-      x_minutes:
-        one: isang minuto
-        other: "%{count} minuto"
-      about_x_hours:
-        one: humigit-kumulang isang oras
-        other: humigit-kumulang %{count} oras
-      x_days:
-        one: isang araw
-        other: "%{count} araw"
-      about_x_months:
-        one: humigit-kumulang isang buwan
-        other: humigit-kumulang %{count} buwan
-      x_months:
-        one: isang buwan
-        other: "%{count} buwan"
-      about_x_years:
-        one: humigit-kumulang isang taon
-        other: humigit-kumulang %{count} taon
-      over_x_years:
-        one: higit sa isang taon
-        other: higit %{count} taon
-      almost_x_years:
-        one: halos isang taon
-        other: halos %{count} taon
-    prompts:
-      year: taon
-      month: buwan
-      day: araw
-      hour: oras
-      minute: minuto
-      second: segundo
-  helpers:
-    select:
-      prompt: Mangyaring pumili
-    submit:
-      create: lumikha ng %{model}
-      update: i-update ang %{model}
-      submit: isumite ang %{model}
-  errors:
-    format: "%{attribute} ay %{message}"
-    messages:
-      inclusion: hindi kasama sa listahan
-      exclusion: nakalaan na
-      invalid: hindi wasto
-      confirmation: hindi tumutugma ang pagpapatunay
-      accepted: dapat na tanggapin
-      empty: hindi maaaring walang laman
-      blank: hindi maaaring walang laman
-      too_long:
-        one: masyadong mahaba (pinakamadami ay %{count} character)
-        other: masyadong mahaba (pinakamadami ay %{count} character)
-      too_short:
-        one: masyadong maikli (pinakakonti ay %{count} character)
-        other: masyadong maikli (pinakakonti ay %{count} character)
-      wrong_length:
-        one: ang maling haba (ito ay dapat eksaktong %{count} character)
-        other: ang maling haba (ito ay dapat eksaktong %{count} character)
-      not_a_number: hindi isang numero
-      not_an_integer: dapat na isang integer
-      greater_than: dapat na mas higit sa %{count}
-      greater_than_or_equal_to: dapat na mas higit sa o katumbas ng %{count}
-      equal_to: dapat na katumba sa %{count}
-      less_than: dapat na mas mababa sa %{count}
-      less_than_or_equal_to: dapat na mas mababa sa o katumbas ng %{count}
-      odd: dapat maging odd
-      even: dapat maging even
-      taken: ginagamit na
-    template:
-      header:
-        one: hindi maaaring i-save ang %{model} na ito dahil sa isang error
-        other: hindi maaaring i-save ang %{model} na ito dahil sa %{count} error
-      body: 'May mga problema sa mga sumusunod na patlang:'
+    percentage:
+      format:
+        delimiter: ''
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: ", at"
+      two_words_connector: at
+      words_connector: ","
+  time:
+    am: AM
+    formats:
+      default: "%A, ika-%d ng %B ng %Y %H:%M:%S %z"
+      long: ika-%d ng %B ng %Y %H:%M
+      short: "%d ng %b %H:%M"
+    pm: PM

--- a/rails/locale/tr.yml
+++ b/rails/locale/tr.yml
@@ -17,7 +17,7 @@ tr:
     - Cum
     - Cts
     abbr_month_names:
-    -
+    - 
     - Oca
     - Şub
     - Mar
@@ -43,7 +43,7 @@ tr:
       long: "%e %B %Y, %A"
       short: "%e %b"
     month_names:
-    -
+    - 
     - Ocak
     - Şubat
     - Mart
@@ -75,43 +75,42 @@ tr:
         one: neredeyse 1 yıl
         other: neredeyse %{count} yıl
       half_a_minute: yarım dakika
-      less_than_x_minutes:
-        one: 1 dakikadan az
-        other: "%{count} dakikadan az"
       less_than_x_seconds:
         one: 1 saniyeden az
         other: "%{count} saniyeden az"
+      less_than_x_minutes:
+        one: 1 dakikadan az
+        other: "%{count} dakikadan az"
       over_x_years:
         one: 1 yıldan fazla
         other: "%{count} yıldan fazla"
-      x_days:
-        one: 1 gün
-        other: "%{count} gün"
-      x_minutes:
-        one: 1 dakika
-        other: "%{count} dakika"
-      x_months:
-        one: 1 ay
-        other: "%{count} ay"
       x_seconds:
         one: 1 saniye
         other: "%{count} saniye"
+      x_minutes:
+        one: 1 dakika
+        other: "%{count} dakika"
+      x_days:
+        one: 1 gün
+        other: "%{count} gün"
+      x_months:
+        one: 1 ay
+        other: "%{count} ay"
       x_years:
         one: 1 yıl
         other: "%{count} yıl"
     prompts:
-      day: Gün
-      hour: Saat
-      minute: Dakika
-      month: Ay
       second: Saniye
+      minute: Dakika
+      hour: Saat
+      day: Gün
+      month: Ay
       year: Yıl
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: kabul edilmeli
       blank: doldurulmalı
-      present: boş bırakılmalı
       confirmation: "%{attribute} teyidiyle uyuşmuyor"
       empty: doldurulmalı
       equal_to: tam olarak %{count} olmalı
@@ -123,9 +122,13 @@ tr:
       invalid: geçersiz
       less_than: "%{count} sayısından küçük olmalı"
       less_than_or_equal_to: "%{count} sayısına eşit veya küçük olmalı"
+      model_invalid: 'Doğrulama başarısız oldu: %{errors}'
       not_a_number: geçerli bir sayı değil
       not_an_integer: tam sayı olmalı
       odd: tek olmalı
+      other_than: "%{count} karakterden oluşamaz"
+      present: boş bırakılmalı
+      required: doldurulmalı
       taken: hali hazırda kullanılmakta
       too_long:
         one: çok uzun (en fazla 1 karakter)
@@ -136,9 +139,6 @@ tr:
       wrong_length:
         one: hatalı uzunlukta (1 karakter olmalı)
         other: hatalı uzunlukta (%{count} karakter olmalı)
-      other_than: "%{count} karakterden oluşamaz"
-      model_invalid: "Doğrulama başarısız oldu: %{errors}"
-      required: doldurulmalı
     template:
       body: 'Lütfen aşağıdaki hataları düzeltiniz:'
       header:
@@ -160,7 +160,7 @@ tr:
         separator: ","
         significant: false
         strip_insignificant_zeros: false
-        unit: ₺
+        unit: "₺"
     format:
       delimiter: "."
       precision: 2

--- a/rails/locale/tt.yml
+++ b/rails/locale/tt.yml
@@ -17,7 +17,7 @@ tt:
     - Җом
     - Шим
     abbr_month_names:
-    -
+    - 
     - гыйн.
     - февр.
     - март
@@ -43,7 +43,7 @@ tt:
       long: "%-d %B %Y"
       short: "%-d %b"
     month_names:
-    -
+    - 
     - гыйнвар
     - февраль
     - март
@@ -75,40 +75,39 @@ tt:
         one: бер ел диярлек
         other: "%{count} ел диярлек"
       half_a_minute: минуттан азрак
-      less_than_x_minutes:
-        one: бер минуттан азрак
-        other: "%{count} минуттан азрак"
       less_than_x_seconds:
         one: бер секундтан азрак
         other: "%{count} секундтан азрак"
+      less_than_x_minutes:
+        one: бер минуттан азрак
+        other: "%{count} минуттан азрак"
       over_x_years:
         one: бер ел артык
         other: "%{count} ел артык"
-      x_days:
-        one: бер көн
-        other: "%{count} көн"
-      x_minutes:
-        one: бер минут
-        other: "%{count} минут"
-      x_months:
-        one: бер ай
-        other: "%{count} ай"
       x_seconds:
         one: бер секунд
         other: "%{count} секунд"
+      x_minutes:
+        one: бер минут
+        other: "%{count} минут"
+      x_days:
+        one: бер көн
+        other: "%{count} көн"
+      x_months:
+        one: бер ай
+        other: "%{count} ай"
     prompts:
-      day: Көн
-      hour: Сәгать
-      minute: Минут
-      month: Ай
       second: Секунд
+      minute: Минут
+      hour: Сәгать
+      day: Көн
+      month: Ай
       year: Ел
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: раслау кирәк
       blank: буш була алмый
-      present: буш булырга тиеш
       confirmation: "%{attribute} читнең мәгнәсе белән тигез түгел"
       empty: буш була алмый
       equal_to: мәгнәсе %{count} була гына ала
@@ -123,6 +122,8 @@ tt:
       not_a_number: сан тугел
       not_an_integer: бөтен сан түгел
       odd: җөп кенә була ала
+      other_than: "%{count} мәгнәсеннән икенче булырга тиеш"
+      present: буш булырга тиеш
       taken: бар инде
       too_long:
         one: бигрәк озын (озынлыгы бердән озынрак була алмый)
@@ -133,7 +134,6 @@ tt:
       wrong_length:
         one: озынлыгы ялгыш (озынлыгы бергә тигез булырга тиеш)
         other: озынлыгы ялгыш (озынлыгы %{count} мәгнәгә тигез булырга тиеш)
-      other_than: "%{count} мәгнәсеннән икенче булырга тиеш"
     template:
       body: ":"
       header:

--- a/rails/locale/ug.yml
+++ b/rails/locale/ug.yml
@@ -17,7 +17,7 @@ ug:
     - جۈمە
     - شەنبە
     abbr_month_names:
-    -
+    - 
     - يانۋار
     - فېۋرال
     - مارت
@@ -43,7 +43,7 @@ ug:
       long: "%Y-%m-%d"
       short: "%b%d"
     month_names:
-    -
+    - 
     - يانۋار
     - فېۋرال
     - مارت
@@ -75,40 +75,39 @@ ug:
         one: بىر يىلغا يېقىن
         other: "%{count} يىلغا يېقىن"
       half_a_minute: يېرىم مىنۇت
-      less_than_x_minutes:
-        one: بىر مىنۇتقا يەتمىگەن
-        other: "%{count} مىنۇتقا يەتمىگەن"
       less_than_x_seconds:
         one: بىر سىكۇنتقا يەتمىگەن
         other: "%{count} سىكنۇتقا"
+      less_than_x_minutes:
+        one: بىر مىنۇتقا يەتمىگەن
+        other: "%{count} مىنۇتقا يەتمىگەن"
       over_x_years:
         one: بىر يىلدىن ئارتۇق
         other: "%{count} يىلدىن ئارتۇق"
-      x_days:
-        one: بىر كۈن
-        other: "%{count} كۈن"
-      x_minutes:
-        one: بىر مىنۇت
-        other: "%{count} مىنۇت"
-      x_months:
-        one: بىر ئاي
-        other: "%{count} ئاي"
       x_seconds:
         one: بىر سىكنۇت
         other: "%{count} سىكنۇت"
+      x_minutes:
+        one: بىر مىنۇت
+        other: "%{count} مىنۇت"
+      x_days:
+        one: بىر كۈن
+        other: "%{count} كۈن"
+      x_months:
+        one: بىر ئاي
+        other: "%{count} ئاي"
     prompts:
-      day: كۈن
-      hour: سائەت
-      minute: مىنۇت
-      month: ئاي
       second: سىكنۇت
+      minute: مىنۇت
+      hour: سائەت
+      day: كۈن
+      month: ئاي
       year: يىل
   errors:
     format: "%{attribute}%{message}"
     messages:
       accepted: تەستىقلاش كېرەك
       blank: بوش بولماسلىقى كېرەك
-      present: بوش بولىشى كېرەك
       confirmation: تەستىق بىلەن ماس ئەمەس
       empty: بوش بولماسلىقى كېرەك
       equal_to: "%{count} غا تەڭ"
@@ -123,6 +122,8 @@ ug:
       not_a_number: سان ئەمەس
       not_an_integer: پۈتۈن سان ئەمەس
       odd: تاق سان
+      other_than: ئىناۋەتسىز ئۇزۇنلۇق (%{count} ھەرىپ بولماسلىقى كېرەك)
+      present: بوش بولىشى كېرەك
       taken: ئىشلىتىپ بولۇنغان
       too_long:
         one: بەك ئۇزۇن (بىر ھەرىپ)
@@ -133,7 +134,6 @@ ug:
       wrong_length:
         one: ئىناۋەتسىز ئۇزۇنلۇق (بىر ھەرىپ)
         other: ئىناۋەتسىز ئۇزۇنلۇق (چوقۇم %{count} ھەرىپ)
-      other_than: ئىناۋەتسىز ئۇزۇنلۇق (%{count} ھەرىپ بولماسلىقى كېرەك)
     template:
       body: تۆۋەندىكى سۆز بۆلەكلىرىدە خاتالىق بار
       header:

--- a/rails/locale/uk.yml
+++ b/rails/locale/uk.yml
@@ -17,7 +17,7 @@ uk:
     - пт.
     - сб.
     abbr_month_names:
-    -
+    - 
     - січ.
     - лют.
     - бер.
@@ -43,7 +43,7 @@ uk:
       long: "%d %B %Y"
       short: "%d %b"
     month_names:
-    -
+    - 
     - Січня
     - Лютого
     - Березня
@@ -63,79 +63,78 @@ uk:
   datetime:
     distance_in_words:
       about_x_hours:
+        one: близько %{count} година
         few: близько %{count} години
         many: близько %{count} годин
-        one: близько %{count} година
         other: близько %{count} години
       about_x_months:
+        one: близько %{count} місяця
         few: близько %{count} місяців
         many: близько %{count} місяців
-        one: близько %{count} місяця
         other: близько %{count} місяця
       about_x_years:
+        one: близько %{count} року
         few: близько %{count} років
         many: близько %{count} років
-        one: близько %{count} року
         other: близько %{count} року
       almost_x_years:
+        one: майже %{count} роки
         few: майже %{count} років
         many: майже %{count} років
-        one: майже %{count} роки
         other: майже %{count} років
       half_a_minute: півхвилини
-      less_than_x_minutes:
-        few: менше %{count} хвилин
-        many: менше %{count} хвилин
-        one: менше %{count} хвилини
-        other: менше %{count} хвилини
       less_than_x_seconds:
+        one: менше %{count} секунди
         few: менше %{count} секунд
         many: менше %{count} секунд
-        one: менше %{count} секунди
         other: менше %{count} секунди
+      less_than_x_minutes:
+        one: менше %{count} хвилини
+        few: менше %{count} хвилин
+        many: менше %{count} хвилин
+        other: менше %{count} хвилини
       over_x_years:
+        one: більше %{count} року
         few: більше %{count} років
         many: більше %{count} років
-        one: більше %{count} року
         other: більше %{count} року
-      x_days:
-        few: "%{count} дні"
-        many: "%{count} днів"
-        one: "%{count} день"
-        other: "%{count} дня"
-      x_minutes:
-        few: "%{count} хвилини"
-        many: "%{count} хвилин"
-        one: "%{count} хвилина"
-        other: "%{count} хвилини"
-      x_months:
-        few: "%{count} місяці"
-        many: "%{count} місяців"
-        one: "%{count} місяць"
-        other: "%{count} місяця"
-      x_years:
-        few: "%{count} роки"
-        many: "%{count} років"
-        one: "%{count} рік"
-        other: "%{count} року"
       x_seconds:
+        one: "%{count} секунда"
         few: "%{count} секунди"
         many: "%{count} секунд"
-        one: "%{count} секунда"
         other: "%{count} секунди"
+      x_minutes:
+        one: "%{count} хвилина"
+        few: "%{count} хвилини"
+        many: "%{count} хвилин"
+        other: "%{count} хвилини"
+      x_days:
+        one: "%{count} день"
+        few: "%{count} дні"
+        many: "%{count} днів"
+        other: "%{count} дня"
+      x_months:
+        one: "%{count} місяць"
+        few: "%{count} місяці"
+        many: "%{count} місяців"
+        other: "%{count} місяця"
+      x_years:
+        one: "%{count} рік"
+        few: "%{count} роки"
+        many: "%{count} років"
+        other: "%{count} року"
     prompts:
-      day: День
-      hour: Година
-      minute: Хвилина
-      month: Місяць
       second: Секунда
+      minute: Хвилина
+      hour: Година
+      day: День
+      month: Місяць
       year: Рік
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: має бути прийнятий
       blank: не може бути пустим
-      present: має бути пустим
       confirmation: не збігається з підтвердженням
       empty: не може бути порожнім
       equal_to: має дорівнювати %{count}
@@ -151,30 +150,31 @@ uk:
       not_a_number: не число
       not_an_integer: не є цілим числом
       odd: має бути непарним
+      other_than: має відрізнятись від %{count}
+      present: має бути пустим
       required: не може бути порожнім
       taken: вже зайнятий
       too_long:
+        one: занадто довгий (максимум %{count} знак)
         few: занадто довгий (максимум %{count} знаки)
         many: занадто довгий (максимум %{count} знаків)
-        one: занадто довгий (максимум %{count} знак)
         other: занадто довгий (максимум %{count} знаку)
       too_short:
+        one: занадто короткий (мінімум %{count} знак)
         few: занадто короткий (мінімум %{count} знаки)
         many: занадто короткий (мінімум %{count} знаків)
-        one: занадто короткий (мінімум %{count} знак)
         other: занадто короткий (мінімум %{count} знаку)
       wrong_length:
+        one: неправильна довжина (має бути %{count} знак)
         few: неправильна довжина (має бути %{count} знаки)
         many: неправильна довжина (має бути %{count} знаків)
-        one: неправильна довжина (має бути %{count} знак)
         other: неправильна довжина (має бути %{count} знаку)
-      other_than: має відрізнятись від %{count}
     template:
       body: 'Помилки виявлено в таких полях:'
       header:
+        one: "%{model} не збережено через %{count} помилку"
         few: "%{model} не збережено через %{count} помилки"
         many: "%{model} не збережено через %{count} помилок"
-        one: "%{model} не збережено через %{count} помилку"
         other: "%{model} не збережено через %{count} помилки"
   helpers:
     select:
@@ -204,29 +204,29 @@ uk:
         format: "%n %u"
         units:
           billion:
+            one: Мільярд
             few: Мільярдів
             many: Мільярдів
-            one: Мільярд
             other: Мільярдів
           million:
+            one: Мільйон
             few: Мільйонів
             many: Мільйонів
-            one: Мільйон
             other: Мільйонів
           quadrillion:
+            one: Кквадрильйон
             few: Квадрильйонів
             many: Квадрильйонів
-            one: Кквадрильйон
             other: Квадрильйонів
           thousand:
+            one: Тисяча
             few: Тисяч
             many: Тисяч
-            one: Тисяча
             other: Тисяч
           trillion:
+            one: Трильйон
             few: Трильйонів
             many: Трильйонів
-            one: Трильйон
             other: Трильйонів
           unit: ''
       format:
@@ -238,9 +238,9 @@ uk:
         format: "%n %u"
         units:
           byte:
+            one: байт
             few: байти
             many: байтів
-            one: байт
             other: байту
           gb: ГБ
           kb: кБ

--- a/rails/locale/ur.yml
+++ b/rails/locale/ur.yml
@@ -5,9 +5,10 @@ ur:
       messages:
         record_invalid: 'توثیق میں نا کا می: %{errors}'
         restrict_dependent_destroy:
-          has_one: ایک منحصر %{record} کی موجودگی کے باعث اس ریکارڈ کو حذف نہیں کیا جا سکتا
-          has_many: چند منحصر %{record}  کی موجودگی کے باعث اس ریکارڈ کو حذف نہیں کیا جا
-            سکتا
+          has_one: ایک منحصر %{record} کی موجودگی کے باعث اس ریکارڈ کو حذف نہیں کیا
+            جا سکتا
+          has_many: چند منحصر %{record}  کی موجودگی کے باعث اس ریکارڈ کو حذف نہیں
+            کیا جا سکتا
   date:
     abbr_day_names:
     - اتوار
@@ -18,7 +19,7 @@ ur:
     - جمعہ
     - ہفتہ
     abbr_month_names:
-    -
+    - 
     - جنوری
     - فروری
     - مارچ
@@ -44,7 +45,7 @@ ur:
       long: "%B %d، %Y"
       short: "%d %b"
     month_names:
-    -
+    - 
     - جنوری
     - فروری
     - مارچ
@@ -76,40 +77,39 @@ ur:
         one: تقریبا ایک سال
         other: تقریبا %{count} سال
       half_a_minute: آدھا منٹ
-      less_than_x_minutes:
-        one: ایک مںٹ سے کم
-        other: "%{count} مںٹوں سے کم"
       less_than_x_seconds:
         one: ایک سیکنڈ سے کم
         other: "%{count} سیکنڈوں سے کم"
+      less_than_x_minutes:
+        one: ایک مںٹ سے کم
+        other: "%{count} مںٹوں سے کم"
       over_x_years:
         one: ایک سال سے زیادہ
         other: "%{count} سالوں سے زیادہ"
-      x_days:
-        one: ایک دن
-        other: "%{count} دن"
-      x_minutes:
-        one: ایک منٹ
-        other: "%{count} منٹ"
-      x_months:
-        one: ایک ماہ
-        other: "%{count} ماہ"
       x_seconds:
         one: ایک سیکنڈ
         other: "%{count} سیکنڈ"
+      x_minutes:
+        one: ایک منٹ
+        other: "%{count} منٹ"
+      x_days:
+        one: ایک دن
+        other: "%{count} دن"
+      x_months:
+        one: ایک ماہ
+        other: "%{count} ماہ"
     prompts:
-      day: دن
-      hour: گھنٹہ
-      minute: منٹ
-      month: ماہ
       second: سیکنڈ
+      minute: منٹ
+      hour: گھنٹہ
+      day: دن
+      month: ماہ
       year: سال
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: قبول ہونا ضروری ہے
       blank: لازم ہے
-      present: خالی ہونا ضروری ہے
       confirmation: "%{attribute} میل نہیں رکھتا"
       empty: لازم ہے
       equal_to: "%{count} کے برابر ہونا چاہیے"
@@ -124,6 +124,8 @@ ur:
       not_a_number: ایک نمبر نہیں ہے
       not_an_integer: ایک عدد صحیح ہونا ضروری ہے
       odd: طاق ہونا ضروری ہے
+      other_than: "%{count} کے علاوہ کسی اور کا ہونا لازمی ہے"
+      present: خالی ہونا ضروری ہے
       taken: پہلے سے ہی استعمال میں ہے
       too_long:
         one: بہت طویل ہے (زیادہ سے زیادہ ایک حرف)
@@ -134,7 +136,6 @@ ur:
       wrong_length:
         one: غلط طوالت (ایک حرف ہونا چاہئے)
         other: غلط طوالت (%{count} حروف ہونے چاہئے)
-      other_than: "%{count} کے علاوہ کسی اور کا ہونا لازمی ہے"
     template:
       body: 'مندرجہ ذیل متن کے ساتھ مسائل ہیں:'
       header:
@@ -167,11 +168,11 @@ ur:
       decimal_units:
         format: "%n %u"
         units:
-          thousand: ہزار
-          million: ملین
           billion: بلین
-          trillion: ٹریلن
+          million: ملین
           quadrillion: کواڈریلن
+          thousand: ہزار
+          trillion: ٹریلن
           unit: Rs
       format:
         delimiter: ''
@@ -202,8 +203,8 @@ ur:
       words_connector: "، "
   time:
     am: صبح
-    pm: شام
     formats:
       default: "%a، %d %b %Y، %p %l:%M %Z"
       long: "%B %d، %Y %p %H:%M"
       short: "%d %b، %H:%M"
+    pm: شام

--- a/rails/locale/uz.yml
+++ b/rails/locale/uz.yml
@@ -14,7 +14,7 @@ uz:
     - Ju
     - Sh
     abbr_month_names:
-    -
+    - 
     - yan.
     - fev.
     - mart
@@ -40,7 +40,7 @@ uz:
       long: "%d %B %Y"
       short: "%d %b"
     month_names:
-    -
+    - 
     - yanvar
     - fevral
     - mart
@@ -60,19 +60,19 @@ uz:
   datetime:
     distance_in_words:
       about_x_hours:
+        one: chamasi %{count} soat
         few: chamasi %{count} soat
         many: chamasi %{count} soat
-        one: chamasi %{count} soat
         other: chamasi %{count} soat
       about_x_months:
+        one: chamasi %{count} oy
         few: chamasi %{count} oy
         many: chamasi %{count} oy
-        one: chamasi %{count} oy
         other: chamasi %{count} oy
       about_x_years:
+        one: chamasi %{count} yil
         few: chamasi %{count} yil
         many: chamasi %{count} yil
-        one: chamasi %{count} yil
         other: chamasi %{count} yil
       almost_x_years:
         one: deyarli 1 yil
@@ -80,47 +80,47 @@ uz:
         many: deyarli %{count} yil
         other: deyarli %{count} yil
       half_a_minute: bir daqiqadan kam
-      less_than_x_minutes:
-        few: "%{count} daqiqadan kam"
-        many: "%{count} daqiqadan kam"
-        one: "%{count} daqiqadan kam"
-        other: "%{count} daqiqadan kam"
       less_than_x_seconds:
+        one: "%{count} soniyadan kam"
         few: "%{count} soniyadan kam"
         many: "%{count} soniyadan kam"
-        one: "%{count} soniyadan kam"
         other: "%{count} soniyadan kam"
+      less_than_x_minutes:
+        one: "%{count} daqiqadan kam"
+        few: "%{count} daqiqadan kam"
+        many: "%{count} daqiqadan kam"
+        other: "%{count} daqiqadan kam"
       over_x_years:
+        one: "%{count} yildan ziyod"
         few: "%{count} yildan ziyod"
         many: "%{count} yildan ziyod"
-        one: "%{count} yildan ziyod"
         other: "%{count} yildan ziyod"
-      x_days:
-        few: "%{count} kun"
-        many: "%{count} kun"
-        one: "%{count} kun"
-        other: "%{count} kun"
-      x_minutes:
-        few: "%{count} daqiqa"
-        many: "%{count} daqiqa"
-        one: "%{count} daqiqa"
-        other: "%{count} daqiqa"
-      x_months:
-        few: "%{count} oy"
-        many: "%{count} oy"
-        one: "%{count} oy"
-        other: "%{count} oy"
       x_seconds:
+        one: "%{count} soniya"
         few: "%{count} soniya"
         many: "%{count} soniya"
-        one: "%{count} soniya"
         other: "%{count} soniya"
+      x_minutes:
+        one: "%{count} daqiqa"
+        few: "%{count} daqiqa"
+        many: "%{count} daqiqa"
+        other: "%{count} daqiqa"
+      x_days:
+        one: "%{count} kun"
+        few: "%{count} kun"
+        many: "%{count} kun"
+        other: "%{count} kun"
+      x_months:
+        one: "%{count} oy"
+        few: "%{count} oy"
+        many: "%{count} oy"
+        other: "%{count} oy"
     prompts:
-      day: kun
-      hour: soat
-      minute: daqiqa
-      month: oy
       second: soniya
+      minute: daqiqa
+      hour: soat
+      day: kun
+      month: oy
       year: yil
   errors:
     format: "%{attribute} %{message}"
@@ -143,26 +143,26 @@ uz:
       odd: toq sonlar mumkin
       taken: band
       too_long:
+        one: uzunligi yetarligidan ortiq (%{count} ta simvoldan yuqori mumkin emas)
         few: uzunligi yetarligidan ortiq (%{count} ta simvoldan yuqori mumkin emas)
         many: uzunligi yetarligidan ortiq (%{count} ta simvoldan yuqori mumkin emas)
-        one: uzunligi yetarligidan ortiq (%{count} ta simvoldan yuqori mumkin emas)
         other: uzunligi yetarligidan ortiq (%{count} ta simvoldan yuqori mumkin emas)
       too_short:
+        one: uzunligi yetarli emas (%{count} ta simvoldan kam mumkin emas)
         few: uzunligi yetarli emas (%{count} ta simvoldan kam mumkin emas)
         many: uzunligi yetarli emas (%{count} ta simvoldan kam mumkin emas)
-        one: uzunligi yetarli emas (%{count} ta simvoldan kam mumkin emas)
         other: uzunligi yetarli emas (%{count} ta simvoldan kam mumkin emas)
       wrong_length:
+        one: uzunligi noto'gri (uzunligi %{count} simvolga teng bulishi kerak)
         few: uzunligi noto'gri (uzunligi %{count} simvolga teng bulishi kerak)
         many: uzunligi noto'gri (uzunligi %{count} simvolga teng bulishi kerak)
-        one: uzunligi noto'gri (uzunligi %{count} simvolga teng bulishi kerak)
         other: uzunligi noto'gri (uzunligi %{count} simvolga teng bulishi kerak)
     template:
       body: 'Quyidagilarda hatolar mavjud:'
       header:
+        one: "%{count} ta hato sababli %{model}:ni saqlab bulmadi"
         few: "%{count} ta hatolar sababli %{model}:ni saqlab bulmadi"
         many: "%{count} ta hatolar sababli %{model}:ni saqlab bulmadi"
-        one: "%{count} ta hato sababli %{model}:ni saqlab bulmadi"
         other: "%{count} ta hatolar sababli %{model}:ni saqlab bulmadi"
   helpers:
     select:
@@ -192,29 +192,29 @@ uz:
         format: "%n %u"
         units:
           billion:
+            one: milliard
             few: milliard
             many: milliard
-            one: milliard
             other: milliard
           million:
+            one: million
             few: million
             many: million
-            one: million
             other: million
           quadrillion:
+            one: kvadrillion
             few: kvadrillion
             many: kvadrillion
-            one: kvadrillion
             other: kvadrillion
           thousand:
+            one: ming
             few: ming
             many: ming
-            one: ming
             other: ming
           trillion:
+            one: trillion
             few: trillion
             many: trillion
-            one: trillion
             other: trillion
           unit: ''
       format:
@@ -226,9 +226,9 @@ uz:
         format: "%n %u"
         units:
           byte:
+            one: bayt
             few: bayt
             many: bayt
-            one: bayt
             other: bayt
           gb: GB
           kb: KB

--- a/rails/locale/vi.yml
+++ b/rails/locale/vi.yml
@@ -17,7 +17,7 @@ vi:
     - Thứ 6
     - Thứ 7
     abbr_month_names:
-    -
+    - 
     - Thg 1
     - Thg 2
     - Thg 3
@@ -43,7 +43,7 @@ vi:
       long: "%d %B, %Y"
       short: "%d %b"
     month_names:
-    -
+    - 
     - Tháng một
     - Tháng hai
     - Tháng ba
@@ -75,40 +75,39 @@ vi:
         one: gần 1 năm
         other: gần %{count} năm
       half_a_minute: 30 giây
-      less_than_x_minutes:
-        one: chưa tới 1 phút
-        other: chưa tới %{count} phút
       less_than_x_seconds:
         one: chưa tới 1 giây
         other: chưa tới %{count} giây
+      less_than_x_minutes:
+        one: chưa tới 1 phút
+        other: chưa tới %{count} phút
       over_x_years:
         one: hơn 1 năm
         other: hơn %{count} năm
-      x_days:
-        one: 1 ngày
-        other: "%{count} ngày"
-      x_minutes:
-        one: 1 phút
-        other: "%{count} phút"
-      x_months:
-        one: 1 tháng
-        other: "%{count} tháng"
       x_seconds:
         one: 1 giây
         other: "%{count} giây"
+      x_minutes:
+        one: 1 phút
+        other: "%{count} phút"
+      x_days:
+        one: 1 ngày
+        other: "%{count} ngày"
+      x_months:
+        one: 1 tháng
+        other: "%{count} tháng"
     prompts:
-      day: Ngày
-      hour: Giờ
-      minute: Phút
-      month: Tháng
       second: Giây
+      minute: Phút
+      hour: Giờ
+      day: Ngày
+      month: Tháng
       year: Năm
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: phải được đồng ý
       blank: không thể để trắng
-      present: cần phải để trắng
       confirmation: không khớp với xác nhận
       empty: không thể rỗng
       equal_to: phải bằng %{count}
@@ -123,11 +122,12 @@ vi:
       not_a_number: không phải là số
       not_an_integer: phải là một số nguyên
       odd: phải là số lẻ
+      other_than: cần phải khác %{count}
+      present: cần phải để trắng
       taken: đã có
       too_long: quá dài (tối đa %{count} ký tự)
       too_short: quá ngắn (tối thiểu %{count} ký tự)
       wrong_length: độ dài không đúng (phải là %{count} ký tự)
-      other_than: cần phải khác %{count}
     template:
       body: 'Có lỗi với các mục sau:'
       header:
@@ -160,12 +160,12 @@ vi:
       decimal_units:
         format: "%n %u"
         units:
-          unit: ''
           billion: Tỷ
           million: Triệu
           quadrillion: Triệu tỷ
           thousand: Nghìn
           trillion: Nghìn tỷ
+          unit: ''
       format:
         delimiter: ''
         precision: 1

--- a/rails/locale/wo.yml
+++ b/rails/locale/wo.yml
@@ -3,10 +3,10 @@ wo:
   activerecord:
     errors:
       messages:
-        record_invalid: "Validation failed: %{errors}"
+        record_invalid: 'Validation failed: %{errors}'
         restrict_dependent_destroy:
-          has_one: "Cannot delete record because a dependent %{record} exists"
-          has_many: "Cannot delete record because dependent %{record} exist"
+          has_one: Cannot delete record because a dependent %{record} exists
+          has_many: Cannot delete record because dependent %{record} exist
   date:
     abbr_day_names:
     - Dib
@@ -17,7 +17,7 @@ wo:
     - Ajj
     - Gaw
     abbr_month_names:
-    -
+    - 
     - Jan
     - Feb
     - Mar
@@ -43,7 +43,7 @@ wo:
       long: "%B %d, %Y"
       short: "%b %d"
     month_names:
-    -
+    - 
     - Tamkharit
     - Digui Gamou
     - Gamou
@@ -75,36 +75,36 @@ wo:
         one: almost 1 year
         other: almost %{count} years
       half_a_minute: half a minute
-      less_than_x_minutes:
-        one: less than a minute
-        other: less than %{count} minutes
       less_than_x_seconds:
         one: less than 1 second
         other: less than %{count} seconds
+      less_than_x_minutes:
+        one: less than a minute
+        other: less than %{count} minutes
       over_x_years:
         one: over 1 year
         other: over %{count} years
-      x_days:
-        one: 1 day
-        other: "%{count} days"
+      x_seconds:
+        one: 1 second
+        other: "%{count} seconds"
       x_minutes:
         one: 1 minute
         other: "%{count} minutes"
+      x_days:
+        one: 1 day
+        other: "%{count} days"
       x_months:
         one: 1 month
         other: "%{count} months"
       x_years:
         one: 1 year
-        other: "%{count} years"  
-      x_seconds:
-        one: 1 second
-        other: "%{count} seconds"
+        other: "%{count} years"
     prompts:
-      day: Day
-      hour: Hour
-      minute: Minute
-      month: Month
       second: Seconds
+      minute: Minute
+      hour: Hour
+      day: Day
+      month: Month
       year: Year
   errors:
     format: "%{attribute} %{message}"

--- a/rails/locale/zh-CN.yml
+++ b/rails/locale/zh-CN.yml
@@ -3,7 +3,7 @@ zh-CN:
   activerecord:
     errors:
       messages:
-        record_invalid: "验证失败: %{errors}"
+        record_invalid: '验证失败: %{errors}'
         restrict_dependent_destroy:
           has_one: 由于 %{record} 需要此记录，所以无法移除记录
           has_many: 由于 %{record} 需要此记录，所以无法移除记录
@@ -17,7 +17,7 @@ zh-CN:
     - 周五
     - 周六
     abbr_month_names:
-    -
+    - 
     - 1月
     - 2月
     - 3月
@@ -43,7 +43,7 @@ zh-CN:
       long: "%Y年%m月%d日"
       short: "%m月%d日"
     month_names:
-    -
+    - 
     - 一月
     - 二月
     - 三月
@@ -67,27 +67,26 @@ zh-CN:
       about_x_years: 大约 %{count} 年
       almost_x_years: 接近 %{count} 年
       half_a_minute: 半分钟
-      less_than_x_minutes: 不到 %{count} 分钟
       less_than_x_seconds: 不到 %{count} 秒
+      less_than_x_minutes: 不到 %{count} 分钟
       over_x_years: "%{count} 年多"
-      x_days: "%{count} 天"
+      x_seconds: "%{count} 秒"
       x_minutes: "%{count} 分钟"
+      x_days: "%{count} 天"
       x_months: "%{count} 个月"
       x_years: "%{count} 年"
-      x_seconds: "%{count} 秒"
     prompts:
-      day: 日
-      hour: 时
-      minute: 分
-      month: 月
       second: 秒
+      minute: 分
+      hour: 时
+      day: 日
+      month: 月
       year: 年
   errors:
     format: "%{attribute}%{message}"
     messages:
       accepted: 必须是可被接受的
       blank: 不能为空字符
-      present: 必须是空白
       confirmation: 与确认值不匹配
       empty: 不能留空
       equal_to: 必须等于 %{count}
@@ -99,16 +98,17 @@ zh-CN:
       invalid: 是无效的
       less_than: 必须小于 %{count}
       less_than_or_equal_to: 必须小于或等于 %{count}
-      model_invalid: "验证失败: %{errors}"
+      model_invalid: '验证失败: %{errors}'
       not_a_number: 不是数字
       not_an_integer: 必须是整数
       odd: 必须为单数
+      other_than: 长度非法（不可为 %{count} 个字符
+      present: 必须是空白
       required: 必须存在
       taken: 已经被使用
       too_long: 过长（最长为 %{count} 个字符）
       too_short: 过短（最短为 %{count} 个字符）
       wrong_length: 长度非法（必须为 %{count} 个字符）
-      other_than: 长度非法（不可为 %{count} 个字符
     template:
       body: 如下字段出现错误：
       header: 有 %{count} 个错误发生导致“%{model}”无法被保存。
@@ -154,12 +154,12 @@ zh-CN:
         format: "%n %u"
         units:
           byte: 字节
+          eb: EB
           gb: GB
           kb: KB
           mb: MB
-          tb: TB
           pb: PB
-          eb: EB
+          tb: TB
     percentage:
       format:
         delimiter: ''

--- a/rails/locale/zh-HK.yml
+++ b/rails/locale/zh-HK.yml
@@ -3,7 +3,7 @@ zh-HK:
   activerecord:
     errors:
       messages:
-        record_invalid: "驗證失敗︰%{errors}"
+        record_invalid: 驗證失敗︰%{errors}
         restrict_dependent_destroy:
           has_one: 由於%{record}依賴此記錄，無法移除
           has_many: 由於%{record}依賴此記錄，無法移除
@@ -17,7 +17,7 @@ zh-HK:
     - 周五
     - 周六
     abbr_month_names:
-    -
+    - 
     - 1月
     - 2月
     - 3月
@@ -43,7 +43,7 @@ zh-HK:
       long: "%Y年%m月%d日"
       short: "%m月%d日"
     month_names:
-    -
+    - 
     - 一月
     - 二月
     - 三月
@@ -75,60 +75,61 @@ zh-HK:
         one: 接近一年
         other: 接近%{count}年
       half_a_minute: 半分鐘
-      less_than_x_minutes:
-        one: 不到一分鐘
-        other: 不到%{count}分鐘
       less_than_x_seconds:
         one: 不到一秒
         other: 不到%{count}秒
+      less_than_x_minutes:
+        one: 不到一分鐘
+        other: 不到%{count}分鐘
       over_x_years:
         one: 超過一年
         other: 超過%{count}年
-      x_days:
-        one: 一天
-        other: "%{count}天"
+      x_seconds:
+        one: 一秒
+        other: "%{count}秒"
       x_minutes:
         one: 一分鐘
         other: "%{count}分鐘"
+      x_days:
+        one: 一天
+        other: "%{count}天"
       x_months:
         one: 一個月
         other: "%{count}個月"
       x_years:
         one: 一年
         other: "%{count} 年"
-      x_seconds:
-        one: 一秒
-        other: "%{count}秒"
     prompts:
-      day: 日
-      hour: 時
-      minute: 分
-      month: 月
       second: 秒
+      minute: 分
+      hour: 時
+      day: 日
+      month: 月
       year: 年
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: 必定要被接受
-      blank: "不可以是空白"
-      present: "必定要是空白"
+      blank: 不可以是空白
       confirmation: 兩次輸入不一致
-      empty: "不可以留空"
-      equal_to: "必須等於 %{count}"
-      even: "必須要是雙數"
-      exclusion: "是被保留的關鍵字"
-      greater_than: "必須大於 %{count}"
-      greater_than_or_equal_to: "必須大於或等於 %{count}"
-      inclusion: "並非可被接受的內容"
-      invalid: "是無效的"
-      less_than: "必須小於 %{count}"
-      less_than_or_equal_to: "必須小於或等於 %{count}"
-      model_invalid: "驗證失敗︰%{errors}"
-      not_a_number: "必須是數字"
-      not_an_integer: "必須是整數"
-      odd: "必須是單數"
+      empty: 不可以留空
+      equal_to: 必須等於 %{count}
+      even: 必須要是雙數
+      exclusion: 是被保留的關鍵字
+      greater_than: 必須大於 %{count}
+      greater_than_or_equal_to: 必須大於或等於 %{count}
+      inclusion: 並非可被接受的內容
+      invalid: 是無效的
+      less_than: 必須小於 %{count}
+      less_than_or_equal_to: 必須小於或等於 %{count}
+      model_invalid: 驗證失敗︰%{errors}
+      not_a_number: 必須是數字
+      not_an_integer: 必須是整數
+      odd: 必須是單數
+      other_than: 不可以是 %{count} 個字
+      present: 必定要是空白
       required: 必須存在
-      taken: "已被使用"
+      taken: 已被使用
       too_long:
         one: 太長（最長為一個字元）
         other: 太長（最長為 %{count} 個字元）
@@ -138,7 +139,6 @@ zh-HK:
       wrong_length:
         one: 字數錯誤 (應為一個字元)
         other: 字數錯誤 (應為 %{count} 個字元)
-      other_than: "不可以是 %{count} 個字"
     template:
       body: 以下欄位發生問題︰
       header:

--- a/rails/locale/zh-TW.yml
+++ b/rails/locale/zh-TW.yml
@@ -3,7 +3,7 @@ zh-TW:
   activerecord:
     errors:
       messages:
-        record_invalid: "校驗失敗: %{errors}"
+        record_invalid: '校驗失敗: %{errors}'
         restrict_dependent_destroy:
           has_one: 由於 %{record} 需要此記錄，所以無法移除記錄
           has_many: 由於 %{record} 需要此記錄，所以無法移除記錄
@@ -17,7 +17,7 @@ zh-TW:
     - 周五
     - 周六
     abbr_month_names:
-    -
+    - 
     - 1月
     - 2月
     - 3月
@@ -43,7 +43,7 @@ zh-TW:
       long: "%Y年%m月%d日"
       short: "%m月%d日"
     month_names:
-    -
+    - 
     - 一月
     - 二月
     - 三月
@@ -75,43 +75,42 @@ zh-TW:
         one: 接近一年
         other: 接近 %{count} 年
       half_a_minute: 半分鐘
-      less_than_x_minutes:
-        one: 不到一分鐘
-        other: 不到 %{count} 分鐘
       less_than_x_seconds:
         one: 不到一秒
         other: 不到 %{count} 秒
+      less_than_x_minutes:
+        one: 不到一分鐘
+        other: 不到 %{count} 分鐘
       over_x_years:
         one: 一年多
         other: "%{count} 年多"
-      x_days:
-        one: 一天
-        other: "%{count} 天"
+      x_seconds:
+        one: 一秒
+        other: "%{count} 秒"
       x_minutes:
         one: 一分鐘
         other: "%{count} 分鐘"
+      x_days:
+        one: 一天
+        other: "%{count} 天"
       x_months:
         one: 一個月
         other: "%{count} 個月"
       x_years:
         one: 一年
         other: "%{count} 年"
-      x_seconds:
-        one: 一秒
-        other: "%{count} 秒"
     prompts:
-      day: 日
-      hour: 時
-      minute: 分
-      month: 月
       second: 秒
+      minute: 分
+      hour: 時
+      day: 日
+      month: 月
       year: 年
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: 必須是可被接受的
       blank: 不能為空白
-      present: 必須是空白
       confirmation: 兩次輸入須一致
       empty: 不能留空
       equal_to: 必須等於 %{count}
@@ -123,10 +122,12 @@ zh-TW:
       invalid: 是無效的
       less_than: 必須小於 %{count}
       less_than_or_equal_to: 必須小於或等於 %{count}
-      model_invalid: "校驗失敗: %{errors}"
+      model_invalid: '校驗失敗: %{errors}'
       not_a_number: 不是數字
       not_an_integer: 必須是整數
       odd: 必須是奇數
+      other_than: 不可以是 %{count} 個字
+      present: 必須是空白
       required: 必須存在
       taken: 已經被使用
       too_long:
@@ -138,7 +139,6 @@ zh-TW:
       wrong_length:
         one: 字數錯誤 (必須是一個字)
         other: 字數錯誤 (必須是 %{count} 個字)
-      other_than: 不可以是 %{count} 個字
     template:
       body: 以下欄位發生問題：
       header:

--- a/rails/locale/zh-YUE.yml
+++ b/rails/locale/zh-YUE.yml
@@ -3,7 +3,7 @@ zh-YUE:
   activerecord:
     errors:
       messages:
-        record_invalid: "驗證失敗︰%{errors}"
+        record_invalid: 驗證失敗︰%{errors}
         restrict_dependent_destroy:
           has_one: 唔可以刪除，因為%{record}要用佢
           has_many: 唔可以刪除，因為%{record}要用佢
@@ -17,7 +17,7 @@ zh-YUE:
     - 周五
     - 周六
     abbr_month_names:
-    -
+    - 
     - 1月
     - 2月
     - 3月
@@ -43,7 +43,7 @@ zh-YUE:
       long: "%Y年%b%d日"
       short: "%b%d日"
     month_names:
-    -
+    - 
     - 一月
     - 二月
     - 三月
@@ -75,60 +75,61 @@ zh-YUE:
         one: 差唔多一年
         other: 差唔多%{count}年
       half_a_minute: 半分鐘
-      less_than_x_minutes:
-        one: 唔夠一分鐘
-        other: 唔夠%{count}分鐘
       less_than_x_seconds:
         one: 唔夠一秒
         other: 唔夠%{count}秒
+      less_than_x_minutes:
+        one: 唔夠一分鐘
+        other: 唔夠%{count}分鐘
       over_x_years:
         one: 超過一年
         other: 超過%{count}年
-      x_days:
-        one: 一日
-        other: "%{count}日"
+      x_seconds:
+        one: 一秒
+        other: "%{count}秒"
       x_minutes:
         one: 一分鐘
         other: "%{count}分鐘"
+      x_days:
+        one: 一日
+        other: "%{count}日"
       x_months:
         one: 一個月
         other: "%{count}個月"
       x_years:
         one: 一年
         other: "%{count} 年"
-      x_seconds:
-        one: 一秒
-        other: "%{count}秒"
     prompts:
-      day: 日
-      hour: 點
-      minute: 分
-      month: 月
       second: 秒
+      minute: 分
+      hour: 點
+      day: 日
+      month: 月
       year: 年
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: 一定要被接受
-      blank: "唔可以空白"
-      present: "一定要空白"
-      confirmation: "兩次輸入唔夾"
-      empty: "唔可以漏空"
-      equal_to: "要等於 %{count}"
-      even: "要係雙數"
-      exclusion: "唔用得"
-      greater_than: "要大過%{count}"
-      greater_than_or_equal_to: "要大過或者等於%{count}"
-      inclusion: "唔係可被接受嘅內容"
-      invalid: "無效"
-      less_than: "要細過%{count}"
-      less_than_or_equal_to: "要細過或者等於%{count}"
-      model_invalid: "驗證失敗︰%{errors}"
-      not_a_number: "唔係一個數字"
-      not_an_integer: "要係整數"
-      odd: "要係單數"
+      blank: 唔可以空白
+      confirmation: 兩次輸入唔夾
+      empty: 唔可以漏空
+      equal_to: 要等於 %{count}
+      even: 要係雙數
+      exclusion: 唔用得
+      greater_than: 要大過%{count}
+      greater_than_or_equal_to: 要大過或者等於%{count}
+      inclusion: 唔係可被接受嘅內容
+      invalid: 無效
+      less_than: 要細過%{count}
+      less_than_or_equal_to: 要細過或者等於%{count}
+      model_invalid: 驗證失敗︰%{errors}
+      not_a_number: 唔係一個數字
+      not_an_integer: 要係整數
+      odd: 要係單數
+      other_than: 唔可以係%{count} 個字
+      present: 一定要空白
       required: 必須存在
-      taken: "已經用緊"
+      taken: 已經用緊
       too_long:
         one: 太長（最多 1 個字）
         other: 太長（最多 %{count} 個字）
@@ -138,7 +139,6 @@ zh-YUE:
       wrong_length:
         one: 唔啱字數 (要係 1 個字)
         other: 唔啱字數 (要係 %{count} 個字)
-      other_than: "唔可以係%{count} 個字"
     template:
       body: 呢啲有問題︰
       header:

--- a/rails/test/lib/normalize.rb
+++ b/rails/test/lib/normalize.rb
@@ -1,0 +1,43 @@
+require 'active_support'
+
+# Inspired from https://stackoverflow.com/questions/7275952/how-can-i-sort-yaml-files/13368706#13368706
+
+module Normalize
+  PLURALIZATION_KEYS = %w(zero one two few many other).freeze
+  ACTIVERECORD_KEYS = %w(has_one has_many).freeze
+  DATETIME_KEYS = %w(second minute hour day month year).freeze
+
+  class << self
+    def deep_sort(object)
+      return object unless object.is_a?(Hash)
+
+      hash = RUBY_VERSION >= '1.9' ? Hash.new : ActiveSupport::OrderedHash.new
+      object.each { |k, v| hash[k] = deep_sort(v) }
+
+      keys = hash.keys.map(&:to_s)
+      sorted = hash.sort do |a, b|
+        a_key = a[0].to_s
+        b_key = b[0].to_s
+        if (keys - PLURALIZATION_KEYS).empty?
+          PLURALIZATION_KEYS.index(a_key) <=> PLURALIZATION_KEYS.index(b_key)
+        elsif (keys - ACTIVERECORD_KEYS).empty?
+          ACTIVERECORD_KEYS.index(a_key) <=> ACTIVERECORD_KEYS.index(b_key)
+        elsif (keys - DATETIME_KEYS).empty?
+          DATETIME_KEYS.index(a_key) <=> DATETIME_KEYS.index(b_key)
+        else
+          a_matches = a_key.match(/^(.+)(#{DATETIME_KEYS.join('|')})(.*)$/)
+          b_matches = b_key.match(/^(.+)(#{DATETIME_KEYS.join('|')})(.*)$/)
+          if a_matches.nil? || b_matches.nil?
+            a_key <=> b_key
+          else
+            s1 = format('%s%s', a_matches[1], DATETIME_KEYS.index(a_matches[2]))
+            s2 = format('%s%s', b_matches[1], DATETIME_KEYS.index(b_matches[2]))
+            s1 <=> s2
+          end
+        end
+      end
+
+      hash.class[sorted]
+    end
+  end
+end


### PR DESCRIPTION
Hello,

Normalization ensures the quoting is the simplest, that the line break width is respected and last but not leasts it sorts all the keys alphabetically, making it much easier to compare locales. For example `fr.yml` and `fr-CA.yml` have keys at different positions, making it a pain to diff in the editor.

**EDIT**: the following disadvantages are not true anymore, see below

The only disadvantage is when counts or units are involved:

``` yaml
      about_x_hours:
        few: ປະມານ %{count} ຊົ່ວໂມງ
        many: ປະມານ %{count} ຊົ່ວໂມງ
        one: ປະມານ 1 ຊົ່ວໂມງ
        other: ປະມານ %{count} ຊົ່ວໂມງ
        two: ປະມານ %{count} ຊົ່ວໂມງ
        zero: ປະມານ %{count} ຊົ່ວໂມງ
```

In this case it's probably more convenient to have it like this:

``` yaml
      about_x_hours:
        zero: ປະມານ %{count} ຊົ່ວໂມງ
        one: ປະມານ 1 ຊົ່ວໂມງ
        two: ປະມານ %{count} ຊົ່ວໂມງ
        few: ປະມານ %{count} ຊົ່ວໂມງ
        many: ປະມານ %{count} ຊົ່ວໂມງ
        other: ປະມານ %{count} ຊົ່ວໂມງ
```

I think the disadvantage is minor compared to the advantages.