### PR TITLE
Update long date format for Finnish locale

### DIFF
--- a/rails/locale/fi.yml
+++ b/rails/locale/fi.yml
@@ -40,7 +40,7 @@ fi:
     - lauantai
     formats:
       default: "%-d.%-m.%Y"
-      long: "%A %e. %Bta %Y"
+      long: "%d. %Bta %Y"
       short: "%d. %b"
     month_names:
     -


### PR DESCRIPTION
Drops weekday from the string. This is inline with a majority of the other locales.
Changes day of month from blank-padded to zero-padded, to match the style of the "default" & "short" formats.