### PR TITLE
Danish: Propose change da.errors.messages.required to "skal udfyldes"

### DIFF
--- a/rails/locale/da.yml
+++ b/rails/locale/da.yml
@@ -128,7 +128,7 @@ da:
       odd: skal være et ulige tal
       other_than: skal være forskellig fra %{count}
       present: skal være tom
-      required: skal eksistere
+      required: skal udfyldes
       taken: er allerede brugt
       too_long:
         one: er for lang (højst 1 tegn)


### PR DESCRIPTION
In my opinion, this sounds better in Danish

I acknowledge that this is the same formulation for the two:

* `da.errors.messages.required: skal udfyldes`
* `da.errors.messages.blank: skal udfyldes`

However, this sounds better and more natural when you read it. Example: "Kategori skal udfyldes"