### PR TITLE
Use no-padded date format for fr locale

### DIFF
--- a/rails/locale/fr-CH.yml
+++ b/rails/locale/fr-CH.yml
@@ -42,8 +42,8 @@ fr-CH:
     - samedi
     formats:
       default: "%d.%m.%Y"
-      long: "%e %B %Y"
-      short: "%e %b"
+      long: "%-d %B %Y"
+      short: "%-d %b"
     month_names:
     - 
     - janvier

--- a/rails/locale/fr-FR.yml
+++ b/rails/locale/fr-FR.yml
@@ -42,8 +42,8 @@ fr-FR:
     - samedi
     formats:
       default: "%d/%m/%Y"
-      long: "%e %B %Y"
-      short: "%e %b"
+      long: "%-d %B %Y"
+      short: "%-d %b"
     month_names:
     - 
     - janvier

--- a/rails/locale/fr.yml
+++ b/rails/locale/fr.yml
@@ -42,8 +42,8 @@ fr:
     - samedi
     formats:
       default: "%d/%m/%Y"
-      long: "%e %B %Y"
-      short: "%e %b"
+      long: "%-d %B %Y"
+      short: "%-d %b"
     month_names:
     - 
     - janvier


### PR DESCRIPTION
The goal of this PR is to change the date format from blank-padded to no-padded for the day in the french locale.

Before:
```
> I18n.with_locale("fr") { I18n.l("Jan 01".to_date, format: :long) }
=> " 1 janvier 2022"
> I18n.with_locale("fr") { I18n.l("Jan 01".to_date, format: :short) }
=> " 1 jan."
```

After:
```
> I18n.with_locale("fr") { I18n.l("Jan 01".to_date, format: :long) }
=> "1 janvier 2022"
> I18n.with_locale("fr") { I18n.l("Jan 01".to_date, format: :short) }
=> "1 jan."
```