### PR TITLE
Update ro.yml

### DIFF
--- a/rails/locale/ro.yml
+++ b/rails/locale/ro.yml
@@ -6,53 +6,53 @@ ro:
         record_invalid: Validare nereuşită %{errors}
   date:
     abbr_day_names:
-    - Dum
-    - Lun
-    - Mar
-    - Mie
-    - Joi
-    - Vin
-    - Sâm
+    - dum
+    - lun
+    - mar
+    - mie
+    - joi
+    - vin
+    - sâm
     abbr_month_names:
     - 
-    - Ian
-    - Feb
-    - Mar
-    - Apr
-    - Mai
-    - Iun
-    - Iul
-    - Aug
-    - Sep
-    - Oct
-    - Noi
-    - Dec
+    - ian
+    - feb
+    - mar
+    - apr
+    - mai
+    - iun
+    - iul
+    - aug
+    - sep
+    - oct
+    - noi
+    - dec
     day_names:
-    - Duminică
-    - Luni
-    - Marți
-    - Miercuri
-    - Joi
-    - Vineri
-    - Sâmbată
+    - duminică
+    - luni
+    - marți
+    - miercuri
+    - joi
+    - vineri
+    - sâmbată
     formats:
       default: "%d-%m-%Y"
       long: "%d %B %Y"
       short: "%d %b"
     month_names:
     - 
-    - Ianuarie
-    - Februarie
-    - Martie
-    - Aprilie
-    - Mai
-    - Iunie
-    - Iulie
-    - August
-    - Septembrie
-    - Octombrie
-    - Noiembrie
-    - Decembrie
+    - ianuarie
+    - februarie
+    - martie
+    - aprilie
+    - mai
+    - iunie
+    - iulie
+    - august
+    - septembrie
+    - octombrie
+    - noiembrie
+    - decembrie
     order:
     - :day
     - :month
@@ -105,19 +105,19 @@ ro:
         few: "%{count} luni"
         other: "%{count} luni"
     prompts:
-      second: Secunda
-      minute: Minutul
-      hour: Ora
-      day: Ziua
-      month: Luna
-      year: Anul
+      second: secunda
+      minute: minutul
+      hour: ora
+      day: ziua
+      month: luna
+      year: anul
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: trebuie dat acceptul
-      blank: nu poate fi gol
+      blank: nu poate fi necompletat
       confirmation: nu este confirmat
-      empty: nu poate fi gol
+      empty: nu poate fi necompletat
       equal_to: trebuie să fie egal cu %{count}
       even: trebuie să fie impar
       exclusion: este rezervat
@@ -133,7 +133,7 @@ ro:
       taken: este deja folosit
       too_long: este prea lung (se pot folosi maximum %{count} caractere)
       too_short: este prea scurt (minimum de caractere este %{count})
-      wrong_length: nu are lungimea corectă (trebuie să aiba %{count} caractere)
+      wrong_length: nu are lungimea corectă (trebuie să aibă %{count} caractere)
     template:
       body: 'Încearcă să corectezi urmatoarele câmpuri:'
       header:
@@ -142,7 +142,7 @@ ro:
         other: 'Nu am putut salva acest %{model}: %{count} erori.'
   helpers:
     select:
-      prompt: Alegeţi
+      prompt: Alegeți
     submit:
       create: Creare %{model}
       submit: Salvare %{model}
@@ -167,11 +167,11 @@ ro:
       decimal_units:
         format: "%n %u"
         units:
-          billion: Miliard
-          million: Milion
-          quadrillion: Quadrilion
-          thousand: Mie
-          trillion: Trilion
+          billion: miliard
+          million: milion
+          quadrillion: quadrilion
+          thousand: mie
+          trillion: trilion
           unit: ''
       format:
         delimiter: ","
@@ -197,8 +197,8 @@ ro:
         delimiter: ''
   support:
     array:
-      last_word_connector: " şi "
-      two_words_connector: " şi "
+      last_word_connector: " și "
+      two_words_connector: " și "
       words_connector: ", "
   time:
     am: ''


### PR DESCRIPTION
Fix names of numbers, days and months: in Romanian, they are spelled with lowercase. Replace "ș" and "ț" with the correct letters.