### PR TITLE
Add delimiter and correct format for percentage in sv locale

### DIFF
--- a/rails/locale/sv.yml
+++ b/rails/locale/sv.yml
@@ -188,8 +188,8 @@ sv:
           tb: TB
     percentage:
       format:
-        delimiter: ''
-        format: "%n%"
+        delimiter: ' '
+        format: "%n %"
     precision:
       format:
         delimiter: ''


### PR DESCRIPTION
https://sv.wikipedia.org/wiki/Procenttecken

This changes the format so that 100000.50 is formatted like "100 000,50 %" rather than "100000,50%".