### PR TITLE
Add Ruby 2.7.1 + bump previous ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
 language: ruby
 rvm:
-  - 2.5.3
-  - 2.6.0
+  - 2.5.8
+  - 2.6.6
+  - 2.7.2
 branches:
   only:
     - master
     - rails-5-x
+before_install:
+    - gem install bundler
+    - bundle update --bundler


### PR DESCRIPTION
While working on other PR. I noticed that Ruby versions in CI are not the last one, and that Ruby 2.7 is not present.

See: https://www.ruby-lang.org/en/downloads/releases/