### PR TITLE
Remove Ruby < 1.9 patches

### DIFF
--- a/lib/rails_i18n.rb
+++ b/lib/rails_i18n.rb
@@ -1,2 +1,1 @@
-require 'rails_i18n/unicode'
 require 'rails_i18n/railtie'

--- a/lib/rails_i18n/unicode.rb
+++ b/lib/rails_i18n/unicode.rb
@@ -1,1 +1,0 @@
-$KCODE = "U" if RUBY_VERSION < '1.9' && $KCODE == 'NONE'

--- a/rails/transliteration/uk.rb
+++ b/rails/transliteration/uk.rb
@@ -62,28 +62,12 @@ module RailsI18n
 
         private
 
-        if RUBY_VERSION < '1.9'
-          # two bytes will be enough for Cyrillic
-          class_eval <<-END, __FILE__, __LINE__ + 1
-            def behind
-              tail = @pre_match && @pre_match[-2..-1]
-              tail && tail.split(//).last
-            end
+        def behind
+          @pre_match && @pre_match[-1]
+        end
 
-            def ahead
-              @post_match && @post_match[0..1].split(//).first
-            end
-          END
-        else
-          class_eval <<-END, __FILE__, __LINE__ + 1
-            def behind
-              @pre_match && @pre_match[-1]
-            end
-
-            def ahead
-              @post_match && @post_match[0]
-            end
-          END
+        def ahead
+          @post_match && @post_match[0]
         end
 
         def downcased?(symbol)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,6 @@
 ENV["RAILS_ENV"] = "test"
 
 require 'i18n-spec'
-require 'rails_i18n/unicode'
 require 'i18n/core_ext/hash'
 require 'active_support/core_ext/kernel/reporting'
 require 'socket'


### PR DESCRIPTION
These were added in https://github.com/svenfuchs/rails-i18n/commit/e3fca5ef12bb2ccdcbc2b4166a7aff61dcbaef22, I'm not sure when 1.8 was EOL'd, but Ruby 1.9 was EOL'd in 2015 and Ruby 1.8 was removed from CI builds in 419d8f9

Additionally, the `railties` dependency (`'>= 6.0.0', '< 7'`) restricts consumers to [Ruby >= 2.5](https://rubygems.org/gems/railties/versions/6.0.0)