### PR TITLE
Danish: Space before %

### DIFF
--- a/rails/locale/da.yml
+++ b/rails/locale/da.yml
@@ -195,7 +195,7 @@ da:
     percentage:
       format:
         delimiter: ''
-        format: "%n%"
+        format: "%n %"
     precision:
       format:
         delimiter: ''


### PR DESCRIPTION
Change percent format for Danish from `25%` to  `25 %`.

There is no official rule for this in Danish orthography, but Dansk Sprognævn (Danish Language Council) recommends `25 %`: 
https://sproget.dk/raad-og-regler/artikler-mv/svarbase/SV00000086/

CLDR also uses `25 %`:
https://unicode-org.github.io/cldr-staging/charts/latest/by_type/numbers.number_formatting_patterns.html#17acd127f9139476