### PR TITLE
Fix german pluralization of days, months and years

### DIFF
--- a/rails/locale/de.yml
+++ b/rails/locale/de.yml
@@ -87,16 +87,16 @@ de:
         other: mehr als %{count} Jahre
       x_days:
         one: ein Tag
-        other: "%{count} Tage"
+        other: "%{count} Tagen"
       x_minutes:
         one: eine Minute
         other: "%{count} Minuten"
       x_months:
         one: ein Monat
-        other: "%{count} Monate"
+        other: "%{count} Monaten"
       x_years:
         one: ein Jahr
-        other: "%{count} Jahr"
+        other: "%{count} Jahren"
       x_seconds:
         one: eine Sekunde
         other: "%{count} Sekunden"


### PR DESCRIPTION
This keeps it in line with 'Sekunden', 'Minuten' etc