### PR TITLE
Translate ordinals

### DIFF
--- a/lib/rails_i18n/railtie.rb
+++ b/lib/rails_i18n/railtie.rb
@@ -10,6 +10,7 @@ module RailsI18n
 
         add("rails/locale/#{pattern}.yml")
         add("rails/pluralization/#{pattern}.rb")
+        add("rails/ordinals/#{pattern}.rb")
         add("rails/transliteration/#{pattern}.{rb,yml}")
 
         init_pluralization_module

--- a/rails/ordinals/fr-CA.rb
+++ b/rails/ordinals/fr-CA.rb
@@ -1,0 +1,19 @@
+{
+  :"fr-CA": {
+    number: {
+      nth: {
+        ordinals: -> (_key, number:, **_options) {
+          if number.to_i.abs == 1
+            'er'
+          else
+            'e'
+          end
+        },
+
+        ordinalized:  -> (_key, number:, **_options) {
+          "#{number}#{ActiveSupport::Inflector.ordinal(number)}"
+        }
+      }
+    }
+  }
+}

--- a/rails/ordinals/fr-CH.rb
+++ b/rails/ordinals/fr-CH.rb
@@ -1,0 +1,19 @@
+{
+  :"fr-CH": {
+    number: {
+      nth: {
+        ordinals: -> (_key, number:, **_options) {
+          if number.to_i.abs == 1
+            'er'
+          else
+            'e'
+          end
+        },
+
+        ordinalized:  -> (_key, number:, **_options) {
+          "#{number}#{ActiveSupport::Inflector.ordinal(number)}"
+        }
+      }
+    }
+  }
+}

--- a/rails/ordinals/fr-FR.rb
+++ b/rails/ordinals/fr-FR.rb
@@ -1,0 +1,19 @@
+{
+  :"fr-FR": {
+    number: {
+      nth: {
+        ordinals: -> (_key, number:, **_options) {
+          if number.to_i.abs == 1
+            'er'
+          else
+            'e'
+          end
+        },
+
+        ordinalized:  -> (_key, number:, **_options) {
+          "#{number}#{ActiveSupport::Inflector.ordinal(number)}"
+        }
+      }
+    }
+  }
+}

--- a/rails/ordinals/fr.rb
+++ b/rails/ordinals/fr.rb
@@ -1,0 +1,19 @@
+{
+  fr: {
+    number: {
+      nth: {
+        ordinals: -> (_key, number:, **_options) {
+          if number.to_i.abs == 1
+            'er'
+          else
+            'e'
+          end
+        },
+
+        ordinalized:  -> (_key, number:, **_options) {
+          "#{number}#{ActiveSupport::Inflector.ordinal(number)}"
+        }
+      }
+    }
+  }
+}

--- a/spec/unit/ordinals_spec.rb
+++ b/spec/unit/ordinals_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+require 'rails_i18n/railtie'
+
+describe 'Ordinals for' do
+  # Mock Rails app in order to trigger the Railtie
+  let(:app) { double :app, config: config }
+  let(:config) { double :config, eager_load_namespaces: [], i18n: I18n }
+
+  before do |example|
+    RailsI18n::Railtie.initializers.each { |init| init.run(app) }
+    I18n.backend.reload!
+    I18n.locale = example.metadata[:locale]
+  end
+
+  describe 'French', locale: :fr do
+    it 'uses the custom rules' do
+      ActiveSupport::Inflector.ordinalize(1).should == "1er"
+      ActiveSupport::Inflector.ordinalize(2).should == "2e"
+      ActiveSupport::Inflector.ordinalize(3).should == "3e"
+    end
+  end
+
+  describe 'English', locale: :en do
+    it 'uses the default rules' do
+      ActiveSupport::Inflector.ordinalize(1).should == "1st"
+      ActiveSupport::Inflector.ordinalize(2).should == "2nd"
+      ActiveSupport::Inflector.ordinalize(3).should == "3rd"
+    end
+  end
+end


### PR DESCRIPTION
Hello everybody! 👋🏻 

Since Rails 6 accepts [translations for ordinalize](https://github.com/rails/rails/pull/32168), we might as well add them to rails-i18n as well!

This lets apps do:

```rb
I18n.locale = :en
1.ordinalize # => "1st"

I18n.locale = :fr
1.ordinalize # => "1er"
```