### PR TITLE
fix: pap-AW and pap-CW date order to use english symbols

### DIFF
--- a/rails/locale/pap-AW.yml
+++ b/rails/locale/pap-AW.yml
@@ -57,9 +57,9 @@ pap-AW:
     - novèmber
     - desèmber
     order:
-    - :aña
-    - :luna
-    - :dia
+    - :year
+    - :month
+    - :day
   datetime:
     distance_in_words:
       about_x_hours:

--- a/rails/locale/pap-CW.yml
+++ b/rails/locale/pap-CW.yml
@@ -57,9 +57,9 @@ pap-CW:
     - novèmber
     - desèmber
     order:
-    - :aña
-    - :luna
-    - :dia
+    - :year
+    - :month
+    - :day
   datetime:
     distance_in_words:
       about_x_hours:


### PR DESCRIPTION
When using translated order keys with UTF-8 entities (in this case ñ) Rails will raise ```"\xC3" from ASCII-8BIT to UTF-8 (Encoding::UndefinedConversionError)```