### PR TITLE
Include date in default & short time formats in fr-CA locale

### DIFF
--- a/rails/locale/fr-CA.yml
+++ b/rails/locale/fr-CA.yml
@@ -213,7 +213,7 @@ fr-CA:
   time:
     am: am
     formats:
-      default: "%H h %M min %S s"
+      default: "%d %B %Y %H h %M min %S s"
       long: "%A %d %B %Y %H h %M"
-      short: "%H h %M"
+      short: "%d %b %H h %M"
     pm: pm


### PR DESCRIPTION
These time formats seem to include date information in all the other
French locales, i.e. fr, fr-CH & fr FR. This also seems to be the case
for all the other time formats that I've looked at in other locales.

I'm definitely no expert on the fr-CA locale - in fact I don't even
speak much French! However, I can't find any evidence in the git history
that these formats were intentionally set to be inconsistent with other
similar locales, so I suspect it might just have been an oversight or a
misunderstanding that Ruby time objects include date information.