### PR TITLE
Revert apostrophes that are less known that right quotes

### DIFF
--- a/rails/locale/fr.yml
+++ b/rails/locale/fr.yml
@@ -5,9 +5,9 @@ fr:
       messages:
         record_invalid: 'La validation a échoué : %{errors}'
         restrict_dependent_destroy:
-          has_one: Vous ne pouvez pas supprimer l’enregistrement car un(e) %{record}
+          has_one: Vous ne pouvez pas supprimer l'enregistrement car un(e) %{record}
             dépendant(e) existe
-          has_many: Vous ne pouvez pas supprimer l’enregistrement parce que les %{record}
+          has_many: Vous ne pouvez pas supprimer l'enregistrement parce que les %{record}
             dépendants existent
   date:
     abbr_day_names:
@@ -74,19 +74,19 @@ fr:
         one: environ un an
         other: environ %{count} ans
       almost_x_years:
-        one: presqu’un an
+        one: presqu'un an
         other: presque %{count} ans
       half_a_minute: une demi‑minute
       less_than_x_seconds:
-        zero: moins d’une seconde
-        one: moins d’une seconde
+        zero: moins d'une seconde
+        one: moins d'une seconde
         other: moins de %{count} secondes
       less_than_x_minutes:
-        zero: moins d’une minute
-        one: moins d’une minute
+        zero: moins d'une minute
+        one: moins d'une minute
         other: moins de %{count} minutes
       over_x_years:
-        one: plus d’un an
+        one: plus d'un an
         other: plus de %{count} ans
       x_seconds:
         one: 1 seconde
@@ -119,23 +119,23 @@ fr:
       empty: doit être rempli(e)
       equal_to: doit être égal à %{count}
       even: doit être pair
-      exclusion: n’est pas disponible
+      exclusion: n'est pas disponible
       greater_than: doit être supérieur à %{count}
       greater_than_or_equal_to: doit être supérieur ou égal à %{count}
-      inclusion: n’est pas inclus(e) dans la liste
-      invalid: n’est pas valide
+      inclusion: n'est pas inclus(e) dans la liste
+      invalid: n'est pas valide
       less_than: doit être inférieur à %{count}
       less_than_or_equal_to: doit être inférieur ou égal à %{count}
       model_invalid: 'Validation échouée : %{errors}'
-      not_a_number: n’est pas un nombre
+      not_a_number: n'est pas un nombre
       not_an_integer: doit être un nombre entier
       odd: doit être impair
       other_than: doit être différent de %{count}
       present: doit être vide
       required: doit exister
-      taken: n’est pas disponible
+      taken: n'est pas disponible
       too_long:
-        one: est trop long (pas plus d’un caractère)
+        one: est trop long (pas plus d'un caractère)
         other: est trop long (pas plus de %{count} caractères)
       too_short:
         one: est trop court (au moins un caractère)
@@ -146,8 +146,8 @@ fr:
     template:
       body: 'Veuillez vérifier les champs suivants : '
       header:
-        one: 'Impossible d’enregistrer ce(tte) %{model} : 1 erreur'
-        other: 'Impossible d’enregistrer ce(tte) %{model} : %{count} erreurs'
+        one: 'Impossible d''enregistrer ce(tte) %{model} : 1 erreur'
+        other: 'Impossible d''enregistrer ce(tte) %{model} : %{count} erreurs'
   helpers:
     select:
       prompt: Veuillez sélectionner


### PR DESCRIPTION
True apostrophes are the best way of writing in french but this is not well
known and rarely used outside of printed documents. French rarely knows
how to type it, and rarely use them in webpages.

Partially revert: https://github.com/svenfuchs/rails-i18n/pull/889

Related: https://github.com/svenfuchs/rails-i18n/pull/889#issuecomment-701964424