### PR TITLE
Tamil (ta): Add pluralization rule

### DIFF
--- a/rails/pluralization/ta.rb
+++ b/rails/pluralization/ta.rb
@@ -1,0 +1,3 @@
+require 'rails_i18n/common_pluralizations/one_other'
+
+::RailsI18n::Pluralization::OneOther.with_locale(:ta)


### PR DESCRIPTION
Found that Tamil (ta) is missing the pluralization rule while I was making a [PR to the pagy gem](https://github.com/ddnexus/pagy/pull/349#event-5682153254). This PR adds the missing rule. For reference: [Unicode supplemental](https://www.unicode.org/cldr/cldr-aux/charts/29/supplemental/language_plural_rules.html)