### PR TITLE
update ukrainian translations

### DIFF
--- a/rails/locale/uk.yml
+++ b/rails/locale/uk.yml
@@ -63,8 +63,8 @@ uk:
   datetime:
     distance_in_words:
       about_x_hours:
-        one: близько %{count} година
-        few: близько %{count} години
+        one: близько %{count} години
+        few: близько %{count} годин
         many: близько %{count} годин
         other: близько %{count} години
       about_x_months:
@@ -78,8 +78,8 @@ uk:
         many: близько %{count} років
         other: близько %{count} року
       almost_x_years:
-        one: майже %{count} роки
-        few: майже %{count} років
+        one: майже %{count} рік
+        few: майже %{count} роки
         many: майже %{count} років
         other: майже %{count} років
       half_a_minute: пів хвилини


### PR DESCRIPTION
Because

* `близько 1(однієї) години` not `близько 1(одна) година`
* `близько 2(вдох) годин` not `близько 2(дві) години`
* `майже 1(один) рік` not `майже 1(один?) роки`
* `майже 2(два) роки` not `майже 2(вдох) років`