### PR TITLE
Fix typo in hash notation

### DIFF
--- a/rails/ordinals/fr-CA.rb
+++ b/rails/ordinals/fr-CA.rb
@@ -1,5 +1,5 @@
 {
-  :"fr-CA": {
+  "fr-CA": {
     number: {
       nth: {
         ordinals: -> (_key, number:, **_options) {

--- a/rails/ordinals/fr-CH.rb
+++ b/rails/ordinals/fr-CH.rb
@@ -1,5 +1,5 @@
 {
-  :"fr-CH": {
+  "fr-CH": {
     number: {
       nth: {
         ordinals: -> (_key, number:, **_options) {

--- a/rails/ordinals/fr-FR.rb
+++ b/rails/ordinals/fr-FR.rb
@@ -1,5 +1,5 @@
 {
-  :"fr-FR": {
+  "fr-FR": {
     number: {
       nth: {
         ordinals: -> (_key, number:, **_options) {


### PR DESCRIPTION
Hello

I may be missing something here, but it looks like a typo found its way in https://github.com/svenfuchs/rails-i18n/pull/922 . I'm not sure how to maybe add a test case for it.