### PR TITLE
Update es-PE.yml, the currency unit is incorrect

### DIFF
--- a/rails/locale/es-PE.yml
+++ b/rails/locale/es-PE.yml
@@ -160,7 +160,7 @@ es-PE:
         separator: "."
         significant: false
         strip_insignificant_zeros: false
-        unit: S/.
+        unit: S/
     format:
       delimiter: ","
       precision: 2


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Peruvian_sol

Peruvian Sol updated the format of it's unit, which is now `S/` instead of `S/.`