### PR TITLE
gemspec: drop rubyforge_project, it is EOL

### DIFF
--- a/rails-i18n.gemspec
+++ b/rails-i18n.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |s|
                    %w(README.md CHANGELOG.md MIT-LICENSE.txt)
   s.platform     = Gem::Platform::RUBY
   s.require_path = 'lib'
-  s.rubyforge_project = '[none]'
   s.required_rubygems_version = '>= 1.8.11'
 
   s.add_runtime_dependency('i18n', '>= 0.7', '< 2')


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement.