### PR TITLE
Add transliteration rules for Danish

### DIFF
--- a/rails/transliteration/da.yml
+++ b/rails/transliteration/da.yml
@@ -1,0 +1,10 @@
+da:
+  i18n:
+    transliterate:
+      rule:
+        æ: "ae"
+        ø: "oe"
+        å: "aa"
+        Æ: "Ae"
+        Ø: "Oe"
+        Å: "Aa"


### PR DESCRIPTION
The last three letters of the Danish alphabet, Æ Ø Å, are transliterated AE, OE AA in Danish.