### PR TITLE
Fix the 'errors.messages.confirmation' in 'zh' missing %{attribute} bug.

### DIFF
--- a/rails/locale/zh-CN.yml
+++ b/rails/locale/zh-CN.yml
@@ -87,7 +87,7 @@ zh-CN:
     messages:
       accepted: 必须是可被接受的
       blank: 不能为空字符
-      confirmation: 与确认值不匹配
+      confirmation: 与 %{attribute} 不匹配
       empty: 不能留空
       equal_to: 必须等于 %{count}
       even: 必须为双数

--- a/rails/locale/zh-HK.yml
+++ b/rails/locale/zh-HK.yml
@@ -111,7 +111,7 @@ zh-HK:
     messages:
       accepted: 必定要被接受
       blank: 不可以是空白
-      confirmation: 兩次輸入不一致
+      confirmation: 與 %{attribute} 不一致
       empty: 不可以留空
       equal_to: 必須等於 %{count}
       even: 必須要是雙數

--- a/rails/locale/zh-TW.yml
+++ b/rails/locale/zh-TW.yml
@@ -111,7 +111,7 @@ zh-TW:
     messages:
       accepted: 必須是可被接受的
       blank: 不能為空白
-      confirmation: 兩次輸入須一致
+      confirmation: 與 %{attribute} 須一致
       empty: 不能留空
       equal_to: 必須等於 %{count}
       even: 必須是偶數

--- a/rails/locale/zh-YUE.yml
+++ b/rails/locale/zh-YUE.yml
@@ -111,7 +111,7 @@ zh-YUE:
     messages:
       accepted: 一定要被接受
       blank: 唔可以空白
-      confirmation: 兩次輸入唔夾
+      confirmation: 與 %{attribute} 唔夾
       empty: 唔可以漏空
       equal_to: 要等於 %{count}
       even: 要係雙數


### PR DESCRIPTION
It confused me when I met the error information in my Rails project. For zh-CN.yml, I saw "确认密码 与确认值不匹配".
This Chinese sentence means: Password Confirmation doesn't match the confirmation value.
It's wrong because it has semantic problem. One value doesn't match itself is impossible. One value doesn't match another value is rational. So I fixed it.

For zh-HK.yml, zh-TW.yml, zh-YUE.yml, I saw that these three yaml's 'errors.messages.confirmation' 
 meaning is different from zh-CN.yml. 
Their English meaning is: 'Password Confirmation the two value entered doesn't match each other'. 
It's readable when we see the sentence 'the two value entered doesn't match each other'. But when Rails add 'Password Confirmation' before 'the two value entered doesn't match each other', it become confusing.
So I also fixed 'errors.messages.confirmation' in zh-HK.yml, zh-TW.yml, zh-YUE.yml. 

I used the correct words in these three languages.