### PR TITLE
Danish: Remove redundant commas

### DIFF
--- a/rails/locale/da.yml
+++ b/rails/locale/da.yml
@@ -117,11 +117,11 @@ da:
       even: skal være et lige tal
       exclusion: er reserveret
       greater_than: skal være større end %{count}
-      greater_than_or_equal_to: skal være større end, eller lig med, %{count}
+      greater_than_or_equal_to: skal være større end eller lig med %{count}
       inclusion: er ikke på listen
       invalid: er ikke gyldig
       less_than: skal være mindre end %{count}
-      less_than_or_equal_to: skal være mindre end, eller lig med, %{count}
+      less_than_or_equal_to: skal være mindre end eller lig med %{count}
       model_invalid: 'Godkendelse gik galt: %{errors}'
       not_a_number: er ikke et tal
       not_an_integer: er ikke et heltal


### PR DESCRIPTION
Remove commas not usually used in Danish.

I don't think these are in consistent with Danish orthography. In any case they are very unusual.

See e.g. https://da.wikipedia.org/wiki/St%C3%B8rre_end-tegn:
“[...] at noget er større end eller lig med noget andet”