### PR TITLE
Fix typo in ordinals hash

### DIFF
--- a/rails/ordinals/fr-CA.rb
+++ b/rails/ordinals/fr-CA.rb
@@ -1,5 +1,5 @@
 {
-  :"fr-CA": {
+  "fr-CA": {
     number: {
       nth: {
         ordinals: -> (_key, number:, **_options) {

--- a/rails/ordinals/fr-CH.rb
+++ b/rails/ordinals/fr-CH.rb
@@ -1,5 +1,5 @@
 {
-  :"fr-CH": {
+  "fr-CH": {
     number: {
       nth: {
         ordinals: -> (_key, number:, **_options) {

--- a/rails/ordinals/fr-FR.rb
+++ b/rails/ordinals/fr-FR.rb
@@ -1,5 +1,5 @@
 {
-  :"fr-FR": {
+  "fr-FR": {
     number: {
       nth: {
         ordinals: -> (_key, number:, **_options) {

--- a/spec/unit/ordinals_spec.rb
+++ b/spec/unit/ordinals_spec.rb
@@ -6,25 +6,32 @@ describe 'Ordinals for' do
   let(:app) { double :app, config: config }
   let(:config) { double :config, eager_load_namespaces: [], i18n: I18n }
 
-  before do |example|
+  before do
+    I18n.available_locales = %w[fr en fr-CA fr-CH fr-FR]
+
     RailsI18n::Railtie.initializers.each { |init| init.run(app) }
     I18n.backend.reload!
-    I18n.locale = example.metadata[:locale]
   end
 
-  describe 'French', locale: :fr do
+  describe 'French' do
     it 'uses the custom rules' do
-      ActiveSupport::Inflector.ordinalize(1).should == "1er"
-      ActiveSupport::Inflector.ordinalize(2).should == "2e"
-      ActiveSupport::Inflector.ordinalize(3).should == "3e"
+      %w[fr fr-CA fr-CH fr-FR ].each do |locale|
+        I18n.with_locale(locale) do
+          ActiveSupport::Inflector.ordinalize(1).should == "1er"
+          ActiveSupport::Inflector.ordinalize(2).should == "2e"
+          ActiveSupport::Inflector.ordinalize(3).should == "3e"
+        end
+      end
     end
   end
 
-  describe 'English', locale: :en do
+  describe 'English' do
     it 'uses the default rules' do
-      ActiveSupport::Inflector.ordinalize(1).should == "1st"
-      ActiveSupport::Inflector.ordinalize(2).should == "2nd"
-      ActiveSupport::Inflector.ordinalize(3).should == "3rd"
+      I18n.with_locale(:en) do
+        ActiveSupport::Inflector.ordinalize(1).should == "1st"
+        ActiveSupport::Inflector.ordinalize(2).should == "2nd"
+        ActiveSupport::Inflector.ordinalize(3).should == "3rd"
+      end
     end
   end
 end


### PR DESCRIPTION
As reported by @idabmat in #956, @f6p in #957 and @casperisfine in https://github.com/svenfuchs/rails-i18n/pull/922#discussion_r770499178, a typo found its way in #922 😞 

This fixes the typo and makes sure all ordinal files are tested.

Closes #956
