### PR TITLE
Improve translation of blank

### DIFF
--- a/rails/locale/nb.yml
+++ b/rails/locale/nb.yml
@@ -110,7 +110,7 @@ nb:
     format: "%{attribute} %{message}"
     messages:
       accepted: må være akseptert
-      blank: kan ikke være blank
+      blank: kan ikke være tom
       confirmation: er ikke lik %{attribute}
       empty: kan ikke være tom
       equal_to: må være lik %{count}
@@ -127,7 +127,7 @@ nb:
       not_an_integer: er ikke et heltall
       odd: må være oddetall
       other_than: kan ikke være nøyaktig %{count}
-      present: må være blank
+      present: må være tom
       required: må eksistere
       taken: er allerede i bruk
       too_long: er for lang (maksimum %{count} tegn)


### PR DESCRIPTION
Use "tom" instead of "blank" in Norwegian translation. "Blank" means shiny in Norwegian, while "tom" can mean both "blank" and "empty".