### PR TITLE
Fix Ukrainian translation for x_years

### DIFF
--- a/rails/locale/uk.yml
+++ b/rails/locale/uk.yml
@@ -114,7 +114,7 @@ uk:
         one: "%{count} місяць"
         other: "%{count} місяця"
       x_years:
-        few: "%{count} років"
+        few: "%{count} роки"
         many: "%{count} років"
         one: "%{count} рік"
         other: "%{count} року"


### PR DESCRIPTION
Hi

Correct Ukrainian sentence example:
> Минуло 2 роки.

and wrong: 
> Минуло 2 років.