### PR TITLE
Fixed errors.format missed space issue.

### DIFF
--- a/rails/locale/zh-CN.yml
+++ b/rails/locale/zh-CN.yml
@@ -83,7 +83,7 @@ zh-CN:
       month: 月
       year: 年
   errors:
-    format: "%{attribute}%{message}"
+    format: "%{attribute} %{message}"
     messages:
       accepted: 必须是可被接受的
       blank: 不能为空字符


### PR DESCRIPTION
The key errors.format  in zh_CY.yml missed a space between attribute and message.