### PR TITLE
Use https for GitHub link

### DIFF
--- a/rails-i18n.gemspec
+++ b/rails-i18n.gemspec
@@ -3,7 +3,7 @@ Gem::Specification.new do |s|
   s.version      = '7.0.2'
   s.authors      = ["Rails I18n Group"]
   s.email        = "rails-i18n@googlegroups.com"
-  s.homepage     = "http://github.com/svenfuchs/rails-i18n"
+  s.homepage     = "https://github.com/svenfuchs/rails-i18n"
   s.summary      = "Common locale data and translations for Rails i18n."
   s.description  = "A set of common locale data and translations to internationalize and/or localize your Rails applications."
   s.license      = 'MIT'


### PR DESCRIPTION
This reduces unnecessary redirection from http://... to https://... when someone visits this gem's homepage via https://rubygems.org/gems/rails-i18n or some tools or APIs that use the gem's metadata.