### PR TITLE
Automatically eager load I18n if possible

### DIFF
--- a/lib/rails_i18n/railtie.rb
+++ b/lib/rails_i18n/railtie.rb
@@ -3,6 +3,8 @@ require 'rails'
 module RailsI18n
   class Railtie < ::Rails::Railtie #:nodoc:
     initializer 'rails-i18n' do |app|
+      app.config.eager_load_namespaces << ::I18n if ::I18n.respond_to?(:eager_load!)
+
       RailsI18n::Railtie.instance_eval do
         pattern = pattern_from app.config.i18n.available_locales
 


### PR DESCRIPTION
Since `i18n 1.6.0` you can call `I18n.eager_load!` so that all translations are loaded immediately during the boot phase, rather than of the first request.

So ideally if we detect this, we add it automatically to `eager_load_namespaces` so that users don't have to know about it.

cc @rafaelfranca @Edouard-Chin