### PR TITLE
Fix pap.

### DIFF
--- a/rails/locale/pap-AW.yml
+++ b/rails/locale/pap-AW.yml
@@ -57,9 +57,9 @@ pap-AW:
     - novèmber
     - desèmber
     order:
-    - :aña
-    - :luna
-    - :dia
+    - :year
+    - :month
+    - :day
   datetime:
     distance_in_words:
       about_x_hours:
@@ -165,8 +165,8 @@ pap-AW:
       delimiter: '.'
       precision: 3
       separator: ','
-      significant: falsu
-      strip_insignificant_zeros: falsu
+      significant: false
+      strip_insignificant_zeros: false
     human:
       decimal_units:
         format: '%n %u'

--- a/rails/locale/pap-CW.yml
+++ b/rails/locale/pap-CW.yml
@@ -57,9 +57,9 @@ pap-CW:
     - novèmber
     - desèmber
     order:
-    - :aña
-    - :luna
-    - :dia
+    - :year
+    - :month
+    - :day
   datetime:
     distance_in_words:
       about_x_hours:
@@ -165,8 +165,8 @@ pap-CW:
       delimiter: '.'
       precision: 3
       separator: ','
-      significant: falsu
-      strip_insignificant_zeros: falsu
+      significant: false
+      strip_insignificant_zeros: false
     human:
       decimal_units:
         format: '%n %u'


### PR DESCRIPTION
This was probably due to a bad replacement. This pr has an overlap with #974, but also fixes `falsu` bad replacements.