### PR TITLE
Revert "Fix problems in Azerbaijani locale"

### DIFF
--- a/rails/locale/az.yml
+++ b/rails/locale/az.yml
@@ -110,15 +110,15 @@ az:
       blank: boş ola bilməz
       confirmation: təsdiqə uygun deyil
       empty: boş ola bilməz
-      equal_to: "%{count} simvoldan ibarət olmalıdır"
+      equal_to: "%{count}-ə bərabər olmalıdır"
       even: cüt olmalıdır
       exclusion: qorunur
-      greater_than: "%{count} simvoldan böyük olmalıdır"
-      greater_than_or_equal_to: "%{count} simvoldan az olmamalıdır"
+      greater_than: "%{count}-dən böyük olmalıdır"
+      greater_than_or_equal_to: böyük və ya %{count}-ə bərabər olmalıdır
       inclusion: siyahiyə daxil deyil
       invalid: yanlışdır
-      less_than: "%{count} simvoldan kiçik olmalıdır"
-      less_than_or_equal_to: "%{count} simvoldan çox olmamalıdır"
+      less_than: "%{count}-dən kiçik olmalıdır"
+      less_than_or_equal_to: kiçik və ya %{count}-ə bərabər olmalıdır
       model_invalid: 'Yoxlama uğursuz oldu: %{errors}'
       not_a_number: rəqəm deyil
       not_an_integer: tam rəqəm olmalıdır
@@ -127,8 +127,8 @@ az:
       present: boş olmalıdır
       required: mövcud olmalıdır
       taken: artıq mövcuddur
-      too_long: çox uzundur (%{count} simvoldan az olmalıdır)
-      too_short: çox qısadır (%{count} simvoldan çox olmalıdır)
+      too_long: çox uzundur (%{count} simvoldan çox olmalı deyil)
+      too_short: çox qısadır (%{count} simvoldan az olmalı deyil)
       wrong_length: uzunluqu səhvdir (%{count} simvol olmalıdır)
     template:
       body: 'Aşağıdaki səhvlər üzə çıxdı:'


### PR DESCRIPTION
This reverts commit 03fd3b080560aa406e83e618f986b0bfadf44ad3 made in https://github.com/svenfuchs/rails-i18n/pull/865

Reason: I was never advocating for these changes. On the contrary, if you read the comments that I've left in [the original PR](https://github.com/svenfuchs/rails-i18n/pull/789), I was against them. These changes are grammatically incorrect.

/cc @digitalfrost