### PR TITLE
Fixed almost_x_years values for the IT locale

### DIFF
--- a/rails/locale/it.yml
+++ b/rails/locale/it.yml
@@ -74,7 +74,7 @@ it:
         one: circa un anno
         other: circa %{count} anni
       almost_x_years:
-        one: quasi 1 anno
+        one: quasi un anno
         other: quasi %{count} anni
       half_a_minute: mezzo minuto
       less_than_x_seconds:

--- a/rails/locale/it.yml
+++ b/rails/locale/it.yml
@@ -74,8 +74,8 @@ it:
         one: circa un anno
         other: circa %{count} anni
       almost_x_years:
-        one: circa 1 anno
-        other: circa %{count} anni
+        one: quasi 1 anno
+        other: quasi %{count} anni
       half_a_minute: mezzo minuto
       less_than_x_seconds:
         one: meno di un secondo


### PR DESCRIPTION
In Italian:

- circa == about
- quasi == almost

Also, the article "un" replaces the numeral 1 for consistency with related keys