### PR TITLE
Danish: Missing attribute name for `confirmation`

### DIFF
--- a/rails/locale/da.yml
+++ b/rails/locale/da.yml
@@ -111,7 +111,7 @@ da:
     messages:
       accepted: skal accepteres
       blank: skal udfyldes
-      confirmation: stemmer ikke overens med bekræftelse
+      confirmation: stemmer ikke overens med %{attribute}
       empty: må ikke udelades
       equal_to: skal være %{count}
       even: skal være et lige tal


### PR DESCRIPTION
Include the attribute name for `confirmation` like in the official `en` locale.