### PR TITLE
Brazilian Portuguese: Translate 'short' to curta instead of curto

### DIFF
--- a/rails/locale/pt-BR.yml
+++ b/rails/locale/pt-BR.yml
@@ -134,8 +134,8 @@ pt-BR:
         one: 'é muito longo (máximo: 1 caracter)'
         other: 'é muito longo (máximo: %{count} caracteres)'
       too_short:
-        one: 'é muito curto (mínimo: 1 caracter)'
-        other: 'é muito curto (mínimo: %{count} caracteres)'
+        one: 'é muito curta (mínimo: 1 caracter)'
+        other: 'é muito curta (mínimo: %{count} caracteres)'
       wrong_length:
         one: não possui o tamanho esperado (1 caracter)
         other: não possui o tamanho esperado (%{count} caracteres)


### PR DESCRIPTION
The 'too_short' error is mainly used when showing errors about password, in which case it would be better translated as 'curta' ( A senha )