### PR TITLE
Fix number currency format in ja.yml

### DIFF
--- a/rails/locale/ja.yml
+++ b/rails/locale/ja.yml
@@ -149,7 +149,7 @@ ja:
     currency:
       format:
         delimiter: ","
-        format: "%u%n"
+        format: "%n%u"
         precision: 0
         separator: "."
         significant: false


### PR DESCRIPTION
issue: https://github.com/svenfuchs/rails-i18n/issues/846

wrong order number currency in ja.yml

```rb
# format: "%u%n"
> helper.number_to_currency(1000, locale: :ja)
=> "円1,000"

# format: "%n%u"
> helper.number_to_currency(1000, locale: :ja)
=> "1,000円"
```