### PR TITLE
There is no space between symbol and number

### DIFF
--- a/rails/locale/zh-TW.yml
+++ b/rails/locale/zh-TW.yml
@@ -155,7 +155,7 @@ zh-TW:
     currency:
       format:
         delimiter: ","
-        format: "%u %n"
+        format: "%u%n"
         precision: 2
         separator: "."
         significant: false


### PR DESCRIPTION
Correct: `NT$300`
Incorrect: `NT$ 300`

ref: https://en.wikipedia.org/wiki/New_Taiwan_dollar