### PR TITLE
Croatian: improve translation for errors.messages.template.header

### DIFF
--- a/rails/locale/hr.yml
+++ b/rails/locale/hr.yml
@@ -165,10 +165,10 @@ hr:
     template:
       body: 'Sljedeća polja su neispravno popunjena:'
       header:
-        one: "%{count} greška je spriječila %{model} da se spremi"
-        few: "%{count} greške su spriječile %{model} da se spremi"
-        many: "%{count} grešaka je spriječilo %{model} da se spremi"
-        other: "%{count} grešaka je spriječilo %{model} da se spremi"
+        one: "%{count} greška je spriječila da se spremi %{model}"
+        few: "%{count} greške su spriječile da se spremi %{model}"
+        many: "%{count} grešaka je spriječilo da se spremi %{model}"
+        other: "%{count} grešaka je spriječilo da se spremi %{model}"
   helpers:
     select:
       prompt: Izaberite


### PR DESCRIPTION
This improves translation because model is interpolated as normative case and not genitive case like it used to be.

For example (in Croatian):

Before it was: `2 greške su spriječile korisnik da se spremi`  (korisnik)
Gramatically correct is: `2 greške su spriječile korisnika da se spremi`  (korisnik**a**)
Now: `2 greške su spriječile da se spremi korisnik`