### PR TITLE
Add x_hours to de.yml

### DIFF
--- a/rails/locale/de.yml
+++ b/rails/locale/de.yml
@@ -91,6 +91,9 @@ de:
       x_minutes:
         one: eine Minute
         other: "%{count} Minuten"
+      x_hours:
+        one: eine Stunde
+        other: "%{count} Stunden"
       x_days:
         one: ein Tag
         other: "%{count} Tage"


### PR DESCRIPTION
I had an issue with the current rails version, that a translation ist missung for datetime distance in words `x_hours`