### PR TITLE
Correct Serbian pluralization rules

### DIFF
--- a/lib/rails_i18n/common_pluralizations/east_slavic.rb
+++ b/lib/rails_i18n/common_pluralizations/east_slavic.rb
@@ -1,7 +1,7 @@
 # Originally was implemented by Yaroslav Markin in "russian" gem
 # (http://github.com/yaroslav/russian)
 #
-# Used for Belarusian, Bosnian, Croatian, Russian, Serbian, Serbo-Croatian, Ukrainian.
+# Used for Belarusian, Bosnian, Croatian, Russian, Serbo-Croatian, Ukrainian.
 
 module RailsI18n
   module Pluralization

--- a/rails/pluralization/sr.rb
+++ b/rails/pluralization/sr.rb
@@ -1,3 +1,34 @@
 require 'rails_i18n/common_pluralizations/east_slavic'
 
 ::RailsI18n::Pluralization::EastSlavic.with_locale(:sr)
+
+module RailsI18n
+  module Pluralization
+    module Serbian
+      FROM_2_TO_4   = (2..4).to_a.freeze
+      FROM_12_TO_14 = (12..14).to_a.freeze
+
+      def self.rule
+        lambda do |n|
+          n ||= 0
+          mod10 = n % 10
+          mod100 = n % 100
+
+          if mod10 == 1 && mod100 != 11
+            :one
+          elsif FROM_2_TO_4.include?(mod10) && !FROM_12_TO_14.include?(mod100)
+            :few
+          else
+            :other
+          end
+        end
+      end
+    end
+  end
+end
+
+{ :sr => {
+  :i18n => {
+    :plural => {
+      :keys => [:one, :few, :other],
+      :rule => RailsI18n::Pluralization::Serbian.rule }}}}

--- a/rails/pluralization/sr.rb
+++ b/rails/pluralization/sr.rb
@@ -1,7 +1,3 @@
-require 'rails_i18n/common_pluralizations/east_slavic'
-
-::RailsI18n::Pluralization::EastSlavic.with_locale(:sr)
-
 module RailsI18n
   module Pluralization
     module Serbian

--- a/spec/unit/pluralization_spec.rb
+++ b/spec/unit/pluralization_spec.rb
@@ -656,7 +656,29 @@ describe 'Pluralization rule for' do
 
   describe 'Serbian', :locale => :sr do
     it_behaves_like 'an ordinary pluralization rule'
-    it_behaves_like 'East Slavic'
+
+    it 'has "one", "few", and "other" plural keys' do
+      plural_keys.size.should == 3
+      plural_keys.should include(:one, :few, :other)
+    end
+
+    [0.1, 0.31, 1, 21, 31, 41, 51, 61, 81, 101, 1031].each do |count|
+      it "detects that #{count} in category 'one'" do
+        rule.call(count).should == :one
+      end
+    end
+
+    [0.3, 0.42, 2, 3, 4, 22, 23, 24, 102, 1034].each do |count|
+      it "detects that #{count} in category 'few'" do
+        rule.call(count).should == :few
+      end
+    end
+
+    [0.11, 0.13, 56.78, 11, 12, 13, 14, 15, 27, 100, 1012].each do |count|
+      it "detects that #{count} in category 'other'" do
+        rule.call(count).should == :other
+      end
+    end
   end
 
   describe 'Serbo-Croatian', :locale => :sh do

--- a/spec/unit/pluralization_spec.rb
+++ b/spec/unit/pluralization_spec.rb
@@ -662,13 +662,13 @@ describe 'Pluralization rule for' do
       plural_keys.should include(:one, :few, :other)
     end
 
-    [0.1, 0.31, 1, 21, 31, 41, 51, 61, 81, 101, 1031].each do |count|
+    [1, 21, 31, 41, 51, 61, 81, 101, 1031].each do |count|
       it "detects that #{count} in category 'one'" do
         rule.call(count).should == :one
       end
     end
 
-    [0.3, 0.42, 2, 3, 4, 22, 23, 24, 102, 1034].each do |count|
+    [2, 3, 4, 22, 23, 24, 102, 1034].each do |count|
       it "detects that #{count} in category 'few'" do
         rule.call(count).should == :few
       end


### PR DESCRIPTION
This updates the pluralization rules for the `sr` locale to correctly match the [Unicode Language Plural Rules](https://unicode-org.github.io/cldr-staging/charts/37/supplemental/language_plural_rules.html#sr) for integers, instead of using the East Slavic rules that include a `many` key.

Resolves https://github.com/svenfuchs/rails-i18n/issues/921