### PR TITLE
Add missing active_record and storage_unit keys to all EN locales

### DIFF
--- a/rails/locale/en-AU.yml
+++ b/rails/locale/en-AU.yml
@@ -3,7 +3,10 @@ en-AU:
   activerecord:
     errors:
       messages:
-        record_invalid: 'Validation failed: %{errors}'
+        record_invalid: "Validation failed: %{errors}"
+        restrict_dependent_destroy:
+          has_one: "Cannot delete record because a dependent %{record} exists"
+          has_many: "Cannot delete record because dependent %{record} exist"
   date:
     abbr_day_names:
     - Sun
@@ -92,7 +95,7 @@ en-AU:
         other: "%{count} months"
       x_years:
         one: 1 year
-        other: "%{count} years" 
+        other: "%{count} years"
       x_seconds:
         one: 1 second
         other: "%{count} seconds"
@@ -108,6 +111,7 @@ en-AU:
     messages:
       accepted: must be accepted
       blank: can't be blank
+      present: must be blank
       confirmation: doesn't match %{attribute}
       empty: can't be empty
       equal_to: must be equal to %{count}
@@ -119,9 +123,11 @@ en-AU:
       invalid: is invalid
       less_than: must be less than %{count}
       less_than_or_equal_to: must be less than or equal to %{count}
+      model_invalid: "Validation failed: %{errors}"
       not_a_number: is not a number
       not_an_integer: must be an integer
       odd: must be odd
+      required: must exist
       taken: has already been taken
       too_long:
         one: is too long (maximum is 1 character)
@@ -132,6 +138,7 @@ en-AU:
       wrong_length:
         one: is the wrong length (should be 1 character)
         other: is the wrong length (should be %{count} characters)
+      other_than: must be other than %{count}
     template:
       body: 'There were problems with the following fields:'
       header:
@@ -185,9 +192,12 @@ en-AU:
           kb: KB
           mb: MB
           tb: TB
+          pb: PB
+          eb: EB
     percentage:
       format:
         delimiter: ''
+        format: "%n%"
     precision:
       format:
         delimiter: ''

--- a/rails/locale/en-CA.yml
+++ b/rails/locale/en-CA.yml
@@ -3,7 +3,7 @@ en-CA:
   activerecord:
     errors:
       messages:
-        record_invalid: 'Validation failed: %{errors}'
+        record_invalid: "Validation failed: %{errors}"
         restrict_dependent_destroy:
           has_one: "Cannot delete record because a dependent %{record} exists"
           has_many: "Cannot delete record because dependent %{record} exist"
@@ -111,6 +111,7 @@ en-CA:
     messages:
       accepted: must be accepted
       blank: can't be blank
+      present: must be blank
       confirmation: doesn't match %{attribute}
       empty: can't be empty
       equal_to: must be equal to %{count}
@@ -122,9 +123,11 @@ en-CA:
       invalid: is invalid
       less_than: must be less than %{count}
       less_than_or_equal_to: must be less than or equal to %{count}
+      model_invalid: "Validation failed: %{errors}"
       not_a_number: is not a number
       not_an_integer: must be an integer
       odd: must be odd
+      required: must exist
       taken: has already been taken
       too_long:
         one: is too long (maximum is 1 character)
@@ -135,6 +138,7 @@ en-CA:
       wrong_length:
         one: is the wrong length (should be 1 character)
         other: is the wrong length (should be %{count} characters)
+      other_than: must be other than %{count}
     template:
       body: 'There were problems with the following fields:'
       header:
@@ -188,9 +192,12 @@ en-CA:
           kb: KB
           mb: MB
           tb: TB
+          pb: PB
+          eb: EB
     percentage:
       format:
         delimiter: ''
+        format: "%n%"
     precision:
       format:
         delimiter: ''

--- a/rails/locale/en-CY.yml
+++ b/rails/locale/en-CY.yml
@@ -111,6 +111,7 @@ en-CY:
     messages:
       accepted: must be accepted
       blank: can't be blank
+      present: must be blank
       confirmation: doesn't match %{attribute}
       empty: can't be empty
       equal_to: must be equal to %{count}
@@ -122,9 +123,11 @@ en-CY:
       invalid: is invalid
       less_than: must be less than %{count}
       less_than_or_equal_to: must be less than or equal to %{count}
+      model_invalid: "Validation failed: %{errors}"
       not_a_number: is not a number
       not_an_integer: must be an integer
       odd: must be odd
+      required: must exist
       taken: has already been taken
       too_long:
         one: is too long (maximum is 1 character)
@@ -135,6 +138,7 @@ en-CY:
       wrong_length:
         one: is the wrong length (should be 1 character)
         other: is the wrong length (should be %{count} characters)
+      other_than: must be other than %{count}
     template:
       body: 'There were problems with the following fields:'
       header:
@@ -188,9 +192,12 @@ en-CY:
           kb: KB
           mb: MB
           tb: TB
+          pb: PB
+          eb: EB
     percentage:
       format:
         delimiter: ''
+        format: "%n%"
     precision:
       format:
         delimiter: ''

--- a/rails/locale/en-GB.yml
+++ b/rails/locale/en-GB.yml
@@ -3,7 +3,7 @@ en-GB:
   activerecord:
     errors:
       messages:
-        record_invalid: 'Validation failed: %{errors}'
+        record_invalid: "Validation failed: %{errors}"
         restrict_dependent_destroy:
           has_one: "Cannot delete record because a dependent %{record} exists"
           has_many: "Cannot delete record because dependent %{record} exist"
@@ -95,7 +95,7 @@ en-GB:
         other: "%{count} months"
       x_years:
         one: 1 year
-        other: "%{count} years"    
+        other: "%{count} years"
       x_seconds:
         one: 1 second
         other: "%{count} seconds"
@@ -111,6 +111,7 @@ en-GB:
     messages:
       accepted: must be accepted
       blank: can't be blank
+      present: must be blank
       confirmation: doesn't match %{attribute}
       empty: can't be empty
       equal_to: must be equal to %{count}
@@ -122,9 +123,11 @@ en-GB:
       invalid: is invalid
       less_than: must be less than %{count}
       less_than_or_equal_to: must be less than or equal to %{count}
+      model_invalid: "Validation failed: %{errors}"
       not_a_number: is not a number
       not_an_integer: must be an integer
       odd: must be odd
+      required: must exist
       taken: has already been taken
       too_long:
         one: is too long (maximum is 1 character)
@@ -135,6 +138,7 @@ en-GB:
       wrong_length:
         one: is the wrong length (should be 1 character)
         other: is the wrong length (should be %{count} characters)
+      other_than: must be other than %{count}
     template:
       body: 'There were problems with the following fields:'
       header:
@@ -188,9 +192,12 @@ en-GB:
           kb: KB
           mb: MB
           tb: TB
+          pb: PB
+          eb: EB
     percentage:
       format:
         delimiter: ''
+        format: "%n%"
     precision:
       format:
         delimiter: ''

--- a/rails/locale/en-IE.yml
+++ b/rails/locale/en-IE.yml
@@ -95,7 +95,7 @@ en-IE:
         other: "%{count} months"
       x_years:
         one: 1 year
-        other: "%{count} years"  
+        other: "%{count} years"
       x_seconds:
         one: 1 second
         other: "%{count} seconds"
@@ -111,6 +111,7 @@ en-IE:
     messages:
       accepted: must be accepted
       blank: can't be blank
+      present: must be blank
       confirmation: doesn't match %{attribute}
       empty: can't be empty
       equal_to: must be equal to %{count}
@@ -122,9 +123,11 @@ en-IE:
       invalid: is invalid
       less_than: must be less than %{count}
       less_than_or_equal_to: must be less than or equal to %{count}
+      model_invalid: "Validation failed: %{errors}"
       not_a_number: is not a number
       not_an_integer: must be an integer
       odd: must be odd
+      required: must exist
       taken: has already been taken
       too_long:
         one: is too long (maximum is 1 character)
@@ -135,6 +138,7 @@ en-IE:
       wrong_length:
         one: is the wrong length (should be 1 character)
         other: is the wrong length (should be %{count} characters)
+      other_than: must be other than %{count}
     template:
       body: 'There were problems with the following fields:'
       header:
@@ -188,9 +192,12 @@ en-IE:
           kb: KB
           mb: MB
           tb: TB
+          pb: PB
+          eb: EB
     percentage:
       format:
         delimiter: ''
+        format: "%n%"
     precision:
       format:
         delimiter: ''

--- a/rails/locale/en-IN.yml
+++ b/rails/locale/en-IN.yml
@@ -3,7 +3,7 @@ en-IN:
   activerecord:
     errors:
       messages:
-        record_invalid: 'Validation failed: %{errors}'
+        record_invalid: "Validation failed: %{errors}"
         restrict_dependent_destroy:
           has_one: "Cannot delete record because a dependent %{record} exists"
           has_many: "Cannot delete record because dependent %{record} exist"
@@ -95,7 +95,7 @@ en-IN:
         other: "%{count} months"
       x_years:
         one: 1 year
-        other: "%{count} years"  
+        other: "%{count} years"
       x_seconds:
         one: 1 second
         other: "%{count} seconds"
@@ -111,6 +111,7 @@ en-IN:
     messages:
       accepted: must be accepted
       blank: can't be blank
+      present: must be blank
       confirmation: doesn't match %{attribute}
       empty: can't be empty
       equal_to: must be equal to %{count}
@@ -122,9 +123,11 @@ en-IN:
       invalid: is invalid
       less_than: must be less than %{count}
       less_than_or_equal_to: must be less than or equal to %{count}
+      model_invalid: "Validation failed: %{errors}"
       not_a_number: is not a number
       not_an_integer: must be an integer
       odd: must be odd
+      required: must exist
       taken: has already been taken
       too_long:
         one: is too long (maximum is 1 character)
@@ -135,6 +138,7 @@ en-IN:
       wrong_length:
         one: is the wrong length (should be 1 character)
         other: is the wrong length (should be %{count} characters)
+      other_than: must be other than %{count}
     template:
       body: 'There were problems with the following fields:'
       header:
@@ -188,9 +192,12 @@ en-IN:
           kb: KB
           mb: MB
           tb: TB
+          pb: PB
+          eb: EB
     percentage:
       format:
         delimiter: ''
+        format: "%n%"
     precision:
       format:
         delimiter: ''

--- a/rails/locale/en-NZ.yml
+++ b/rails/locale/en-NZ.yml
@@ -95,7 +95,7 @@ en-NZ:
         other: "%{count} months"
       x_years:
         one: 1 year
-        other: "%{count} years"    
+        other: "%{count} years"
       x_seconds:
         one: 1 second
         other: "%{count} seconds"
@@ -111,6 +111,7 @@ en-NZ:
     messages:
       accepted: must be accepted
       blank: can't be blank
+      present: must be blank
       confirmation: doesn't match %{attribute}
       empty: can't be empty
       equal_to: must be equal to %{count}
@@ -122,9 +123,11 @@ en-NZ:
       invalid: is invalid
       less_than: must be less than %{count}
       less_than_or_equal_to: must be less than or equal to %{count}
+      model_invalid: "Validation failed: %{errors}"
       not_a_number: is not a number
       not_an_integer: must be an integer
       odd: must be odd
+      required: must exist
       taken: has already been taken
       too_long:
         one: is too long (maximum is 1 character)
@@ -135,6 +138,7 @@ en-NZ:
       wrong_length:
         one: is the wrong length (should be 1 character)
         other: is the wrong length (should be %{count} characters)
+      other_than: must be other than %{count}
     template:
       body: 'There were problems with the following fields:'
       header:
@@ -188,9 +192,12 @@ en-NZ:
           kb: KB
           mb: MB
           tb: TB
+          pb: PB
+          eb: EB
     percentage:
       format:
         delimiter: ''
+        format: "%n%"
     precision:
       format:
         delimiter: ''

--- a/rails/locale/en-US.yml
+++ b/rails/locale/en-US.yml
@@ -192,6 +192,8 @@ en-US:
           kb: KB
           mb: MB
           tb: TB
+          pb: PB
+          eb: EB
     percentage:
       format:
         delimiter: ''

--- a/rails/locale/en-ZA.yml
+++ b/rails/locale/en-ZA.yml
@@ -123,9 +123,11 @@ en-ZA:
       invalid: is invalid
       less_than: must be less than %{count}
       less_than_or_equal_to: must be less than or equal to %{count}
+      model_invalid: "Validation failed: %{errors}"
       not_a_number: is not a number
       not_an_integer: must be an integer
       odd: must be odd
+      required: must exist
       taken: has already been taken
       too_long:
         one: is too long (maximum is 1 character)
@@ -190,6 +192,8 @@ en-ZA:
           kb: KB
           mb: MB
           tb: TB
+          pb: PB
+          eb: EB
     percentage:
       format:
         delimiter: ''


### PR DESCRIPTION
Added missing active_record messages and PB/EB storage units to complete all EN-* locales with respect to en.yml.