### PR TITLE
format mismatch for Portuguese with chrome

### DIFF
--- a/rails/locale/pt.yml
+++ b/rails/locale/pt.yml
@@ -148,8 +148,8 @@ pt:
   number:
     currency:
       format:
-        delimiter: " "
-        format: "%n %u"
+        delimiter: "."
+        format: "%u %n"
         precision: 2
         separator: ","
         significant: false


### PR DESCRIPTION
* There is a mismatch in `pt` locale number formatting with chrome/firefox, e.g:-
```
(3500).toLocaleString('pt', {style:'currency', currency: 'eur'})
 => € 3.500,00
```
* rails-i18n provides :- 3 500,00 €

