### PR TITLE
update taken error for fr translation

### DIFF
--- a/rails/locale/fr.yml
+++ b/rails/locale/fr.yml
@@ -133,7 +133,7 @@ fr:
       other_than: doit être différent de %{count}
       present: doit être vide
       required: doit exister
-      taken: n'est pas disponible
+      taken: est déjà utilisé(e)
       too_long:
         one: est trop long (pas plus d'un caractère)
         other: est trop long (pas plus de %{count} caractères)


### PR DESCRIPTION
the translation for `taken` was the same of `exclusion`

But in the usage (for exemple when your email is already taken), the sentence "n'est pas disponible" is not really clear