### PR TITLE
Add yalphabetize to ci

### DIFF
--- a/.yalphabetize.yml
+++ b/.yalphabetize.yml
@@ -1,0 +1,23 @@
+allowed_orders:
+  - [has_one, has_many]
+  - [zero, one, two, few, many, other]
+  - [second, minute, hour, day, month, year]
+  -
+    - about_x_hours
+    - about_x_months
+    - about_x_years
+    - almost_x_years
+    - half_a_minute
+    - less_than_x_seconds
+    - less_than_x_minutes
+    - over_x_years
+    - x_seconds
+    - x_minutes
+    - x_days
+    - x_months
+    - x_years
+
+
+indent_sequences: false
+only:
+  - rails/locale/

--- a/.yalphabetize.yml
+++ b/.yalphabetize.yml
@@ -16,8 +16,6 @@ allowed_orders:
     - x_days
     - x_months
     - x_years
-
-
 indent_sequences: false
 only:
   - rails/locale/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,6 +101,7 @@ GEM
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.1.0)
+    yalphabetize (0.6.2)
     zeitwerk (2.5.4)
 
 PLATFORMS
@@ -111,6 +112,7 @@ DEPENDENCIES
   i18n-tasks (~> 0.9.37)
   rails-i18n!
   rspec-rails (~> 3.7)
+  yalphabetize
 
 BUNDLED WITH
    2.3.7

--- a/Rakefile
+++ b/Rakefile
@@ -13,6 +13,11 @@ namespace :test do
   end
 end
 
+desc 'Check alphabetisation of all locale files.'
+task :yalphabetize do
+  system('bundle exec yalphabetize')
+end
+
 require 'rspec/core'
 require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec) do |spec|
@@ -30,4 +35,4 @@ end
 
 require 'i18n-spec/tasks' # needs to be loaded after rspec
 
-task :default => :spec
+task :default => [:spec, :yalphabetize]

--- a/rails-i18n.gemspec
+++ b/rails-i18n.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec-rails", "~> 3.7"
   s.add_development_dependency "i18n-spec", "~> 0.6.0"
   s.add_development_dependency 'i18n-tasks', '~> 0.9.37'
+  s.add_development_dependency 'yalphabetize'
 end

--- a/rails/locale/en-TT.yml
+++ b/rails/locale/en-TT.yml
@@ -75,43 +75,42 @@ en-TT:
         one: almost 1 year
         other: almost %{count} years
       half_a_minute: half a minute
-      less_than_x_minutes:
-        one: less than a minute
-        other: less than %{count} minutes
       less_than_x_seconds:
         one: less than 1 second
         other: less than %{count} seconds
+      less_than_x_minutes:
+        one: less than a minute
+        other: less than %{count} minutes
       over_x_years:
         one: over 1 year
         other: over %{count} years
-      x_days:
-        one: 1 day
-        other: "%{count} days"
+      x_seconds:
+        one: 1 second
+        other: "%{count} seconds"
       x_minutes:
         one: 1 minute
         other: "%{count} minutes"
+      x_days:
+        one: 1 day
+        other: "%{count} days"
       x_months:
         one: 1 month
         other: "%{count} months"
       x_years:
         one: 1 year
         other: "%{count} years"
-      x_seconds:
-        one: 1 second
-        other: "%{count} seconds"
     prompts:
-      day: Day
-      hour: Hour
-      minute: Minute
-      month: Month
       second: Seconds
+      minute: Minute
+      hour: Hour
+      day: Day
+      month: Month
       year: Year
   errors:
     format: "%{attribute} %{message}"
     messages:
       accepted: must be accepted
       blank: can't be blank
-      present: must be blank
       confirmation: doesn't match %{attribute}
       empty: can't be empty
       equal_to: must be equal to %{count}
@@ -127,6 +126,8 @@ en-TT:
       not_a_number: is not a number
       not_an_integer: must be an integer
       odd: must be odd
+      other_than: must be other than %{count}
+      present: must be blank
       required: must exist
       taken: has already been taken
       too_long:
@@ -138,7 +139,6 @@ en-TT:
       wrong_length:
         one: is the wrong length (should be 1 character)
         other: is the wrong length (should be %{count} characters)
-      other_than: must be other than %{count}
     template:
       body: 'There were problems with the following fields:'
       header:

--- a/rails/locale/iso-639-2/csb.yml
+++ b/rails/locale/iso-639-2/csb.yml
@@ -9,7 +9,7 @@ csb:
     - pią
     - sob
     abbr_month_names:
-    - 
+    -
     - stë
     - gro
     - str
@@ -35,7 +35,7 @@ csb:
       long: ! '%B %d, %Y'
       short: ! '%d %b'
     month_names:
-    - 
+    -
     - stëcznik
     - gromicznik
     - strëmiannik
@@ -55,56 +55,56 @@ csb:
   datetime:
     distance_in_words:
       about_x_hours:
-        few: kòle %{count} gòdzën
         one: kòle gòdzënë
+        few: kòle %{count} gòdzën
         other: kòle %{count} gòdzën
       about_x_months:
-        few: kòle %{count} miesąców
         one: kòle miesąca
+        few: kòle %{count} miesąców
         other: kòle %{count} miesąców
       about_x_years:
-        few: kòle %{count} lat
         one: kòle rokù
+        few: kòle %{count} lat
         other: kòle %{count} lat
       almost_x_years:
-        few: wnet %{count} lata
         one: wnet rok
+        few: wnet %{count} lata
         other: wnet %{count} lat
       half_a_minute: pół minutë
-      less_than_x_minutes:
-        few: mni jak %{count} minutë
-        one: mni jak minuta
-        other: mni jak %{count} minutów
       less_than_x_seconds:
-        few: mni jak %{count} sekùndë
         one: mni jak sekùnda
+        few: mni jak %{count} sekùndë
         other: mni jak %{count} sekùndów
+      less_than_x_minutes:
+        one: mni jak minuta
+        few: mni jak %{count} minutë
+        other: mni jak %{count} minutów
       over_x_years:
-        few: wicy jak %{count} lata
         one: wicy jak rok
+        few: wicy jak %{count} lata
         other: wicy jak %{count} lat
-      x_days:
-        few: ! '%{count} dni'
-        one: 1 dzéń
-        other: ! '%{count} dniów'
-      x_minutes:
-        few: ! '%{count} minutë'
-        one: 1 minuta
-        other: ! '%{count} minutów'
-      x_months:
-        few: ! '%{count} miesiące'
-        one: 1 miesąc
-        other: ! '%{count} miesięców'
       x_seconds:
-        few: ! '%{count} sekùndë'
         one: 1 sekùnda
+        few: ! '%{count} sekùndë'
         other: ! '%{count} sekùndów'
+      x_minutes:
+        one: 1 minuta
+        few: ! '%{count} minutë'
+        other: ! '%{count} minutów'
+      x_days:
+        one: 1 dzéń
+        few: ! '%{count} dni'
+        other: ! '%{count} dniów'
+      x_months:
+        one: 1 miesąc
+        few: ! '%{count} miesiące'
+        other: ! '%{count} miesięców'
     prompts:
-      day: Dzéń
-      hour: Gòdzëna
-      minute: Minuta
-      month: Miesiąc
       second: Sekunda
+      minute: Minuta
+      hour: Gòdzëna
+      day: Dzéń
+      month: Miesiąc
       year: Rok
   errors:
     format: ! '%{attribute} %{message}'

--- a/rails/locale/iso-639-2/dsb.yml
+++ b/rails/locale/iso-639-2/dsb.yml
@@ -9,7 +9,7 @@ dsb:
     - Pě
     - So
     abbr_month_names:
-    - 
+    -
     - jan
     - feb
     - měr
@@ -35,7 +35,7 @@ dsb:
       long: ! '%d. %B %Y'
       short: ! '%d %b'
     month_names:
-    - 
+    -
     - Januar
     - Februar
     - Měrc
@@ -55,56 +55,56 @@ dsb:
   datetime:
     distance_in_words:
       about_x_hours:
-        few: něźi %{count} góźinami
         one: něźi 1 góźinu
-        other: něźi %{count} góźinami
         two: něźi %{count} góźinoma
+        few: něźi %{count} góźinami
+        other: něźi %{count} góźinami
       about_x_months:
-        few: něźi %{count} mjasecami
         one: něźi 1 mjasecom
-        other: něźi %{count} mjasecami
         two: něźi %{count} mjasecoma
+        few: něźi %{count} mjasecami
+        other: něźi %{count} mjasecami
       about_x_years:
-        few: něźi %{count} lětami
         one: něźi 1 lětom
-        other: něźi %{count} lětami
         two: něźi %{count} lětoma
+        few: něźi %{count} lětami
+        other: něźi %{count} lětami
       half_a_minute: poł minuty
-      less_than_x_minutes:
-        few: mjenjej ako %{count} minutami
-        one: mjenjej ako 1 minutu
-        other: mjenjej ako %{count} minutami
-        two: mjenjej ako %{count} minutoma
       less_than_x_seconds:
-        few: mjenjej ako %{count} sekundami
         one: mjenjej ako 1 sekundu
-        other: mjenjej ako %{count} sekundami
         two: mjenjej ako %{count} sekundoma
+        few: mjenjej ako %{count} sekundami
+        other: mjenjej ako %{count} sekundami
+      less_than_x_minutes:
+        one: mjenjej ako 1 minutu
+        two: mjenjej ako %{count} minutoma
+        few: mjenjej ako %{count} minutami
+        other: mjenjej ako %{count} minutami
       over_x_years:
-        few: wěcej ako %{count} lětami
         one: wěcej ako 1 lětom
-        other: wěcej ako %{count} lětami
         two: wěcej ako %{count} lětoma
-      x_days:
-        few: ! '%{count} dnjami'
-        one: 1 dnjom
-        other: ! '%{count} dnjami'
-        two: ! '%{count} dnjoma'
-      x_minutes:
-        few: ! '%{count} minutami'
-        one: 1 minutu
-        other: ! '%{count} minutami'
-        two: ! '%{count} minutoma'
-      x_months:
-        few: ! '%{count} mjasecami'
-        one: 1 mjasecom
-        other: ! '%{count} mjasecami'
-        two: ! '%{count} mjasecoma'
+        few: wěcej ako %{count} lětami
+        other: wěcej ako %{count} lětami
       x_seconds:
-        few: ! '%{count} sekundami'
         one: 1 sekundu
-        other: ! '%{count} sekundami'
         two: ! '%{count} sekundoma'
+        few: ! '%{count} sekundami'
+        other: ! '%{count} sekundami'
+      x_minutes:
+        one: 1 minutu
+        two: ! '%{count} minutoma'
+        few: ! '%{count} minutami'
+        other: ! '%{count} minutami'
+      x_days:
+        one: 1 dnjom
+        two: ! '%{count} dnjoma'
+        few: ! '%{count} dnjami'
+        other: ! '%{count} dnjami'
+      x_months:
+        one: 1 mjasecom
+        two: ! '%{count} mjasecoma'
+        few: ! '%{count} mjasecami'
+        other: ! '%{count} mjasecami'
   errors:
     format: ! '%{attribute} %{message}'
     messages:
@@ -125,31 +125,27 @@ dsb:
       odd: musy njerowna licba byś
       taken: jo južo w datowej bance
       too_long:
-        few: jo pśedłujki (maks. %{count} znamješka)
         one: jo pśedłujki (maks. 1 znamješko)
-        other: jo pśedłujki (maks. %{count} znamješkow)
         two: jo pśedłujki (maks. %{count} znamješce)
+        few: jo pśedłujki (maks. %{count} znamješka)
+        other: jo pśedłujki (maks. %{count} znamješkow)
       too_short:
-        few: jo překrotki (min. %{count} znamješka)
         one: jo překrotki (min. 1 znamješko)
-        other: jo překrotki (min. %{count} znamješkow)
         two: jo překrotki (min. %{count} znamješce)
+        few: jo překrotki (min. %{count} znamješka)
+        other: jo překrotki (min. %{count} znamješkow)
       wrong_length:
-        few: njama pšawu dłujkosć (%{count} znamješka wócakane)
         one: njama pšawu dłujkosć (1 znamješko wócakane)
-        other: njama pšawu dłujkosć (%{count} znamješkow wócakanych)
         two: njama pšawu dłujkosć (%{count} znamješce wócakanej)
+        few: njama pšawu dłujkosć (%{count} znamješka wócakane)
+        other: njama pšawu dłujkosć (%{count} znamješkow wócakanych)
     template:
       body: ! 'Pšosym pśeglědaj slědujuce póla:'
       header:
-        few: Pśi składowanju objekta %{model} jo k %{count} zmólkam dojšło a njejo
-          było móžno składowaś
-        one: Pśi składowanju objekta %{model} jo k zmólce dojšło a njejo było móžno
-          składowaś
-        other: Pśi składowanju objekta %{model} jo k %{count} zmólkam dojšło a njejo
-          było móžno składowaś
-        two: Pśi składowanju objekta %{model} jo k %{count} zmólkam dojšło a njejo
-          było móžno składowaś
+        one: Pśi składowanju objekta %{model} jo k zmólce dojšło a njejo było móžno składowaś
+        two: Pśi składowanju objekta %{model} jo k %{count} zmólkam dojšło a njejo było móžno składowaś
+        few: Pśi składowanju objekta %{model} jo k %{count} zmólkam dojšło a njejo było móžno składowaś
+        other: Pśi składowanju objekta %{model} jo k %{count} zmólkam dojšło a njejo było móžno składowaś
   number:
     currency:
       format:
@@ -180,10 +176,10 @@ dsb:
         format: ! '%n %u'
         units:
           byte:
-            few: bajty
             one: bajt
-            other: bajtow
             two: bajta
+            few: bajty
+            other: bajtow
           gb: GB
           kb: KB
           mb: MB

--- a/rails/locale/iso-639-2/fur.yml
+++ b/rails/locale/iso-639-2/fur.yml
@@ -9,7 +9,7 @@ fur:
     - vin
     - sab
     abbr_month_names:
-    - 
+    -
     - Zen
     - Fev
     - Mar
@@ -35,7 +35,7 @@ fur:
       long: ! '%d di %B dal %Y'
       short: ! '%d di %b'
     month_names:
-    - 
+    -
     - Zenâr
     - Fevrâr
     - Març
@@ -67,33 +67,33 @@ fur:
         one: cuasi un an
         other: cuasi %{count} agns
       half_a_minute: mieç minût
-      less_than_x_minutes:
-        one: mancul di un minût
-        other: mancul di %{count} minûts
       less_than_x_seconds:
         one: mancul di un secont
         other: mancul di %{count} seconts
+      less_than_x_minutes:
+        one: mancul di un minût
+        other: mancul di %{count} minûts
       over_x_years:
         one: plui di un an
         other: plui di %{count} agns
-      x_days:
-        one: 1 zornade
-        other: ! '%{count} zornadis'
-      x_minutes:
-        one: 1 minût
-        other: ! '%{count} minûts'
-      x_months:
-        one: 1 mês
-        other: ! '%{count} mês'
       x_seconds:
         one: 1 secont
         other: ! '%{count} seconts'
+      x_minutes:
+        one: 1 minût
+        other: ! '%{count} minûts'
+      x_days:
+        one: 1 zornade
+        other: ! '%{count} zornadis'
+      x_months:
+        one: 1 mês
+        other: ! '%{count} mês'
     prompts:
-      day: Zornade
-      hour: Ore
-      minute: Minût
-      month: Mês
       second: Secont
+      minute: Minût
+      hour: Ore
+      day: Zornade
+      month: Mês
       year: An
   errors:
     format: ! '%{attribute} %{message}'

--- a/rails/locale/iso-639-2/gsw-CH.yml
+++ b/rails/locale/iso-639-2/gsw-CH.yml
@@ -9,7 +9,7 @@
     - Fr
     - Sa
     abbr_month_names:
-    - 
+    -
     - Jan
     - Feb
     - Mär
@@ -35,7 +35,7 @@
       long: ! '%e. %B %Y'
       short: ! '%e. %b'
     month_names:
-    - 
+    -
     - Januar
     - Februar
     - März
@@ -67,33 +67,33 @@
         one: fascht es johr
         other: fascht %{count} johr
       half_a_minute: e halbi minute
-      less_than_x_minutes:
-        one: weniger als e minute
-        other: weniger als %{count} minute
       less_than_x_seconds:
         one: weniger als e sekunde
         other: weniger als %{count} sekunde
+      less_than_x_minutes:
+        one: weniger als e minute
+        other: weniger als %{count} minute
       over_x_years:
         one: meh als es johr
         other: meh als %{count} johr
-      x_days:
-        one: ein tag
-        other: ! '%{count} täg'
-      x_minutes:
-        one: ei minute
-        other: ! '%{count} minute'
-      x_months:
-        one: ein monet
-        other: ! '%{count} mönet'
       x_seconds:
         one: ei sekunde
         other: ! '%{count} sekunde'
+      x_minutes:
+        one: ei minute
+        other: ! '%{count} minute'
+      x_days:
+        one: ein tag
+        other: ! '%{count} täg'
+      x_months:
+        one: ein monet
+        other: ! '%{count} mönet'
     prompts:
-      day: tag
-      hour: stund
-      minute: minute
-      month: monet
       second: sekunde
+      minute: minute
+      hour: stund
+      day: tag
+      month: monet
       year: johr
   errors:
     format: ! '%{attribute} %{message}'

--- a/rails/locale/iso-639-2/hsb.yml
+++ b/rails/locale/iso-639-2/hsb.yml
@@ -9,7 +9,7 @@ hsb:
     - Pj
     - So
     abbr_month_names:
-    - 
+    -
     - jan
     - feb
     - měr
@@ -35,7 +35,7 @@ hsb:
       long: ! '%d. %B %Y'
       short: ! '%d %b'
     month_names:
-    - 
+    -
     - Januar
     - Februar
     - Měrc
@@ -55,56 +55,56 @@ hsb:
   datetime:
     distance_in_words:
       about_x_hours:
-        few: něhdźe %{count} hodźinami
         one: něhdźe 1 hodźinu
-        other: něhdźe %{count} hodźinami
         two: něhdźe %{count} hodźinomaj
+        few: něhdźe %{count} hodźinami
+        other: něhdźe %{count} hodźinami
       about_x_months:
-        few: něhdźe %{count} měsacami
         one: něhdźe 1 měsacom
-        other: něhdźe %{count} měsacami
         two: něhdźe %{count} měsacomaj
+        few: něhdźe %{count} měsacami
+        other: něhdźe %{count} měsacami
       about_x_years:
-        few: něhdźe %{count} lětami
         one: něhdźe 1 lětom
-        other: něhdźe %{count} lětami
         two: něhdźe %{count} lětomaj
+        few: něhdźe %{count} lětami
+        other: něhdźe %{count} lětami
       half_a_minute: poł mjeńšiny
-      less_than_x_minutes:
-        few: mjenje hač %{count} mjeńšinami
-        one: mjenje hač 1 mjeńšinu
-        other: mjenje hač %{count} mjeńšinami
-        two: mjenje hač %{count} mjeńšinomaj
       less_than_x_seconds:
-        few: mjenje hač %{count} sekundami
         one: mjenje hač 1 sekundu
-        other: mjenje hač %{count} sekundami
         two: mjenje hač %{count} sekundomaj
+        few: mjenje hač %{count} sekundami
+        other: mjenje hač %{count} sekundami
+      less_than_x_minutes:
+        one: mjenje hač 1 mjeńšinu
+        two: mjenje hač %{count} mjeńšinomaj
+        few: mjenje hač %{count} mjeńšinami
+        other: mjenje hač %{count} mjeńšinami
       over_x_years:
-        few: přez %{count} lětami
         one: přez 1 lětom
-        other: přez %{count} lětami
         two: přez %{count} lětomaj
-      x_days:
-        few: ! '%{count} dnjemi'
-        one: 1 dnjom
-        other: ! '%{count} dnjemi'
-        two: ! '%{count} dnjomaj'
-      x_minutes:
-        few: ! '%{count} mjeńšinami'
-        one: 1 mjeńšinu
-        other: ! '%{count} mjeńšinami'
-        two: ! '%{count} mjeńšinomaj'
-      x_months:
-        few: ! '%{count} měsacami'
-        one: 1 měsacom
-        other: ! '%{count} měsacami'
-        two: ! '%{count} měsacomaj'
+        few: přez %{count} lětami
+        other: přez %{count} lětami
       x_seconds:
-        few: ! '%{count} sekundami'
         one: 1 sekundu
-        other: ! '%{count} sekundami'
         two: ! '%{count} sekundomaj'
+        few: ! '%{count} sekundami'
+        other: ! '%{count} sekundami'
+      x_minutes:
+        one: 1 mjeńšinu
+        two: ! '%{count} mjeńšinomaj'
+        few: ! '%{count} mjeńšinami'
+        other: ! '%{count} mjeńšinami'
+      x_days:
+        one: 1 dnjom
+        two: ! '%{count} dnjomaj'
+        few: ! '%{count} dnjemi'
+        other: ! '%{count} dnjemi'
+      x_months:
+        one: 1 měsacom
+        two: ! '%{count} měsacomaj'
+        few: ! '%{count} měsacami'
+        other: ! '%{count} měsacami'
   errors:
     format: ! '%{attribute} %{message}'
     messages:
@@ -125,30 +125,27 @@ hsb:
       odd: dyrbi njeruna ličby być
       taken: je hižo w datowej bance
       too_long:
-        few: je předołhi (maks. %{count} znamješka)
         one: je předołhi (maks. 1 znamješko)
-        other: je předołhi (maks. %{count} znamješkow)
         two: je předołhi (maks. %{count} znamješce)
+        few: je předołhi (maks. %{count} znamješka)
+        other: je předołhi (maks. %{count} znamješkow)
       too_short:
-        few: je překrótki (min. %{count} znamješka)
         one: je překrótki (min. 1 znamješko)
-        other: je překrótki (min. %{count} znamješkow)
         two: je překrótki (min. %{count} znamješće)
+        few: je překrótki (min. %{count} znamješka)
+        other: je překrótki (min. %{count} znamješkow)
       wrong_length:
-        few: nima prawu dołhosć (%{count} znamješka wočakowane)
         one: nima prawu dołhosć (1 znamješko wočakowane)
-        other: nima prawu dołhosć (%{count} znamješkow wočakowanych)
         two: nima prawu dołhosć (%{count} znamješce wočakowanej)
+        few: nima prawu dołhosć (%{count} znamješka wočakowane)
+        other: nima prawu dołhosć (%{count} znamješkow wočakowanych)
     template:
       body: ! 'Prošu přepruwuj slědowace pola:'
       header:
-        few: Při składowanju objekta %{model} je k %{count} zmylkam dóšło a njebě
-          móžno składować
         one: Při składowanju objekta %{model} je k zmylkej dóšło a njebě móžno składować
-        other: Při składowanju objekta %{model} je k %{count} zmylkam dóšło a njebě
-          móžno składować
-        two: Při składowanju objekta %{model} je k %{count} zmylkam dóšło a njebě
-          móžno składować
+        two: Při składowanju objekta %{model} je k %{count} zmylkam dóšło a njebě móžno składować
+        few: Při składowanju objekta %{model} je k %{count} zmylkam dóšło a njebě móžno składować
+        other: Při składowanju objekta %{model} je k %{count} zmylkam dóšło a njebě móžno składować
   number:
     currency:
       format:
@@ -179,10 +176,10 @@ hsb:
         format: ! '%n %u'
         units:
           byte:
-            few: bajty
             one: bajt
-            other: bajtow
             two: bajtaj
+            few: bajty
+            other: bajtow
           gb: GB
           kb: KB
           mb: MB

--- a/rails/locale/iso-639-2/scr.yml
+++ b/rails/locale/iso-639-2/scr.yml
@@ -9,7 +9,7 @@ scr:
     - Pet
     - Sub
     abbr_month_names:
-    - 
+    -
     - Jan
     - Feb
     - Mar
@@ -35,7 +35,7 @@ scr:
       long: ! '%B %e, %Y'
       short: ! '%e %b'
     month_names:
-    - 
+    -
     - Januar
     - Februar
     - Mart
@@ -75,54 +75,53 @@ scr:
         many: skoro %{count} godina
         other: skoro %{count} godina
       half_a_minute: pola minute
+      less_than_x_seconds:
+        one: manje od %{count} sekund
+        few: manje od %{count} sekunde
+        many: manje od %{count} sekundi
+        other: manje od %{count} sekundi
       less_than_x_minutes:
         one: manje od %{count} minut
         few: manje od %{count} minuta
         many: manje od %{count} minuta
         other: manje od %{count} minuta
-      less_than_x_seconds:
-        few: manje od %{count} sekunde
-        one: manje od %{count} sekund
-        many: manje od %{count} sekundi
-        other: manje od %{count} sekundi
       over_x_years:
         one: preko %{count} godine
         few: preko %{count} godine
         many: preko %{count} godina
         other: preko %{count} godina
-      x_days:
-        one: ! '%{count} dan'
-        few: ! '%{count} dana'
-        many: ! '%{count} dana'
-        other: ! '%{count} dana'
-      x_minutes:
-        one: ! '%{count} minut'
-        few: ! '%{count} minuta'
-        many: ! '%{count} minuta'
-        other: ! '%{count} minuta'
-      x_months:
-        one: ! '%{count} mesec'
-        few: ! '%{count} meseca'
-        many: ! '%{count} meseci'
-        other: ! '%{count} meseci'
       x_seconds:
         one: ! '%{count} sekunda'
         few: ! '%{count} sekunde'
         many: ! '%{count} sekundi'
         other: ! '%{count} sekundi'
+      x_minutes:
+        one: ! '%{count} minut'
+        few: ! '%{count} minuta'
+        many: ! '%{count} minuta'
+        other: ! '%{count} minuta'
+      x_days:
+        one: ! '%{count} dan'
+        few: ! '%{count} dana'
+        many: ! '%{count} dana'
+        other: ! '%{count} dana'
+      x_months:
+        one: ! '%{count} mesec'
+        few: ! '%{count} meseca'
+        many: ! '%{count} meseci'
+        other: ! '%{count} meseci'
     prompts:
-      day: Dan
-      hour: Sat
-      minute: Minut
-      month: Mesec
       second: Sekund
+      minute: Minut
+      hour: Sat
+      day: Dan
+      month: Mesec
       year: Godina
   errors:
     format: ! '%{attribute} %{message}'
     messages:
       accepted: mora biti prihvaćen
       blank: ne sme biti prazan
-      present: mora biti prazan
       confirmation: se ne slaže sa potvrdom
       empty: ne sme biti prazan
       equal_to: mora biti jednak %{count}
@@ -137,6 +136,8 @@ scr:
       not_a_number: nije broj
       not_an_integer: nije ceo broj
       odd: mora biti neparan
+      other_than: "mora biti različit od %{count}"
+      present: mora biti prazan
       record_invalid: ! 'Validacija nije uspela: %{errors}'
       restrict_dependent_destroy:
         one: "Nije moguće obrisati zapis jer postoji zavisan %{record}"
@@ -157,7 +158,6 @@ scr:
         few: nije odgovarajuće dužine (treba biti %{count} znaka)
         many: nije odgovarajuće dužine (treba biti %{count} znakova)
         other: nije odgovarajuće dužine (treba biti %{count} znakova)
-      other_than: "mora biti različit od %{count}"
     template:
       body: ! 'Molim Vas da proverite sledeća polja:'
       header:
@@ -192,11 +192,11 @@ scr:
       decimal_units:
         format: ! '%n %u'
         units:
-          thousand: Hiljadu
-          million: Milion
           billion: Milijarda
-          trillion: Trilion
+          million: Milion
           quadrillion: Kvadrilion
+          thousand: Hiljadu
+          trillion: Trilion
           unit: ''
       format:
         delimiter: ''

--- a/rails/locale/pap-AW.yml
+++ b/rails/locale/pap-AW.yml
@@ -1,4 +1,3 @@
-# pap-AW merged M. Maduro and Rianne Helings by Richenel Ansano for Suares & Co
 pap-AW:
   activerecord:
     errors:
@@ -75,43 +74,42 @@ pap-AW:
         one: kasi 1 aña
         other: kasi %{count} aña
       half_a_minute: mei minüt
-      less_than_x_minutes:
-        one: ménos ku 1 minüt
-        other: ménos ku %{count} minüt
       less_than_x_seconds:
         one: ménos ku 1 sekònde
         other: ménos ku %{count} sekònde
+      less_than_x_minutes:
+        one: ménos ku 1 minüt
+        other: ménos ku %{count} minüt
       over_x_years:
         one: mas ku 1 aña
         other: mas ku %{count} aña
-      x_days:
-        one: 1 dia
-        other: '%{count} dia'
+      x_seconds:
+        one: 1 sekònde
+        other: '%{count} sekònde'
       x_minutes:
         one: 1 minüt
         other: '%{count} minüt'
+      x_days:
+        one: 1 dia
+        other: '%{count} dia'
       x_months:
         one: 1 luna
         other: '%{count} luna'
       x_years:
         one: 1 year
         other: "%{count} years"
-      x_seconds:
-        one: 1 sekònde
-        other: '%{count} sekònde'
     prompts:
-      day: Dia
-      hour: Ora
-      minute: Minüt
-      month: Luna
       second: Sekònde
+      minute: Minüt
+      hour: Ora
+      day: Dia
+      month: Luna
       year: Aña
   errors:
     format: '%{attribute} %{message}'
     messages:
       accepted: mester asept'é
       blank: no por keda sin yen'é
-      present: mester keda bashí
       confirmation: "no ta meskos %{attribute}"
       empty: no por keda bashí
       equal_to: mester ta meskos ku %{count}
@@ -127,6 +125,8 @@ pap-AW:
       not_a_number: no ta un number
       not_an_integer: mester ta un number hinté
       odd: mester ta impar
+      other_than: "no por ta %{count}"
+      present: mester keda bashí
       required: must exist
       taken: ta usá kaba
       too_long:
@@ -138,7 +138,6 @@ pap-AW:
       wrong_length:
         one: su largura no ta korekto (mester ta 1 karakter)
         other: su largura no ta korekto (mester ta %{count} karakter)
-      other_than: "no por ta %{count}"
     template:
       body: 'E siguiente rúbrikanan ta duna problema:'
       header:
@@ -188,12 +187,12 @@ pap-AW:
           byte:
             one: Bait
             other: Bait
+          eb: EB
           gb: GB
           kb: KB
           mb: MB
-          tb: TB
           pb: PB
-          eb: EB
+          tb: TB
     percentage:
       format:
         delimiter: ''

--- a/rails/locale/pap-CW.yml
+++ b/rails/locale/pap-CW.yml
@@ -1,4 +1,3 @@
-# pap-CW merged M. Maduro and Rianne Helings by Richenel Ansano for Suares & Co
 pap-CW:
   activerecord:
     errors:
@@ -75,43 +74,42 @@ pap-CW:
         one: kasi 1 aña
         other: kasi %{count} aña
       half_a_minute: mei minüt
-      less_than_x_minutes:
-        one: ménos ku 1 minüt
-        other: ménos ku %{count} minüt
       less_than_x_seconds:
         one: ménos ku 1 sekònde
         other: ménos ku %{count} sekònde
+      less_than_x_minutes:
+        one: ménos ku 1 minüt
+        other: ménos ku %{count} minüt
       over_x_years:
         one: mas ku 1 aña
         other: mas ku %{count} aña
-      x_days:
-        one: 1 dia
-        other: '%{count} dia'
+      x_seconds:
+        one: 1 sekònde
+        other: '%{count} sekònde'
       x_minutes:
         one: 1 minüt
         other: '%{count} minüt'
+      x_days:
+        one: 1 dia
+        other: '%{count} dia'
       x_months:
         one: 1 luna
         other: '%{count} luna'
       x_years:
         one: 1 year
         other: "%{count} years"
-      x_seconds:
-        one: 1 sekònde
-        other: '%{count} sekònde'
     prompts:
-      day: Dia
-      hour: Ora
-      minute: Minüt
-      month: Luna
       second: Sekònde
+      minute: Minüt
+      hour: Ora
+      day: Dia
+      month: Luna
       year: Aña
   errors:
     format: '%{attribute} %{message}'
     messages:
       accepted: mester asept'é
       blank: no por keda sin yen'é
-      present: mester keda bashí
       confirmation: "no ta meskos %{attribute}"
       empty: no por keda bashí
       equal_to: mester ta meskos ku %{count}
@@ -127,6 +125,8 @@ pap-CW:
       not_a_number: no ta un number
       not_an_integer: mester ta un number hinté
       odd: mester ta impar
+      other_than: "no por ta %{count}"
+      present: mester keda bashí
       required: must exist
       taken: ta usá kaba
       too_long:
@@ -138,7 +138,6 @@ pap-CW:
       wrong_length:
         one: su largura no ta korekto (mester ta 1 karakter)
         other: su largura no ta korekto (mester ta %{count} karakter)
-      other_than: "no por ta %{count}"
     template:
       body: 'E siguiente rúbrikanan ta duna problema:'
       header:
@@ -188,12 +187,12 @@ pap-CW:
           byte:
             one: Bait
             other: Bait
+          eb: EB
           gb: GB
           kb: KB
           mb: MB
-          tb: TB
           pb: PB
-          eb: EB
+          tb: TB
     percentage:
       format:
         delimiter: ''

--- a/rails/locale/sq.yml
+++ b/rails/locale/sq.yml
@@ -43,7 +43,7 @@ sq:
       long: "%d %B, %Y"
       short: "%d %b"
     month_names:
-    - 
+    -
     - Janar
     - Shkurt
     - Mars
@@ -84,12 +84,12 @@ sq:
       over_x_years:
         one: mbi 1 vit
         other: mbi %{count} vjet
-      x_days:
-        one: 1 ditë
-        other: "%{count} ditë"
       x_minutes:
         one: 1 minutë
         other: "%{count} minuta"
+      x_days:
+        one: 1 ditë
+        other: "%{count} ditë"
       x_days:
         one: 1 ditë
         other: "%{count} ditë"
@@ -111,7 +111,6 @@ sq:
     messages:
       accepted: duhet pranuar
       blank: s’mund të jetë i zbrazët
-      present: duhet të jetë i zbrazët
       confirmation: s’përputhet me %{attribute}
       empty: s’mund të jetë i zbrazët
       equal_to: duhet të jetë baras me %{count}
@@ -128,6 +127,7 @@ sq:
       not_an_integer: duhet të jetë numër i plotë
       odd: duhet të jetë tek
       other_than: duhet të jetë më shumë se %{count}
+      present: duhet të jetë i zbrazët
       present: duhet të jetë e zbrazët
       required: duhet të ekzistojë
       taken: është zënë tashmë

--- a/rails/locale/vi.yml
+++ b/rails/locale/vi.yml
@@ -17,7 +17,7 @@ vi:
     - Thứ 6
     - Thứ 7
     abbr_month_names:
-    - 
+    -
     - Thg 1
     - Thg 2
     - Thg 3
@@ -43,7 +43,7 @@ vi:
       long: "%d %B, %Y"
       short: "%d %b"
     month_names:
-    - 
+    -
     - Tháng một
     - Tháng hai
     - Tháng ba
@@ -124,11 +124,11 @@ vi:
       odd: phải là số lẻ
       other_than: cần phải khác %{count}
       present: cần phải để trắng
+      required: "phải có"
       taken: đã có
       too_long: quá dài (tối đa %{count} ký tự)
       too_short: quá ngắn (tối thiểu %{count} ký tự)
       wrong_length: độ dài không đúng (phải là %{count} ký tự)
-      required: "phải có"
     template:
       body: 'Có lỗi với các mục sau:'
       header:


### PR DESCRIPTION
Multiple locale files in the repo have not been normalized. Adding the yalphabetize gem to our rake tasks and CI will allow us to catch locale yaml files that require normalisation before merging a PR.

This PR adds yalphabetize to our default rake task and corrects any un-alphabetised locale files.

Yalphabetize also offers a tool to alphabetise any un-alphabetised yaml files. In the future, we could potentially use this to replace the rails-i18n Normalize module.