### PR TITLE
Add dynamic "html lang" for easier I18n use with subdomains/domains

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,4 @@ branches:
   only:
     - master
     - rails-3-x
+    - rails-4-x

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,4 @@ rvm:
   - 2.2
 branches:
   only:
-    - master
-    - rails-3-x
     - rails-4-x

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: ruby
 rvm:
-  - 1.9.3
   - 2.0.0
-  - 2.1
-  - 2.2
 branches:
   only:
     - rails-4-x

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.0.7 (2015-11-20)
+- Update Khmer (km)
+- Update Greek (el)
+- Update German (de)
+
 ## 4.0.6 (2015-10-23)
 - Depend on i18n (~> 0.7)
 - Update Indonesian (id)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.8 (2015-12-24)
+- Add Panjabi (pa)
+- Update Russian (ru)
+
 ## 4.0.7 (2015-11-20)
 - Update Khmer (km)
 - Update Greek (el)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 4.0.9 (2016-07-05)
+- Update Bosnian (bs)
+- Update Arabic (ar)
+- Update Panjabi (pa)
+- Update German (de)
+- Update Spanish (es)
+- Update Chinese (zh-CN, zh-TW)
+- Add Albanian (sq)
+
 ## 4.0.8 (2015-12-24)
 - Add Panjabi (pa)
 - Update Russian (ru)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rails-i18n (4.0.6)
+    rails-i18n (4.0.7)
       i18n (~> 0.7)
       railties (~> 4.0)
 
@@ -90,3 +90,6 @@ DEPENDENCIES
   rails-i18n!
   rspec-rails (= 2.14.2)
   spork (= 1.0.0rc3)
+
+BUNDLED WITH
+   1.10.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rails-i18n (4.0.7)
+    rails-i18n (4.0.8)
       i18n (~> 0.7)
       railties (~> 4.0)
 
@@ -92,4 +92,4 @@ DEPENDENCIES
   spork (= 1.0.0rc3)
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ Available locales are:
 > es-419, es-AR, es-CL, es-CO, es-CR, es-EC, es-MX, es-PA, es-PE, es-US, es-VE,
 > et, eu, fa, fi, fr, fr-CA, fr-CH, gl, he, hi, hi-IN, hr, hu, id, is, it,
 > it-CH, ja, km, kn, ko, lb, lo, lt, lv, mk, mn, mr-IN, ms, nb, ne, nl, nn, or,
-> pl, pt, pt-BR, rm, ro, ru, sk, sl, sr, sv, sw, ta, th, tl, tr, tt, ug, uk, ur,
-> uz, vi, wo, zh-CN, zh-HK, zh-TW, zh-YUE
+> pa, pl, pt, pt-BR, rm, ro, ru, sk, sl, sr, sv, sw, ta, th, tl, tr, tt, ug, uk,
+> ur, uz, vi, wo, zh-CN, zh-HK, zh-TW, zh-YUE
 
 Currently, no locales are complete. Typically they lack the following keys:
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Add to your Gemfile:
 
     gem 'rails-i18n', '~> 4.0.0' # For 4.0.x
     gem 'rails-i18n', '~> 3.0.0' # For 3.x
-    gem 'rails-i18n', github: 'svenfuchs/rails-i18n', branch: 'master' # For 4.x
+    gem 'rails-i18n', github: 'svenfuchs/rails-i18n', branch: 'master' # For 5.x
+    gem 'rails-i18n', github: 'svenfuchs/rails-i18n', branch: 'rails-4-x' # For 4.x
     gem 'rails-i18n', github: 'svenfuchs/rails-i18n', branch: 'rails-3-x' # For 3.x
 
 or run this command:

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Available locales are:
 > es-419, es-AR, es-CL, es-CO, es-CR, es-EC, es-ES, es-MX, es-PA, es-PE, es-US, es-VE,
 > et, eu, fa, fi, fr, fr-CA, fr-CH, fr-FR, gl, he, hi, hi-IN, hr, hu, id, is, it,
 > it-CH, ja, km, kn, ko, lb, lo, lt, lv, mk, mn, mr-IN, ms, nb, ne, nl, nn, or,
-> pa, pl, pt, pt-BR, rm, ro, ru, sk, sl, sr, sv, sw, ta, th, tl, tr, tt, ug, uk,
+> pa, pl, pt, pt-BR, rm, ro, ru, sk, sl, sq, sr, sv, sw, ta, th, tl, tr, tt, ug, uk,
 > ur, uz, vi, wo, zh-CN, zh-HK, zh-TW, zh-YUE
 
 Currently, no locales are complete. Typically they lack the following keys:

--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ Locale data whose structure is compatible with Rails 2.3 are available on the se
 
 Available locales are:
 
-> af, ar, az, be, bg, bn, bs, ca, cs, cy, da, de, de-AT, de-CH, el,
+> af, ar, az, be, bg, bn, bs, ca, cs, cy, da, de, de-AT, de-CH, de-DE, el,
 > en, en-AU, en-CA, en-GB, en-IE, en-IN, en-NZ, en-US, en-ZA, eo, es,
-> es-419, es-AR, es-CL, es-CO, es-CR, es-EC, es-MX, es-PA, es-PE, es-US, es-VE,
-> et, eu, fa, fi, fr, fr-CA, fr-CH, gl, he, hi, hi-IN, hr, hu, id, is, it,
+> es-419, es-AR, es-CL, es-CO, es-CR, es-EC, es-ES, es-MX, es-PA, es-PE, es-US, es-VE,
+> et, eu, fa, fi, fr, fr-CA, fr-CH, fr-FR, gl, he, hi, hi-IN, hr, hu, id, is, it,
 > it-CH, ja, km, kn, ko, lb, lo, lt, lv, mk, mn, mr-IN, ms, nb, ne, nl, nn, or,
 > pa, pl, pt, pt-BR, rm, ro, ru, sk, sl, sr, sv, sw, ta, th, tl, tr, tt, ug, uk,
 > ur, uz, vi, wo, zh-CN, zh-HK, zh-TW, zh-YUE

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Available locales are:
 
 > af, ar, az, be, bg, bn, bs, ca, cs, cy, da, de, de-AT, de-CH, de-DE, el,
 > en, en-AU, en-CA, en-GB, en-IE, en-IN, en-NZ, en-US, en-ZA, eo, es,
-> es-419, es-AR, es-CL, es-CO, es-CR, es-EC, es-ES, es-MX, es-PA, es-PE, es-US, es-VE,
+> es-419, es-AR, es-CL, es-CO, es-CR, es-DO, es-EC, es-ES, es-MX, es-PA, es-PE, es-US, es-VE,
 > et, eu, fa, fi, fr, fr-CA, fr-CH, fr-FR, gl, he, hi, hi-IN, hr, hu, id, is, it,
 > it-CH, ja, km, kn, ko, lb, lo, lt, lv, mk, mn, mr-IN, ms, nb, ne, nl, nn, or,
 > pa, pl, pt, pt-BR, rm, ro, ru, sk, sl, sq, sr, sv, sw, ta, th, tl, tr, tt, ug, uk,

--- a/rails-i18n.gemspec
+++ b/rails-i18n.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name         = "rails-i18n"
-  s.version      = '4.0.6'
+  s.version      = '4.0.7'
   s.authors      = ["Rails I18n Group"]
   s.email        = "rails-i18n@googlegroups.com"
   s.homepage     = "http://github.com/svenfuchs/rails-i18n"

--- a/rails-i18n.gemspec
+++ b/rails-i18n.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name         = "rails-i18n"
-  s.version      = '4.0.8'
+  s.version      = '4.0.9'
   s.authors      = ["Rails I18n Group"]
   s.email        = "rails-i18n@googlegroups.com"
   s.homepage     = "http://github.com/svenfuchs/rails-i18n"

--- a/rails-i18n.gemspec
+++ b/rails-i18n.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name         = "rails-i18n"
-  s.version      = '4.0.7'
+  s.version      = '4.0.8'
   s.authors      = ["Rails I18n Group"]
   s.email        = "rails-i18n@googlegroups.com"
   s.homepage     = "http://github.com/svenfuchs/rails-i18n"

--- a/rails/locale/ar.yml
+++ b/rails/locale/ar.yml
@@ -33,7 +33,7 @@ ar:
     - السّبت
     formats:
       default: "%Y-%m-%d"
-      long: "%B %e, %Y"
+      long: "%B %e، %Y"
       short: "%e %b"
     month_names:
     - 
@@ -212,7 +212,7 @@ ar:
   number:
     currency:
       format:
-        delimiter: ","
+        delimiter: "،"
         format: "%u%n"
         precision: 2
         separator: "."
@@ -220,7 +220,7 @@ ar:
         strip_insignificant_zeros: false
         unit: "$"
     format:
-      delimiter: ","
+      delimiter: "،"
       precision: 3
       separator: "."
       significant: false

--- a/rails/locale/bs.yml
+++ b/rails/locale/bs.yml
@@ -238,7 +238,7 @@ bs:
   time:
     am: ''
     formats:
-      default: "%H:%M:%S"
+      default: "%d.%m.%Y. %H:%M:%S"
       long: "%d. %B %Y. - %H:%M:%S"
       short: "%d. %b %Y. %H:%M"
     pm: ''

--- a/rails/locale/de-CH.yml
+++ b/rails/locale/de-CH.yml
@@ -10,7 +10,7 @@ de-CH:
     - Fr
     - Sa
     abbr_month_names:
-    - 
+    -
     - Jan
     - Feb
     - Mär
@@ -36,7 +36,7 @@ de-CH:
       long: "%e. %B %Y"
       short: "%e. %b"
     month_names:
-    - 
+    -
     - Januar
     - Februar
     - März
@@ -92,9 +92,9 @@ de-CH:
     prompts:
       day: Tag
       hour: Stunden
-      minute: Minuten
+      minute: Minute
       month: Monat
-      second: Sekunden
+      second: Sekunde
       year: Jahr
   errors:
     format: "%{attribute} %{message}"

--- a/rails/locale/de-DE.yml
+++ b/rails/locale/de-DE.yml
@@ -1,0 +1,210 @@
+---
+de-DE:
+  date:
+    abbr_day_names:
+    - So
+    - Mo
+    - Di
+    - Mi
+    - Do
+    - Fr
+    - Sa
+    abbr_month_names:
+    - 
+    - Jan
+    - Feb
+    - Mär
+    - Apr
+    - Mai
+    - Jun
+    - Jul
+    - Aug
+    - Sep
+    - Okt
+    - Nov
+    - Dez
+    day_names:
+    - Sonntag
+    - Montag
+    - Dienstag
+    - Mittwoch
+    - Donnerstag
+    - Freitag
+    - Samstag
+    formats:
+      default: "%d.%m.%Y"
+      long: "%e. %B %Y"
+      short: "%e. %b"
+    month_names:
+    - 
+    - Januar
+    - Februar
+    - März
+    - April
+    - Mai
+    - Juni
+    - Juli
+    - August
+    - September
+    - Oktober
+    - November
+    - Dezember
+    order:
+    - :day
+    - :month
+    - :year
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: etwa eine Stunde
+        other: etwa %{count} Stunden
+      about_x_months:
+        one: etwa ein Monat
+        other: etwa %{count} Monate
+      about_x_years:
+        one: etwa ein Jahr
+        other: etwa %{count} Jahre
+      almost_x_years:
+        one: fast ein Jahr
+        other: fast %{count} Jahre
+      half_a_minute: eine halbe Minute
+      less_than_x_minutes:
+        one: weniger als eine Minute
+        other: weniger als %{count} Minuten
+      less_than_x_seconds:
+        one: weniger als eine Sekunde
+        other: weniger als %{count} Sekunden
+      over_x_years:
+        one: mehr als ein Jahr
+        other: mehr als %{count} Jahre
+      x_days:
+        one: ein Tag
+        other: "%{count} Tage"
+      x_minutes:
+        one: eine Minute
+        other: "%{count} Minuten"
+      x_months:
+        one: ein Monat
+        other: "%{count} Monate"
+      x_seconds:
+        one: eine Sekunde
+        other: "%{count} Sekunden"
+    prompts:
+      day: Tag
+      hour: Stunden
+      minute: Minute
+      month: Monat
+      second: Sekunde
+      year: Jahr
+  errors:
+    format: "%{attribute} %{message}"
+    messages:
+      accepted: muss akzeptiert werden
+      blank: muss ausgefüllt werden
+      present: darf nicht ausgefüllt werden
+      confirmation: stimmt nicht mit %{attribute} überein
+      empty: muss ausgefüllt werden
+      equal_to: muss genau %{count} sein
+      even: muss gerade sein
+      exclusion: ist nicht verfügbar
+      greater_than: muss größer als %{count} sein
+      greater_than_or_equal_to: muss größer oder gleich %{count} sein
+      inclusion: ist kein gültiger Wert
+      invalid: ist nicht gültig
+      less_than: muss kleiner als %{count} sein
+      less_than_or_equal_to: muss kleiner oder gleich %{count} sein
+      not_a_number: ist keine Zahl
+      not_an_integer: muss ganzzahlig sein
+      odd: muss ungerade sein
+      record_invalid: 'Gültigkeitsprüfung ist fehlgeschlagen: %{errors}'
+      restrict_dependent_destroy:
+        one: Datensatz kann nicht gelöscht werden, da ein abhängiger %{record}-Datensatz
+          existiert.
+        many: Datensatz kann nicht gelöscht werden, da abhängige %{record} existieren.
+      taken: ist bereits vergeben
+      too_long:
+        one: ist zu lang (mehr als 1 Zeichen)
+        other: ist zu lang (mehr als %{count} Zeichen)
+      too_short:
+        one: ist zu kurz (weniger als 1 Zeichen)
+        other: ist zu kurz (weniger als %{count} Zeichen)
+      wrong_length:
+        one: hat die falsche Länge (muss genau 1 Zeichen haben)
+        other: hat die falsche Länge (muss genau %{count} Zeichen haben)
+      other_than: darf nicht gleich %{count} sein
+    template:
+      body: 'Bitte überprüfen Sie die folgenden Felder:'
+      header:
+        one: 'Konnte %{model} nicht speichern: ein Fehler.'
+        other: 'Konnte %{model} nicht speichern: %{count} Fehler.'
+  helpers:
+    select:
+      prompt: Bitte wählen
+    submit:
+      create: "%{model} erstellen"
+      submit: "%{model} speichern"
+      update: "%{model} aktualisieren"
+  number:
+    currency:
+      format:
+        delimiter: "."
+        format: "%n %u"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "€"
+    format:
+      delimiter: "."
+      precision: 2
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion:
+            one: Milliarde
+            other: Milliarden
+          million: Millionen
+          quadrillion:
+            one: Billiarde
+            other: Billiarden
+          thousand: Tausend
+          trillion: Billionen
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n %"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: " und "
+      two_words_connector: " und "
+      words_connector: ", "
+  time:
+    am: vormittags
+    formats:
+      default: "%A, %d. %B %Y, %H:%M Uhr"
+      long: "%A, %d. %B %Y, %H:%M Uhr"
+      short: "%d. %B, %H:%M Uhr"
+    pm: nachmittags

--- a/rails/locale/de.yml
+++ b/rails/locale/de.yml
@@ -56,39 +56,39 @@ de:
   datetime:
     distance_in_words:
       about_x_hours:
-        one: vor etwa einer Stunde
-        other: vor etwa %{count} Stunden
+        one: etwa eine Stunde
+        other: etwa %{count} Stunden
       about_x_months:
-        one: vor etwa einem Monat
-        other: vor etwa %{count} Monaten
+        one: etwa ein Monat
+        other: etwa %{count} Monate
       about_x_years:
-        one: vor etwa einem Jahr
-        other: vor etwa %{count} Jahren
+        one: etwa ein Jahr
+        other: etwa %{count} Jahre
       almost_x_years:
-        one: vor fast einem Jahr
-        other: vor fast %{count} Jahren
-      half_a_minute: vor einer halben Minute
+        one: fast ein Jahr
+        other: fast %{count} Jahre
+      half_a_minute: eine halbe Minute
       less_than_x_minutes:
-        one: vor weniger als einer Minute
-        other: vor weniger als %{count} Minuten
+        one: weniger als eine Minute
+        other: weniger als %{count} Minuten
       less_than_x_seconds:
-        one: vor weniger als eine Sekunde
-        other: vor weniger als %{count} Sekunden
+        one: weniger als eine Sekunde
+        other: weniger als %{count} Sekunden
       over_x_years:
-        one: vor mehr als einem Jahr
-        other: vor mehr als %{count} Jahren
+        one: mehr als ein Jahr
+        other: mehr als %{count} Jahre
       x_days:
-        one: vor einem Tag
-        other: "vor %{count} Tagen"
+        one: ein Tag
+        other: "%{count} Tage"
       x_minutes:
-        one: vor einer Minute
-        other: "vor %{count} Minuten"
+        one: eine Minute
+        other: "%{count} Minuten"
       x_months:
-        one: vor einem Monat
-        other: "vor %{count} Monaten"
+        one: ein Monat
+        other: "%{count} Monate"
       x_seconds:
-        one: vor einer Sekunde
-        other: "vor %{count} Sekunden"
+        one: eine Sekunde
+        other: "%{count} Sekunden"
     prompts:
       day: Tag
       hour: Stunden

--- a/rails/locale/es-DO.yml
+++ b/rails/locale/es-DO.yml
@@ -1,0 +1,205 @@
+---
+es-DO:
+  date:
+    abbr_day_names:
+    - dom
+    - lun
+    - mar
+    - mié
+    - jue
+    - vie
+    - sáb
+    abbr_month_names:
+    -
+    - ene
+    - feb
+    - mar
+    - abr
+    - may
+    - jun
+    - jul
+    - ago
+    - sep
+    - oct
+    - nov
+    - dic
+    day_names:
+    - domingo
+    - lunes
+    - martes
+    - miércoles
+    - jueves
+    - viernes
+    - sábado
+    formats:
+      default: "%-d/%-m/%Y"
+      long: "%A, %-d de %B de %Y"
+      short: "%-d de %b"
+    month_names:
+    -
+    - enero
+    - febrero
+    - marzo
+    - abril
+    - mayo
+    - junio
+    - julio
+    - agosto
+    - septiembre
+    - octubre
+    - noviembre
+    - diciembre
+    order:
+    - :day
+    - :month
+    - :year
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: alrededor de 1 hora
+        other: alrededor de %{count} horas
+      about_x_months:
+        one: alrededor de 1 mes
+        other: alrededor de %{count} meses
+      about_x_years:
+        one: alrededor de 1 año
+        other: alrededor de %{count} años
+      almost_x_years:
+        one: casi 1 año
+        other: casi %{count} años
+      half_a_minute: medio minuto
+      less_than_x_minutes:
+        one: menos de 1 minuto
+        other: menos de %{count} minutos
+      less_than_x_seconds:
+        one: menos de 1 segundo
+        other: menos de %{count} segundos
+      over_x_years:
+        one: más de 1 año
+        other: más de %{count} años
+      x_days:
+        one: 1 día
+        other: "%{count} días"
+      x_minutes:
+        one: 1 minuto
+        other: "%{count} minutos"
+      x_months:
+        one: 1 mes
+        other: "%{count} meses"
+      x_seconds:
+        one: 1 segundo
+        other: "%{count} segundos"
+    prompts:
+      day: Día
+      hour: Hora
+      minute: Minuto
+      month: Mes
+      second: Segundo
+      year: Año
+  errors:
+    format: "%{attribute} %{message}"
+    messages:
+      accepted: debe ser aceptado(a)
+      blank: no puede estar en blanco
+      present: debe estar en blanco
+      confirmation: no coincide
+      empty: no puede estar vacío(a)
+      equal_to: debe ser igual a %{count}
+      even: debe ser un número par
+      exclusion: está reservado(a)
+      greater_than: debe ser mayor que %{count}
+      greater_than_or_equal_to: debe ser mayor que o igual a %{count}
+      inclusion: no está incluido(a) en la lista
+      invalid: no es válido(a)
+      less_than: debe ser menor que %{count}
+      less_than_or_equal_to: debe ser menor que o igual a %{count}
+      not_a_number: no es un número
+      not_an_integer: debe ser un número entero
+      odd: debe ser un número impar
+      taken: ya está en uso
+      too_long:
+        one: es demasiado largo(a) (máximo 1 caracter)
+        other: es demasiado largo(a) (máximo %{count} caracteres)
+      too_short:
+        one: es demasiado corto(a) (mínimo 1 caracter)
+        other: es demasiado corto(a) (mínimo %{count} caracteres)
+      wrong_length:
+        one: no tiene la longitud correcta (debe ser de 1 caracter)
+        other: no tiene la longitud correcta (debe ser de %{count} caracteres)
+      other_than: debe ser diferente de %{count}
+    template:
+      body: "Revise que los siguientes campos sean válidos:"
+      header:
+        one: No se pudo guardar este(a) %{model} porque se encontró 1 error
+        other: No se pudo guardar este(a) %{model} porque se encontraron %{count} errores
+  helpers:
+    select:
+      prompt: Por favor seleccione
+    submit:
+      create: Crear %{model}
+      submit: Guardar %{model}
+      update: Actualizar %{model}
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u%n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: RD$
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: mil millones
+          million:
+            one: millón
+            other: millones
+          quadrillion: mil billones
+          thousand: mil
+          trillion:
+            one: billón
+            other: billones
+          unit: ""
+      format:
+        delimiter: ""
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ""
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ""
+  support:
+    array:
+      last_word_connector: " y "
+      two_words_connector: " y "
+      words_connector: ", "
+  time:
+    am: am
+    formats:
+      default: "%A, %-d de %B de %Y a las %-I:%M:%S %p %Z"
+      long: "%-d de %B de %Y a las %-I:%M %p"
+      short: "%-d %b %-I:%M %p"
+    pm: pm

--- a/rails/locale/es-ES.yml
+++ b/rails/locale/es-ES.yml
@@ -1,0 +1,204 @@
+---
+es-ES:
+  date:
+    abbr_day_names:
+    - dom
+    - lun
+    - mar
+    - mié
+    - jue
+    - vie
+    - sáb
+    abbr_month_names:
+    - 
+    - ene
+    - feb
+    - mar
+    - abr
+    - may
+    - jun
+    - jul
+    - ago
+    - sep
+    - oct
+    - nov
+    - dic
+    day_names:
+    - domingo
+    - lunes
+    - martes
+    - miércoles
+    - jueves
+    - viernes
+    - sábado
+    formats:
+      default: "%-d/%-m/%Y"
+      long: "%-d de %B de %Y"
+      short: "%-d de %b"
+    month_names:
+    - 
+    - enero
+    - febrero
+    - marzo
+    - abril
+    - mayo
+    - junio
+    - julio
+    - agosto
+    - septiembre
+    - octubre
+    - noviembre
+    - diciembre
+    order:
+    - :day
+    - :month
+    - :year
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: alrededor de 1 hora
+        other: alrededor de %{count} horas
+      about_x_months:
+        one: alrededor de 1 mes
+        other: alrededor de %{count} meses
+      about_x_years:
+        one: alrededor de 1 año
+        other: alrededor de %{count} años
+      almost_x_years:
+        one: casi 1 año
+        other: casi %{count} años
+      half_a_minute: medio minuto
+      less_than_x_minutes:
+        one: menos de 1 minuto
+        other: menos de %{count} minutos
+      less_than_x_seconds:
+        one: menos de 1 segundo
+        other: menos de %{count} segundos
+      over_x_years:
+        one: más de 1 año
+        other: más de %{count} años
+      x_days:
+        one: 1 día
+        other: "%{count} días"
+      x_minutes:
+        one: 1 minuto
+        other: "%{count} minutos"
+      x_months:
+        one: 1 mes
+        other: "%{count} meses"
+      x_seconds:
+        one: 1 segundo
+        other: "%{count} segundos"
+    prompts:
+      day: Día
+      hour: Hora
+      minute: Minutos
+      month: Mes
+      second: Segundos
+      year: Año
+  errors:
+    format: "%{attribute} %{message}"
+    messages:
+      accepted: debe ser aceptado
+      blank: no puede estar en blanco
+      present: debe estar en blanco
+      confirmation: no coincide
+      empty: no puede estar vacío
+      equal_to: debe ser igual a %{count}
+      even: debe ser par
+      exclusion: está reservado
+      greater_than: debe ser mayor que %{count}
+      greater_than_or_equal_to: debe ser mayor que o igual a %{count}
+      inclusion: no está incluido en la lista
+      invalid: no es válido
+      less_than: debe ser menor que %{count}
+      less_than_or_equal_to: debe ser menor que o igual a %{count}
+      not_a_number: no es un número
+      not_an_integer: debe ser un entero
+      odd: debe ser impar
+      record_invalid: 'La validación falló: %{errors}'
+      restrict_dependent_destroy:
+        one: No se puede eliminar el registro porque existe un %{record} dependiente
+        many: No se puede eliminar el registro porque existen %{record} dependientes
+      taken: ya está en uso
+      too_long:
+        one: "es demasiado largo (1 carácter máximo)"
+        other: "es demasiado largo (%{count} caracteres máximo)"
+      too_short:
+        one: "es demasiado corto (1 carácter mínimo)"
+        other: "es demasiado corto (%{count} caracteres mínimo)"
+      wrong_length:
+        one: "no tiene la longitud correcta (1 carácter exactos)"
+        other: "no tiene la longitud correcta (%{count} caracteres exactos)"
+      other_than: debe ser distinto de %{count}
+    template:
+      body: 'Se encontraron problemas con los siguientes campos:'
+      header:
+        one: No se pudo guardar este/a %{model} porque se encontró 1 error
+        other: No se pudo guardar este/a %{model} porque se encontraron %{count} errores
+  helpers:
+    select:
+      prompt: Por favor seleccione
+    submit:
+      create: Crear %{model}
+      submit: Guardar %{model}
+      update: Actualizar %{model}
+  number:
+    currency:
+      format:
+        delimiter: "."
+        format: "%n %u"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "€"
+    format:
+      delimiter: "."
+      precision: 3
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: mil millones
+          million: millón
+          quadrillion: mil billones
+          thousand: mil
+          trillion: billón
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 1
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: " y "
+      two_words_connector: " y "
+      words_connector: ", "
+  time:
+    am: am
+    formats:
+      default: "%A, %-d de %B de %Y %H:%M:%S %z"
+      long: "%-d de %B de %Y %H:%M"
+      short: "%-d de %b %H:%M"
+    pm: pm

--- a/rails/locale/es.yml
+++ b/rails/locale/es.yml
@@ -32,9 +32,9 @@ es:
     - viernes
     - sábado
     formats:
-      default: "%d/%m/%Y"
-      long: "%d de %B de %Y"
-      short: "%d de %b"
+      default: "%-d/%-m/%Y"
+      long: "%-d de %B de %Y"
+      short: "%-d de %b"
     month_names:
     - 
     - enero
@@ -198,7 +198,7 @@ es:
   time:
     am: am
     formats:
-      default: "%A, %d de %B de %Y %H:%M:%S %z"
-      long: "%d de %B de %Y %H:%M"
-      short: "%d de %b %H:%M"
+      default: "%A, %-d de %B de %Y %H:%M:%S %z"
+      long: "%-d de %B de %Y %H:%M"
+      short: "%-d de %b %H:%M"
     pm: pm

--- a/rails/locale/fr-FR.yml
+++ b/rails/locale/fr-FR.yml
@@ -1,0 +1,207 @@
+---
+fr-FR:
+  date:
+    abbr_day_names:
+    - dim
+    - lun
+    - mar
+    - mer
+    - jeu
+    - ven
+    - sam
+    abbr_month_names:
+    - 
+    - jan.
+    - fév.
+    - mar.
+    - avr.
+    - mai
+    - juin
+    - juil.
+    - août
+    - sept.
+    - oct.
+    - nov.
+    - déc.
+    day_names:
+    - dimanche
+    - lundi
+    - mardi
+    - mercredi
+    - jeudi
+    - vendredi
+    - samedi
+    formats:
+      default: "%d/%m/%Y"
+      short: "%e %b"
+      long: "%e %B %Y"
+    month_names:
+    - 
+    - janvier
+    - février
+    - mars
+    - avril
+    - mai
+    - juin
+    - juillet
+    - août
+    - septembre
+    - octobre
+    - novembre
+    - décembre
+    order:
+    - :day
+    - :month
+    - :year
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: environ une heure
+        other: environ %{count} heures
+      about_x_months:
+        one: environ un mois
+        other: environ %{count} mois
+      about_x_years:
+        one: environ un an
+        other: environ %{count} ans
+      almost_x_years:
+        one: presqu'un an
+        other: presque %{count} ans
+      half_a_minute: une demi-minute
+      less_than_x_minutes:
+        zero: moins d'une minute
+        one: moins d'une minute
+        other: moins de %{count} minutes
+      less_than_x_seconds:
+        zero: moins d'une seconde
+        one: moins d'une seconde
+        other: moins de %{count} secondes
+      over_x_years:
+        one: plus d'un an
+        other: plus de %{count} ans
+      x_days:
+        one: 1 jour
+        other: "%{count} jours"
+      x_minutes:
+        one: 1 minute
+        other: "%{count} minutes"
+      x_months:
+        one: 1 mois
+        other: "%{count} mois"
+      x_seconds:
+        one: 1 seconde
+        other: "%{count} secondes"
+    prompts:
+      day: Jour
+      hour: Heure
+      minute: Minute
+      month: Mois
+      second: Seconde
+      year: Année
+  errors:
+    format: "%{attribute} %{message}"
+    messages:
+      accepted: doit être accepté(e)
+      blank: doit être rempli(e)
+      present: doit être vide
+      confirmation: ne concorde pas avec %{attribute}
+      empty: doit être rempli(e)
+      equal_to: doit être égal à %{count}
+      even: doit être pair
+      exclusion: n'est pas disponible
+      greater_than: doit être supérieur à %{count}
+      greater_than_or_equal_to: doit être supérieur ou égal à %{count}
+      inclusion: n'est pas inclus(e) dans la liste
+      invalid: n'est pas valide
+      less_than: doit être inférieur à %{count}
+      less_than_or_equal_to: doit être inférieur ou égal à %{count}
+      not_a_number: n'est pas un nombre
+      not_an_integer: doit être un nombre entier
+      odd: doit être impair
+      record_invalid: 'La validation a échoué : %{errors}'
+      restrict_dependent_destroy:
+        one: 'Suppression impossible: un autre enregistrement est lié'
+        many: 'Suppression impossible: d''autres enregistrements sont liés'
+      taken: n'est pas disponible
+      too_long:
+        one: est trop long (pas plus d'un caractère)
+        other: est trop long (pas plus de %{count} caractères)
+      too_short:
+        one: est trop court (au moins un caractère)
+        other: est trop court (au moins %{count} caractères)
+      wrong_length:
+        one: ne fait pas la bonne longueur (doit comporter un seul caractère)
+        other: ne fait pas la bonne longueur (doit comporter %{count} caractères)
+      other_than: doit être différent de %{count}
+    template:
+      body: 'Veuillez vérifier les champs suivants : '
+      header:
+        one: 'Impossible d''enregistrer ce(tte) %{model} : 1 erreur'
+        other: 'Impossible d''enregistrer ce(tte) %{model} : %{count} erreurs'
+  helpers:
+    select:
+      prompt: Veuillez sélectionner
+    submit:
+      create: Créer un(e) %{model}
+      submit: Enregistrer ce(tte) %{model}
+      update: Modifier ce(tte) %{model}
+  number:
+    currency:
+      format:
+        delimiter: " "
+        format: "%n %u"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "€"
+    format:
+      delimiter: " "
+      precision: 3
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: milliard
+          million: million
+          quadrillion: million de milliards
+          thousand: millier
+          trillion: billion
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 2
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: octet
+            other: octets
+          gb: Go
+          kb: ko
+          mb: Mo
+          tb: To
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: " et "
+      two_words_connector: " et "
+      words_connector: ", "
+  time:
+    am: am
+    formats:
+      default: "%d %B %Y %Hh %Mmin %Ss"
+      long: "%A %d %B %Y %Hh%M"
+      short: "%d %b %Hh%M"
+    pm: pm

--- a/rails/locale/pa.yml
+++ b/rails/locale/pa.yml
@@ -1,0 +1,205 @@
+---
+pa:
+  date:
+    abbr_day_names:
+    - ਅੈਤ
+    - ਸੋਮ
+    - ਮੰਗਲ
+    - ਬੱੁਧ
+    - ਵੀਰ
+    - ਸ਼ੁੱਕਰ
+    - ਸ਼ਨਿੱਚਰ
+    abbr_month_names:
+    - 
+    - ਜਨ
+    - ਫ਼ਰ
+    - ਮਾਰਚ
+    - ਅਪ੍ਰੈ
+    - ਮਈ
+    - ਜੂਨ
+    - ਜੁਲਾ
+    - ਅਗ
+    - ਸਤੰ
+    - ਅਕਤੂ
+    - ਨਵੰ
+    - ਦਸੰ
+    day_names:
+    - ਐਤਵਾਰ
+    - ਸੋਮਵਾਰ
+    - ਮੰਗਲਵਾਰ
+    - ਬੁੱਧਵਾਰ
+    - ਵੀਰਵਾਰ
+    - ਸ਼ੁੱਕਰਵਾਰ
+    - ਸ਼ਨਿੱਚਰਵਾਰ
+    formats:
+      default: "%Y-%m-%d"
+      long: "%B %d, %Y"
+      short: "%b %d"
+    month_names:
+    - 
+    - ਜਨਵਰੀ
+    - ਫ਼ਰਵਰੀ
+    - ਮਾਰਚ
+    - ਅਪ੍ੈਲ
+    - ਮਈ
+    - ਜੂਨ
+    - ਜੁਲਾਈ
+    - ਅਗਸਤ
+    - ਸਤੰਬਰ
+    - ਅਕਤੂਬਰ
+    - ਨਵੰਬਰ
+    - ਦਸੰਬਰ
+    order:
+    - :year
+    - :month
+    - :day
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: ਲਗਭਗ 1 ਘੰਟਾ
+        other: ਲਗਭਗ %{count} ਘੰਟੇ
+      about_x_months:
+        one: ਲਗਭਗ 1 ਮਹੀਨਾ
+        other: ਲਗਭਗ %{count} ਮਹੀਨੇ
+      about_x_years:
+        one: ਲਗਭਗ 1 ਸਾਲ
+        other: ਲਗਭਗ %{count} ਸਾਲ
+      almost_x_years:
+        one: ਤਕਰੀਬਨ 1 ਸਾਲ
+        other: ਤਕਰੀਬਨ %{count} ਸਾਲ
+      half_a_minute: ਅੱਧਾ ਮਿੰਟ
+      less_than_x_minutes:
+        one: 1 ਮਿੰਟ ਤੋਂ ਘੱਟ
+        other: "%{count} ਮਿੰਟਾਂ ਤੋਂ ਘੱਟ"
+      less_than_x_seconds:
+        one: 1 ਸਕਿੰਟ ਤੋਂ ਘੱਟ
+        other: "%{count} ਸਕਿੰਟਾਂ ਤੋਂ ਘੱਟ"
+      over_x_years:
+        one: 1 ਸਾਲ ਤੋਂ ਵੱਧ
+        other: "%{count} ਸਾਲਾਂ ਤੋਂ ਵੱਧ"
+      x_days:
+        one: 1 ਦਿਨ
+        other: "%{count} ਦਿਨ"
+      x_minutes:
+        one: 1 ਮਿੰਟ
+        other: "%{count} ਮਿੰਟ"
+      x_months:
+        one: 1 ਮਹੀਨਾ
+        other: "%{count} ਮਹੀਨੇ"
+      x_seconds:
+        one: 1 ਸਕਿੰਟ
+        other: "%{count} ਸਕਿੰਟ"
+    prompts:
+      day: ਦਿਨ
+      hour: ਘੰਟਾ
+      minute: ਮਿੰਟ
+      month: ਮਹੀਨਾ
+      second: ਸਕਿੰਟ
+      year: ਸਾਲ
+  errors:
+    format: "%{attribute} %{message}"
+    messages:
+      accepted: ਜਰੂਰੀ ਮੰਜੂਰ ਹੋਵੇ
+      blank: ਖਾਲੀ ਨਹੀਂ ਹੋ ਸਕਦਾ
+      present: ਜਰੂਰੀ ਖਾਲੀ ਹੋਵੇ
+      confirmation: "%{attribute} ਨਹੀਂ ਰਲਦੇ"
+      empty: ਖਾਲੀ ਨਹੀਂ ਹੋ ਸਕਦਾ
+      equal_to: "%{count} ਦੇ ਬਰਾਬਰ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ"
+      even: ਜਰੂਰੀ ਹੈ ਕੇ ਜੋਟਾ ਹੋਵੇ
+      exclusion: ਮੱਲਿਆ ਹੋਇਆ ਹੈ
+      greater_than: "%{count} ਤੋਂ ਵਧੇਰੇ ਹੋਣਾ ਜਰੂਰੀ ਹੈ"
+      greater_than_or_equal_to: "%{count} ਤੋਂ ਵਧੇਰੇ ਜਾਂ ਬਰਾਬਰ ਹੋਣਾ ਜਰੂਰੀ ਹੈ"
+      inclusion: ਇਸ ਲਿਸਟ ਵਿੱਚ ਸ਼ਾਮਿਲ ਨਹੀਂ ਹੈ
+      invalid: ਨਾ-ਮੰਜੂਰਸ਼ੁਦਾ ਹੈ
+      less_than: "%{count} ਤੋਂ ਘੱਟ ਹੋਣਾ ਜਰੂਰੀ ਹੈ"
+      less_than_or_equal_to: "%{count} ਤੋਂ ਘੱਟ ਜਾਂ ਬਰਾਬਰ ਹੋਣਾ ਜਰੂਰੀ ਹੈ"
+      not_a_number: ਸੰਖਿਆ ਨਹੀਂ ਹੈ
+      not_an_integer: ਜਰੂਰੀ ਹੈ ਕੇ ਪੂਰਨ ਅੰਕ ਹੋਵੇ
+      odd: ਜਰੂਰੀ ਹੈ ਕੇ ਕਲ੍ਲੀ ਹੋਵੇ
+      record_invalid: 'ਪਰਮਾਣ ਫ਼ੇਲ ਹੋਇਆ: %{errors}'
+      restrict_dependent_destroy:
+        one: ਮਿਟਾ ਨਹੀਂ ਸਕਦੇ ਕਿਉਂਕਿ ਇੱਕ ਨਿਰਭਰ %{record} ਮੌਜੂਦ ਹੈ
+        many: ਮਿਟਾ ਨਹੀਂ ਸਕਦੇ ਕਿਉਂਕਿ ਨਿਰਭਰ %{record} ਮੌਜੂਦ ਹਨ
+      taken: ਪਹਿਲਾਂ ਹੀ ਮੱਲਿਆ ਹੋਇਆ ਹੈ
+      too_long:
+        one: ਲੰਬਾਈ ਜ਼ਿਆਦਾ ਹੈ (ਵੱਧ ਤੋਂ ਵੱਧ 1 ਅੱਖਰ)
+        other: ਲੰਬਾਈ ਜ਼ਿਆਦਾ ਹੈ (ਵੱਧ ਤੋਂ ਵੱਧ %{count} ਅੱਖਰ)
+      too_short:
+        one: ਲੰਬਾਈ ਘੱਟ ਹੈ (ਘੱਟ ਤੋਂ ਘੱਟ 1 ਅੱਖਰ)
+        other: ਲੰਬਾਈ ਘੱਟ ਹੈ (ਘੱਟ ਤੋਂ ਘੱਟ %{count} ਅੱਖਰ)
+      wrong_length:
+        one: ਲੰਬਾਈ ਗਲਤ ਹੈ (1 ਅੱਖਰ ਹੋਣੀ ਚਾਹੀਦੀ ਹੈ)
+        other: ਲੰਬਾਈ ਗਲਤ ਹੈ (%{count} ਅੱਖਰ ਹੋਣੀ ਚਾਹੀਦੀ ਹੈ)
+      other_than: "%{count} ਦੀ ਜਗਾਹ ਹੋਰ ਹੋਣੀ ਚਾਹੀਦੀ ਹੈ"
+    template:
+      body: 'ਹੇਠਲੇ ਖੇਤਰਾਂ ਵਿੱਚ ਗਲਤੀਆਂ ਹਨ:'
+      header:
+        one: 1 ਗਲਤੀ ਕਰਕੇ ਇਹ %{model} ਬਚਾਇਆ ਨਹੀਂ ਗਿਆ
+        other: "%{count} ਗਲਤੀਆਂ ਕਰਕੇ ਇਹ %{model} ਬਚਾਇਆ ਨਹੀਂ ਗਿਆ"
+  helpers:
+    select:
+      prompt: ਕਿਰਪਾ ਕਰਕੇ ਚੁਣੋ
+    submit:
+      create: "%{model} ਬਣਾਓ"
+      submit: "%{model} ਬਚਾਓ"
+      update: "%{model} ਬਦਲੋ"
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u%n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "$"
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: ਅਰਬ
+          million: ਮਿਲੀਅਨ
+          quadrillion: ਕ੍ਵਾਡਰਿਲੀਅਨ
+          thousand: ਹਜਾਰ
+          trillion: ਟ੍ਰਿਲੀਅਨ
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: ਬਾਈਟ
+            other: ਬਾਈਟ
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: ", ਅਤੇ "
+      two_words_connector: " ਅਤੇ "
+      words_connector: ", "
+  time:
+    am: ਪੂ.ਦੁ.
+    formats:
+      default: "%a, %d %b %Y %H:%M:%S %z"
+      long: "%B %d, %Y %H:%M"
+      short: "%d %b %H:%M"
+    pm: ਬਾ.ਦੁ.

--- a/rails/locale/pa.yml
+++ b/rails/locale/pa.yml
@@ -197,9 +197,9 @@ pa:
       two_words_connector: " ਅਤੇ "
       words_connector: ", "
   time:
-    am: ਪੂ.ਦੁ.
+    am: ਸਵੇਰ
     formats:
       default: "%a, %d %b %Y %H:%M:%S %z"
       long: "%B %d, %Y %H:%M"
       short: "%d %b %H:%M"
-    pm: ਬਾ.ਦੁ.
+    pm: ਸ਼ਾਮ

--- a/rails/locale/pa.yml
+++ b/rails/locale/pa.yml
@@ -40,7 +40,7 @@ pa:
     - ਜਨਵਰੀ
     - ਫ਼ਰਵਰੀ
     - ਮਾਰਚ
-    - ਅਪ੍ੈਲ
+    - ਅਪ੍ਰੈਲ
     - ਮਈ
     - ਜੂਨ
     - ਜੁਲਾਈ
@@ -99,9 +99,9 @@ pa:
   errors:
     format: "%{attribute} %{message}"
     messages:
-      accepted: ਜਰੂਰੀ ਮੰਜੂਰ ਹੋਵੇ
+      accepted: ਜਰੂਰ ਮੰਜੂਰ ਹੋਵੇ
       blank: ਖਾਲੀ ਨਹੀਂ ਹੋ ਸਕਦਾ
-      present: ਜਰੂਰੀ ਖਾਲੀ ਹੋਵੇ
+      present: ਜਰੂਰ ਖਾਲੀ ਹੋਵੇ
       confirmation: "%{attribute} ਨਹੀਂ ਰਲਦੇ"
       empty: ਖਾਲੀ ਨਹੀਂ ਹੋ ਸਕਦਾ
       equal_to: "%{count} ਦੇ ਬਰਾਬਰ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ"
@@ -115,7 +115,7 @@ pa:
       less_than_or_equal_to: "%{count} ਤੋਂ ਘੱਟ ਜਾਂ ਬਰਾਬਰ ਹੋਣਾ ਜਰੂਰੀ ਹੈ"
       not_a_number: ਸੰਖਿਆ ਨਹੀਂ ਹੈ
       not_an_integer: ਜਰੂਰੀ ਹੈ ਕੇ ਪੂਰਨ ਅੰਕ ਹੋਵੇ
-      odd: ਜਰੂਰੀ ਹੈ ਕੇ ਕਲ੍ਲੀ ਹੋਵੇ
+      odd: ਜਰੂਰੀ ਹੈ ਕੇ ਕਲ਼ੀ ਹੋਵੇ
       record_invalid: 'ਪਰਮਾਣ ਫ਼ੇਲ ਹੋਇਆ: %{errors}'
       restrict_dependent_destroy:
         one: ਮਿਟਾ ਨਹੀਂ ਸਕਦੇ ਕਿਉਂਕਿ ਇੱਕ ਨਿਰਭਰ %{record} ਮੌਜੂਦ ਹੈ
@@ -130,12 +130,12 @@ pa:
       wrong_length:
         one: ਲੰਬਾਈ ਗਲਤ ਹੈ (1 ਅੱਖਰ ਹੋਣੀ ਚਾਹੀਦੀ ਹੈ)
         other: ਲੰਬਾਈ ਗਲਤ ਹੈ (%{count} ਅੱਖਰ ਹੋਣੀ ਚਾਹੀਦੀ ਹੈ)
-      other_than: "%{count} ਦੀ ਜਗਾਹ ਹੋਰ ਹੋਣੀ ਚਾਹੀਦੀ ਹੈ"
+      other_than: "%{count} ਦੀ ਜਗ੍ਹਾ ਹੋਰ ਹੋਣੀ ਚਾਹੀਦੀ ਹੈ"
     template:
       body: 'ਹੇਠਲੇ ਖੇਤਰਾਂ ਵਿੱਚ ਗਲਤੀਆਂ ਹਨ:'
       header:
-        one: 1 ਗਲਤੀ ਕਰਕੇ ਇਹ %{model} ਬਚਾਇਆ ਨਹੀਂ ਗਿਆ
-        other: "%{count} ਗਲਤੀਆਂ ਕਰਕੇ ਇਹ %{model} ਬਚਾਇਆ ਨਹੀਂ ਗਿਆ"
+        one: 1 ਗਲਤੀ ਕਰਕੇ ਇਹ %{model} ਸੰਭਾਲਿ਼ਆ ਨਹੀਂ ਗਿਆ
+        other: "%{count} ਗਲਤੀਆਂ ਕਰਕੇ ਇਹ %{model} ਸੰਭਾਲਿ਼ਆ ਨਹੀਂ ਗਿਆ"
   helpers:
     select:
       prompt: ਕਿਰਪਾ ਕਰਕੇ ਚੁਣੋ
@@ -163,10 +163,10 @@ pa:
       decimal_units:
         format: "%n %u"
         units:
-          billion: ਅਰਬ
+          billion: ਬਿਲੀਅਨ
           million: ਮਿਲੀਅਨ
           quadrillion: ਕ੍ਵਾਡਰਿਲੀਅਨ
-          thousand: ਹਜਾਰ
+          thousand: ਹਜ਼ਾਰ
           trillion: ਟ੍ਰਿਲੀਅਨ
           unit: ''
       format:

--- a/rails/locale/ru.yml
+++ b/rails/locale/ru.yml
@@ -109,7 +109,7 @@ ru:
       x_seconds:
         few: "%{count} секунды"
         many: "%{count} секунд"
-        one: "%{count} секундy"
+        one: "%{count} секунду"
         other: "%{count} секунды"
     prompts:
       day: День

--- a/rails/locale/sq.yml
+++ b/rails/locale/sq.yml
@@ -1,0 +1,205 @@
+---
+sq:
+  date:
+    abbr_day_names:
+    - E Diel
+    - E Hënë
+    - E Martë
+    - E Mërkurë
+    - E Enjte
+    - E Premte
+    - E Shtunë
+    abbr_month_names:
+    -
+    - Janar
+    - Shkurt
+    - Mars
+    - Prill
+    - Maj
+    - Qershor
+    - Korrik
+    - Gusht
+    - Shtator
+    - Tetor
+    - Nëntor
+    - Dhjetor
+    day_names:
+    - E Diel
+    - E Hënë
+    - E Martë
+    - E Mërkurë
+    - E Enjte
+    - E Premte
+    - E Shtunë
+    formats:
+      default: "%m-%d-%Y"
+      long: "%B %d, %Y"
+      short: "%b %d"
+    month_names:
+    -
+    - Janar
+    - Shkurt
+    - Mars
+    - Prill
+    - Maj
+    - Qershor
+    - Korrik
+    - Gusht
+    - Shtator
+    - Tetor
+    - Nëntor
+    - Dhjetor
+    order:
+    - :month
+    - :day
+    - :year
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: rreth 1 orë
+        other: rreth %{count} orë
+      about_x_months:
+        one: rreth 1 muaj
+        other: rreth %{count} muaj
+      about_x_years:
+        one: rreth 1 vit
+        other: rreth %{count} vite
+      almost_x_years:
+        one: gati 1 vit
+        other: gati %{count} vite
+      half_a_minute: gjysëm minute
+      less_than_x_minutes:
+        one: më pak se një minutë
+        other: më pak se %{count} minuta
+      less_than_x_seconds:
+        one: më pak se 1 sekond
+        other: më pak se %{count} sekonda
+      over_x_years:
+        one: mbi 1 vit
+        other: mbi %{count} vite
+      x_days:
+        one: 1 ditë
+        other: "%{count} ditë"
+      x_minutes:
+        one: 1 minutë
+        other: "%{count} minuta"
+      x_months:
+        one: 1 muaj
+        other: "%{count} muaj"
+      x_seconds:
+        one: 1 sekond
+        other: "%{count} sekonda"
+    prompts:
+      day: Ditë
+      hour: Orë
+      minute: Minutë
+      month: Muaj
+      second: Sekond
+      year: Vit
+  errors:
+    format: "%{attribute} %{message}"
+    messages:
+      accepted: duhet të pranohet
+      blank: nuk mund të jetë bosh
+      present: duhet të jetë bosh
+      confirmation: nuk përputhet me %{attribute}
+      empty: nuk mund të jetë bosh
+      equal_to: duhet të përputhet me %{count}
+      even: duhet të jetë i barabartë
+      exclusion: është i rezervuar
+      greater_than: duhet të jetë më shumë se %{count}
+      greater_than_or_equal_to: duhet të jetë më shumë ose i barabartë me %{count}
+      inclusion: nuk është i përfshirë në list
+      invalid: është e palejuar
+      less_than: duhet të jetë më pak se %{count}
+      less_than_or_equal_to: duhet të jetë më pak ose i barabartë me %{count}
+      not_a_number: nuk është numër
+      not_an_integer: duhet të jetë numër
+      odd: duhet të jetë tek
+      record_invalid: 'Validimi dështoi: %{errors}'
+      restrict_dependent_destroy:
+        one: Nuk mund të fshini rekordin për shkak se një %{record} i varur ekziston
+        many: Nuk mund të fshini rekordin për shkak se %{record} të varura ekzistojnë
+      taken: është marrë tashmë
+      too_long:
+        one: është shumë i gjatë (maksimumi është 1 shkronjë)
+        other: është shumë i gjatë (maksimumi është %{count} shkronja)
+      too_short:
+        one: është shumë i shkurtër (minimumi është 1 shkronjë)
+        other: është shumë i shkurtër (minimumi është %{count} shkronja)
+      wrong_length:
+        one: është gjatësia e gabuar (duhet të jetë 1 shkronjë)
+        other: është gjatësia e gabuar (duhet të jetë %{count} shkronja)
+      other_than: duhet të jetë më shumë se %{count}
+    template:
+      body: 'Kishte probleme me formën e mëposhtme:'
+      header:
+        one: 1 veprim i gabuar e ndaloi këtë %{model} për t'u ruajtur
+        other: "%{count} veprime të gabuara e ndaluan këtë %{model} për t'u ruajtur"
+  helpers:
+    select:
+      prompt: Ju lutem zgjidhni
+    submit:
+      create: Krijo %{model}
+      submit: Ruaj %{model}
+      update: Ndrysho %{model}
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u%n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "LEK"
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: Bilion
+          million: Milion
+          quadrillion: Kuatrilion
+          thousand: Mijë
+          trillion: Trilion
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: ", dhe "
+      two_words_connector: " dhe "
+      words_connector: ", "
+  time:
+    am: në mëngjes
+    formats:
+      default: "%a, %d %b %Y %I:%M:%S %p %Z"
+      long: "%B %d, %Y %I:%M %p"
+      short: "%d %b %I:%M %p"
+    pm: mbasdite

--- a/rails/locale/zh-CN.yml
+++ b/rails/locale/zh-CN.yml
@@ -187,6 +187,7 @@ zh-CN:
     percentage:
       format:
         delimiter: ''
+        format: "%n%"
     precision:
       format:
         delimiter: ''

--- a/rails/locale/zh-TW.yml
+++ b/rails/locale/zh-TW.yml
@@ -187,6 +187,7 @@ zh-TW:
     percentage:
       format:
         delimiter: ''
+        format: "%n%"
     precision:
       format:
         delimiter: ''

--- a/rails/pluralization/de-DE.rb
+++ b/rails/pluralization/de-DE.rb
@@ -1,0 +1,3 @@
+require 'rails_i18n/common_pluralizations/one_other'
+
+::RailsI18n::Pluralization::OneOther.with_locale(:'de-DE')

--- a/rails/pluralization/es-ES.rb
+++ b/rails/pluralization/es-ES.rb
@@ -1,0 +1,3 @@
+require 'rails_i18n/common_pluralizations/one_other'
+
+::RailsI18n::Pluralization::OneOther.with_locale(:'es-ES')

--- a/rails/pluralization/fr-FR.rb
+++ b/rails/pluralization/fr-FR.rb
@@ -1,0 +1,3 @@
+require 'rails_i18n/common_pluralizations/one_upto_two_other'
+
+::RailsI18n::Pluralization::OneUptoTwoOther.with_locale(:'fr-FR')

--- a/rails/pluralization/pa.rb
+++ b/rails/pluralization/pa.rb
@@ -1,0 +1,3 @@
+require 'rails_i18n/common_pluralizations/one_with_zero_other'
+
+::RailsI18n::Pluralization::OneWithZeroOther.with_locale(:pa)


### PR DESCRIPTION
Should the documentation add instruction to include `<html lang="**<%= I18n.locale %>**" dir="ltr">` at top of application.html.erb if you're using the gem with a subdomain or domain?

The locale is then set in application_controller.rb
  ```
def set_locale
    # I18n.locale = extract_locale_from_subdomain || I18n.default_locale
    I18n.locale = extract_locale_from_subdomain
end

def extract_locale_from_subdomain
    parsed_locale = request.host.split('.').first
    if parsed_locale.match(/^msr/)    ///my subdomain contains these letters
      I18n.locale = 'en-AU'
    else 
      I18n.default_locale
    end
end
```