### PR TITLE
Add pluralization rule for pt-BR locale

### DIFF
--- a/rails/pluralization/pt-BR.rb
+++ b/rails/pluralization/pt-BR.rb
@@ -1,0 +1,3 @@
+require 'rails_i18n/common_pluralizations/one_other'
+
+::RailsI18n::Pluralization::OneOther.with_locale(:'pt-BR')


### PR DESCRIPTION
I've noticed that pluralization rule for pt-BR is missing. This PR adds it