### PR TITLE
Invert ILS currency symbol position

### DIFF
--- a/rails/locale/he.yml
+++ b/rails/locale/he.yml
@@ -141,7 +141,7 @@ he:
     currency:
       format:
         delimiter: ","
-        format: "%u %n"
+        format: "%n %u"
         precision: 2
         separator: "."
         significant: false


### PR DESCRIPTION
The ILS (new shekel) symbol is currently placed on the left of the number.
This is correct but HE is an RTL language, so we must put it on the right side, and it will be inverted on RTL pages.

I would like a confirmation from a native speaker :)