### PR TITLE
fix ja currency format.

### DIFF
--- a/rails/locale/ja.yml
+++ b/rails/locale/ja.yml
@@ -149,7 +149,7 @@ ja:
     currency:
       format:
         delimiter: ","
-        format: "%u%n"
+        format: "%n%u"
         precision: 0
         separator: "."
         significant: false


### PR DESCRIPTION
`number_to_currency` for ja translation return `円100`. It should be `100円`