### PR TITLE
French (fr): Revert remainder of NBSP characters

### DIFF
--- a/rails/locale/fr.yml
+++ b/rails/locale/fr.yml
@@ -75,19 +75,19 @@ fr:
         other: environ %{count} ans
       almost_x_years:
         one: presqu'un an
-        other: presque %{count} ans
+        other: presque %{count} ans
       half_a_minute: une demi‑minute
       less_than_x_seconds:
         zero: moins d'une seconde
         one: moins d'une seconde
-        other: moins de %{count} secondes
+        other: moins de %{count} secondes
       less_than_x_minutes:
         zero: moins d'une minute
         one: moins d'une minute
-        other: moins de %{count} minutes
+        other: moins de %{count} minutes
       over_x_years:
-        one: plus d'un an
-        other: plus de %{count} ans
+        one: plus d'un an
+        other: plus de %{count} ans
       x_seconds:
         one: 1 seconde
         other: "%{count} secondes"
@@ -120,13 +120,13 @@ fr:
       equal_to: doit être égal à %{count}
       even: doit être pair
       exclusion: n'est pas disponible
-      greater_than: doit être supérieur à %{count}
-      greater_than_or_equal_to: doit être supérieur ou égal à %{count}
+      greater_than: doit être supérieur à %{count}
+      greater_than_or_equal_to: doit être supérieur ou égal à %{count}
       inclusion: n'est pas inclus(e) dans la liste
       invalid: n'est pas valide
-      less_than: doit être inférieur à %{count}
-      less_than_or_equal_to: doit être inférieur ou égal à %{count}
-      model_invalid: 'Validation échouée : %{errors}'
+      less_than: doit être inférieur à %{count}
+      less_than_or_equal_to: doit être inférieur ou égal à %{count}
+      model_invalid: 'Validation échouée : %{errors}'
       not_a_number: n'est pas un nombre
       not_an_integer: doit être un nombre entier
       odd: doit être impair
@@ -136,7 +136,7 @@ fr:
       taken: est déjà utilisé(e)
       too_long:
         one: est trop long (pas plus d'un caractère)
-        other: est trop long (pas plus de %{count} caractères)
+        other: est trop long (pas plus de %{count} caractères)
       too_short:
         one: est trop court (au moins un caractère)
         other: est trop court (au moins %{count} caractères)
@@ -146,8 +146,8 @@ fr:
     template:
       body: 'Veuillez vérifier les champs suivants : '
       header:
-        one: 'Impossible d''enregistrer ce(tte) %{model} : 1 erreur'
-        other: 'Impossible d''enregistrer ce(tte) %{model} : %{count} erreurs'
+        one: 'Impossible d''enregistrer ce(tte) %{model} : 1 erreur'
+        other: 'Impossible d''enregistrer ce(tte) %{model} : %{count} erreurs'
   helpers:
     select:
       prompt: Veuillez sélectionner


### PR DESCRIPTION
In 6f21c25f89573eee05609b6ef1f1c1a12e9ac24d, @benoittgt _partially_ reverted "thin spaces" i.e. NBSP characters from French (`fr`) locale.

I do not understand the reason for a "partial" revert. It's not explained in the commit, and there seems to be no consistent logic regarding which NBSP chars were reverted. For example:

```
      too_long:
        other: est trop long (pas plus de %{count} caractères) # not reverted 🤷 
      too_short:
        other: est trop court (au moins %{count} caractères)   # reverted
```	

This PR reverts all NBSP chars from `fr`, and in the future if the maintainers would like to make some consistent rule on where/how NBSP should in which locales, let's re-apply it at that time.