### PR TITLE
Update Travis badge to use SVG version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Rails Locale Data Repository
 ============================
 
 [![Gem Version](https://badge.fury.io/rb/rails-i18n.svg)](http://badge.fury.io/rb/rails-i18n)
-[![Build Status](https://secure.travis-ci.org/svenfuchs/rails-i18n.png)](http://travis-ci.org/svenfuchs/rails-i18n)
+[![Build Status](https://secure.travis-ci.org/svenfuchs/rails-i18n.svg)](http://travis-ci.org/svenfuchs/rails-i18n)
 
 Centralization of locale data collection for Ruby on Rails.
 


### PR DESCRIPTION
This is a very tiny change, but I just noticed that on the README we are using PNG version of the status badge. Since Travis also offers the SVG version, we should use that instead so it would display nicely on the HiDPI screens.