### PR TITLE
Lithuanian: update lt.date.formats.long

### DIFF
--- a/rails/locale/lt.yml
+++ b/rails/locale/lt.yml
@@ -17,7 +17,7 @@ lt:
     - Pen
     - Šeš
     abbr_month_names:
-    - 
+    -
     - Sau
     - Vas
     - Kov
@@ -40,10 +40,10 @@ lt:
     - šeštadienis
     formats:
       default: "%Y-%m-%d"
-      long: "%B %d, %Y"
+      long: "%Y m. %B %d d."
       short: "%b %d"
     month_names:
-    - 
+    -
     - sausio
     - vasario
     - kovo


### PR DESCRIPTION
This updates the long version of the Lithuanian date format to:

```
"%Y m. %B %d d."
```

According to a client of mine _(I personally don't speak the language)_,
this is the correct long format. See the Wikipedia article on date
formats per country: https://en.wikipedia.org/wiki/Date_format_by_country.

```
yyyy <m.> <month in genitive> d <d.>
```