### PR TITLE
Correct en-CA default date format

### DIFF
--- a/rails/locale/en-CA.yml
+++ b/rails/locale/en-CA.yml
@@ -39,7 +39,7 @@ en-CA:
     - Friday
     - Saturday
     formats:
-      default: "%d-%m-%Y"
+      default: "%Y-%m-%d"
       long: "%B %d, %Y"
       short: "%d %b"
     month_names:


### PR DESCRIPTION
According to the history of the en-CA.yml file [1], the format was taken from the following wiki [2]. The wiki page has since updated [2, 3]. The correct default all numeric date format for Canada is "2021-12-25" which also matches Java's locale format [4].

[1] https://github.com/svenfuchs/rails-i18n/pull/239/files
[2] https://en.wikipedia.org/wiki/Date_and_time_notation_in_Canada
[3] Date and time notation in Canada at 2012-05-14, https://en.wikipedia.org/w/index.php?title=Date_and_time_notation_in_Canada&oldid=492492917
[4] https://www.localeplanet.com/java/en-CA/index.html
