### PR TITLE
Latvian: fixed month February typo.

### DIFF
--- a/rails/locale/lv.yml
+++ b/rails/locale/lv.yml
@@ -42,7 +42,7 @@ lv:
     month_names:
     -
     - janvārī
-    - ferbruārī
+    - februārī
     - martā
     - aprīlī
     - maijā


### PR DESCRIPTION
Any native speakers confirmation welcome in comments.