### PR TITLE
Update serbian pluralization rule

### DIFF
--- a/rails/pluralization/sr.rb
+++ b/rails/pluralization/sr.rb
@@ -1,9 +1,6 @@
 module RailsI18n
   module Pluralization
     module Serbian
-      FROM_2_TO_4   = (2..4).to_a.freeze
-      FROM_12_TO_14 = (12..14).to_a.freeze
-
       def self.rule
         lambda do |n|
           n ||= 0
@@ -12,12 +9,22 @@ module RailsI18n
 
           if mod10 == 1 && mod100 != 11
             :one
-          elsif FROM_2_TO_4.include?(mod10) && !FROM_12_TO_14.include?(mod100)
+          elsif from_2_to_4.include?(mod10) && !from_12_to_14.include?(mod100)
             :few
           else
             :other
           end
         end
+      end
+
+      private
+
+      def self.from_2_to_4
+        @from_2_to_4 ||= (2..4).to_a.freeze
+      end
+
+      def self.from_12_to_14
+        @from_12_to_14 ||= (12..14).to_a.freeze
       end
     end
   end


### PR DESCRIPTION
Use instance variables instead of constants to avoid warning, since I18n reloads the class.

Fixes #965 