### PR TITLE
sv.yml: Fix grammar

### DIFF
--- a/rails/locale/sv.yml
+++ b/rails/locale/sv.yml
@@ -136,8 +136,8 @@ sv:
     template:
       body: 'Det var problem med följande fält:'
       header:
-        one: Ett fel förhindrade denna %{model} från att sparas
-        other: "%{count} fel förhindrade denna %{model} från att sparas"
+        one: Ett fel förhindrade ifrågavarande %{model} från att sparas
+        other: "%{count} fel förhindrade ifrågavarande %{model} från att sparas"
   helpers:
     select:
       prompt: Välj


### PR DESCRIPTION
"denna %{model}" is a bit like hard-coding "a %{model}" in English – it will be grammatically wrong a lot of the time.

Many words should grammatically have "detta" instead of "denna", e.g. "detta föremål" = "this item".

"ifrågavarande" is a bit archaic, but reads better than "denna/detta" IMO. It works with both grammatical genders, unless alternatives like "aktuell/aktuellt".

Also considered removing the article entirely ("Ett fel förhindrade %{model} från att sparas") but I think it can read poorly sometimes ("Ett fel förhindrade inställning från att sparas").