### PR TITLE
Danish: Add plurals for decimal units

### DIFF
--- a/rails/locale/da.yml
+++ b/rails/locale/da.yml
@@ -171,11 +171,19 @@ da:
       decimal_units:
         format: "%n %u"
         units:
-          billion: Milliard
-          million: Million
-          quadrillion: Billiard
+          billion:
+            one: Milliard
+            other: Milliarder
+          million:
+            one: Million
+            other: Millioner
+          quadrillion:
+            one: Billiard
+            other: Billiarder
           thousand: Tusind
-          trillion: Billion
+          trillion:
+            one: Billion
+            other: Billioner
           unit: ''
       format:
         delimiter: ''


### PR DESCRIPTION
Add plurals for decimal units, like for `de`.

See e.g. [da.xml in CLDR](https://github.com/unicode-org/cldr/blob/release-40/common/main/da.xml#L5379-L5404).
