### PR TITLE
Use "en_US" English in default "en" content locale, as per CLDR

### DIFF
--- a/rails/locale/en.yml
+++ b/rails/locale/en.yml
@@ -40,8 +40,8 @@ en:
     - Saturday
     formats:
       default: "%Y-%m-%d"
-      long: "%d %B %Y"
-      short: "%d %b"
+      long: "%B %d, %Y"
+      short: "%b %d"
     month_names:
     - 
     - January
@@ -210,6 +210,6 @@ en:
     am: am
     formats:
       default: "%a, %d %b %Y %H:%M:%S %z"
-      long: "%d %B %Y %H:%M"
+      long: "%B %d, %Y %H:%M"
       short: "%d %b %H:%M"
     pm: pm


### PR DESCRIPTION
Hello 👋!

I spotted what I think it's a regression in the 7.0.2 release.

In https://github.com/svenfuchs/rails-i18n/pull/939, several date formats were updated to match the CLDR spec. These changes included the "en.yml" local file, which was updated to use non-US date formats.

However, CLDR defines "en_US" as the default content locale for "en". So, this file should have "en_US" data.

It took me a while to verify the above from official CLDR sources, but I think I found it:

* https://cldr.unicode.org/translation/translation-guide-general/default-content.
* https://github.com/unicode-org/cldr/blob/492b3c1afe2deb1339b8425302a6e835d951ef3b/common/supplemental/supplementalMetadata.xml#L1695-L1703.