### PR TITLE
Colombian Spanish (es-CO): Change number and currency delimiters

### DIFF
--- a/rails/locale/es-CO.yml
+++ b/rails/locale/es-CO.yml
@@ -17,7 +17,7 @@ es-CO:
     - vie
     - sáb
     abbr_month_names:
-    - 
+    -
     - ene
     - feb
     - mar
@@ -43,7 +43,7 @@ es-CO:
       long: "%A, %d de %B de %Y"
       short: "%d de %b"
     month_names:
-    - 
+    -
     - enero
     - febrero
     - marzo
@@ -154,17 +154,17 @@ es-CO:
   number:
     currency:
       format:
-        delimiter: ","
+        delimiter: "."
         format: "%u%n"
         precision: 0
-        separator: "."
+        separator: ","
         significant: false
         strip_insignificant_zeros: false
         unit: "$"
     format:
-      delimiter: ","
+      delimiter: "."
       precision: 2
-      separator: "."
+      separator: ","
       significant: false
       strip_insignificant_zeros: false
     human:
@@ -182,7 +182,7 @@ es-CO:
             other: billones
           unit: ''
       format:
-        delimiter: ","
+        delimiter: ""
         precision: 3
         significant: true
         strip_insignificant_zeros: true
@@ -200,11 +200,11 @@ es-CO:
           tb: TB
     percentage:
       format:
-        delimiter: ","
+        delimiter: ""
         format: "%n%"
     precision:
       format:
-        delimiter: ","
+        delimiter: ""
   support:
     array:
       last_word_connector: " y "

--- a/rails/locale/es-CO.yml
+++ b/rails/locale/es-CO.yml
@@ -17,7 +17,7 @@ es-CO:
     - vie
     - sáb
     abbr_month_names:
-    -
+    - 
     - ene
     - feb
     - mar
@@ -43,7 +43,7 @@ es-CO:
       long: "%A, %d de %B de %Y"
       short: "%d de %b"
     month_names:
-    -
+    - 
     - enero
     - febrero
     - marzo
@@ -182,7 +182,7 @@ es-CO:
             other: billones
           unit: ''
       format:
-        delimiter: ""
+        delimiter: ''
         precision: 3
         significant: true
         strip_insignificant_zeros: true
@@ -200,11 +200,11 @@ es-CO:
           tb: TB
     percentage:
       format:
-        delimiter: ""
+        delimiter: ''
         format: "%n%"
     precision:
       format:
-        delimiter: ""
+        delimiter: ''
   support:
     array:
       last_word_connector: " y "


### PR DESCRIPTION
See https://github.com/svenfuchs/rails-i18n/issues/890 

The es-CO locale was incorrectly using the English-speaking style of number delimitation, fixed to follow the common Spanish speaking style (https://en.wikipedia.org/wiki/Decimal_separator#Countries_using_decimal_comma)