### PR TITLE
Fix docker build error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use the official Ruby runtime as the parent image
-FROM ruby
+FROM ruby:2.7.5
 
 WORKDIR /gem
 COPY . /gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,4 +112,4 @@ DEPENDENCIES
   rspec-rails (~> 3.7)
 
 BUNDLED WITH
-   1.16.1
+   2.1.4


### PR DESCRIPTION
This fixes 

    i18n-tasks-0.9.29 requires ruby version ~> 2.3, which is incompatible with the
    current version, ruby 3.0.3p157

I've used latest 2.7 ruby version and it's matching bundler version.