### PR TITLE
correct last word connector for pt

### DIFF
--- a/rails/locale/pt.yml
+++ b/rails/locale/pt.yml
@@ -204,7 +204,7 @@ pt:
         delimiter: ''
   support:
     array:
-      last_word_connector: ", e"
+      last_word_connector: " e "
       two_words_connector: " e "
       words_connector: ", "
   time:


### PR DESCRIPTION
In Portuguese the last word connector in an enumeration does not have a comma. The connector is also missing a space.