### PR TITLE
Fix incorrect `require` added in 7838ad5.

### DIFF
--- a/rails/pluralization/hu.rb
+++ b/rails/pluralization/hu.rb
@@ -1,3 +1,3 @@
-require 'rails_i18n/common_pluralizations/other'
+require 'rails_i18n/common_pluralizations/one_other'
 
 ::RailsI18n::Pluralization::OneOther.with_locale(:hu)


### PR DESCRIPTION
This didn't break tests, I imagine that's because the test suite was
already importing `one_other` via some other file?