### PR TITLE
Correct pluralization for Turkish language (tr)

### DIFF
--- a/rails/pluralization/tr.rb
+++ b/rails/pluralization/tr.rb
@@ -1,3 +1,3 @@
 require 'rails_i18n/common_pluralizations/other'
 
-::RailsI18n::Pluralization::Other.with_locale(:tr)
+::RailsI18n::Pluralization::OneOther.with_locale(:tr)

--- a/spec/unit/pluralization_spec.rb
+++ b/spec/unit/pluralization_spec.rb
@@ -749,7 +749,7 @@ describe 'Pluralization rule for' do
 
   describe 'Turkish', :locale => :tr do
     it_behaves_like 'an ordinary pluralization rule'
-    it_behaves_like 'other form language'
+    it_behaves_like 'one-other forms language'
   end
 
   describe 'Ukrainian', :locale => :uk do


### PR DESCRIPTION
Currently we are only using the `other` value for Turkish pluralization, regardless of the number of items.

In the [unicode rules](https://unicode-org.github.io/cldr-staging/charts/37/supplemental/language_plural_rules.html#tr), Turkish is listed as having different rules, which require a `one` and `other` value.

The [locale file for Turkish](https://github.com/svenfuchs/rails-i18n/blob/master/rails/locale/tr.yml) already has the `one` and `other` values included.