### PR TITLE
Standardize all Chinese locales punctuation

### DIFF
--- a/rails/locale/zh-CN.yml
+++ b/rails/locale/zh-CN.yml
@@ -3,10 +3,10 @@ zh-CN:
   activerecord:
     errors:
       messages:
-        record_invalid: '验证失败: %{errors}'
+        record_invalid: 验证失败︰%{errors}
         restrict_dependent_destroy:
-          has_one: 由于 %{record} 需要此记录，所以无法移除记录
-          has_many: 由于 %{record} 需要此记录，所以无法移除记录
+          has_one: 由于%{record}需要此记录，所以无法移除记录
+          has_many: 由于%{record}需要此记录，所以无法移除记录
   date:
     abbr_day_names:
     - 周日
@@ -62,19 +62,19 @@ zh-CN:
     - :day
   datetime:
     distance_in_words:
-      about_x_hours: 大约 %{count} 小时
-      about_x_months: 大约 %{count} 个月
-      about_x_years: 大约 %{count} 年
-      almost_x_years: 接近 %{count} 年
+      about_x_hours: 大约%{count}小时
+      about_x_months: 大约%{count}个月
+      about_x_years: 大约%{count}年
+      almost_x_years: 接近%{count}年
       half_a_minute: 半分钟
-      less_than_x_seconds: 不到 %{count} 秒
-      less_than_x_minutes: 不到 %{count} 分钟
-      over_x_years: "%{count} 年多"
-      x_seconds: "%{count} 秒"
-      x_minutes: "%{count} 分钟"
-      x_days: "%{count} 天"
-      x_months: "%{count} 个月"
-      x_years: "%{count} 年"
+      less_than_x_seconds: 不到%{count}秒
+      less_than_x_minutes: 不到%{count}分钟
+      over_x_years: "%{count}年多"
+      x_seconds: "%{count}秒"
+      x_minutes: "%{count}分钟"
+      x_days: "%{count}天"
+      x_months: "%{count}个月"
+      x_years: "%{count}年"
     prompts:
       second: 秒
       minute: 分
@@ -83,35 +83,35 @@ zh-CN:
       month: 月
       year: 年
   errors:
-    format: "%{attribute} %{message}"
+    format: "%{attribute}%{message}"
     messages:
       accepted: 必须是可被接受的
       blank: 不能为空字符
-      confirmation: 与 %{attribute} 不匹配
+      confirmation: 与%{attribute}不匹配
       empty: 不能留空
-      equal_to: 必须等于 %{count}
+      equal_to: 必须等于%{count}
       even: 必须为双数
       exclusion: 是保留关键字
-      greater_than: 必须大于 %{count}
-      greater_than_or_equal_to: 必须大于或等于 %{count}
+      greater_than: 必须大于%{count}
+      greater_than_or_equal_to: 必须大于或等于%{count}
       inclusion: 不包含于列表中
       invalid: 是无效的
-      less_than: 必须小于 %{count}
-      less_than_or_equal_to: 必须小于或等于 %{count}
-      model_invalid: '验证失败: %{errors}'
+      less_than: 必须小于%{count}
+      less_than_or_equal_to: 必须小于或等于%{count}
+      model_invalid: 验证失败︰%{errors}
       not_a_number: 不是数字
       not_an_integer: 必须是整数
       odd: 必须为单数
-      other_than: 长度非法（不可为 %{count} 个字符
+      other_than: 长度非法（不可为%{count}个字符）
       present: 必须是空白
       required: 必须存在
       taken: 已经被使用
-      too_long: 过长（最长为 %{count} 个字符）
-      too_short: 过短（最短为 %{count} 个字符）
-      wrong_length: 长度非法（必须为 %{count} 个字符）
+      too_long: 过长（最长为%{count}个字符）
+      too_short: 过短（最短为%{count}个字符）
+      wrong_length: 长度非法（必须为%{count}个字符）
     template:
       body: 如下字段出现错误：
-      header: 有 %{count} 个错误发生导致“%{model}”无法被保存。
+      header: 有%{count}个错误发生导致“%{model}”无法被保存。
   helpers:
     select:
       prompt: 请选择
@@ -169,8 +169,8 @@ zh-CN:
         delimiter: ''
   support:
     array:
-      last_word_connector: " 以及 "
-      two_words_connector: " 和 "
+      last_word_connector: "、"
+      two_words_connector: 和
       words_connector: "、"
   time:
     am: 上午

--- a/rails/locale/zh-CN.yml
+++ b/rails/locale/zh-CN.yml
@@ -3,7 +3,7 @@ zh-CN:
   activerecord:
     errors:
       messages:
-        record_invalid: 验证失败︰%{errors}
+        record_invalid: 验证失败：%{errors}
         restrict_dependent_destroy:
           has_one: 由于%{record}需要此记录，所以无法移除记录
           has_many: 由于%{record}需要此记录，所以无法移除记录
@@ -98,7 +98,7 @@ zh-CN:
       invalid: 是无效的
       less_than: 必须小于%{count}
       less_than_or_equal_to: 必须小于或等于%{count}
-      model_invalid: 验证失败︰%{errors}
+      model_invalid: 验证失败：%{errors}
       not_a_number: 不是数字
       not_an_integer: 必须是整数
       odd: 必须为单数

--- a/rails/locale/zh-HK.yml
+++ b/rails/locale/zh-HK.yml
@@ -98,7 +98,7 @@ zh-HK:
         other: "%{count}個月"
       x_years:
         one: 一年
-        other: "%{count} 年"
+        other: "%{count}年"
     prompts:
       second: 秒
       minute: 分
@@ -107,43 +107,43 @@ zh-HK:
       month: 月
       year: 年
   errors:
-    format: "%{attribute} %{message}"
+    format: "%{attribute}%{message}"
     messages:
       accepted: 必定要被接受
       blank: 不可以是空白
-      confirmation: 與 %{attribute} 不一致
+      confirmation: 與%{attribute}不一致
       empty: 不可以留空
-      equal_to: 必須等於 %{count}
+      equal_to: 必須等於%{count}
       even: 必須要是雙數
       exclusion: 是被保留的關鍵字
-      greater_than: 必須大於 %{count}
-      greater_than_or_equal_to: 必須大於或等於 %{count}
+      greater_than: 必須大於%{count}
+      greater_than_or_equal_to: 必須大於或等於%{count}
       inclusion: 並非可被接受的內容
       invalid: 是無效的
-      less_than: 必須小於 %{count}
-      less_than_or_equal_to: 必須小於或等於 %{count}
+      less_than: 必須小於%{count}
+      less_than_or_equal_to: 必須小於或等於%{count}
       model_invalid: 驗證失敗︰%{errors}
       not_a_number: 必須是數字
       not_an_integer: 必須是整數
       odd: 必須是單數
-      other_than: 不可以是 %{count} 個字
+      other_than: 不可以是%{count}個字
       present: 必定要是空白
       required: 必須存在
       taken: 已被使用
       too_long:
         one: 太長（最長為一個字元）
-        other: 太長（最長為 %{count} 個字元）
+        other: 太長（最長為%{count}個字元）
       too_short:
         one: 太短（最少為一個字元）
-        other: 太短（最少為 %{count} 個字元）
+        other: 太短（最少為%{count}個字元）
       wrong_length:
-        one: 字數錯誤 (應為一個字元)
-        other: 字數錯誤 (應為 %{count} 個字元)
+        one: 字數錯誤（應為一個字元）
+        other: 字數錯誤（應為%{count}個字元）
     template:
       body: 以下欄位發生問題︰
       header:
-        one: 發生一項錯誤，以致 %{model} 未能儲存。
-        other: 發生%{count}項錯誤，以致 %{model} 未能儲存。
+        one: 發生一項錯誤，以致%{model}未能儲存。
+        other: 發生%{count}項錯誤，以致%{model}未能儲存。
   helpers:
     select:
       prompt: 請選擇
@@ -201,7 +201,7 @@ zh-HK:
         delimiter: ''
   support:
     array:
-      last_word_connector: 和
+      last_word_connector: "、"
       two_words_connector: 和
       words_connector: "、"
   time:

--- a/rails/locale/zh-HK.yml
+++ b/rails/locale/zh-HK.yml
@@ -3,7 +3,7 @@ zh-HK:
   activerecord:
     errors:
       messages:
-        record_invalid: 驗證失敗︰%{errors}
+        record_invalid: 驗證失敗：%{errors}
         restrict_dependent_destroy:
           has_one: 由於%{record}依賴此記錄，無法移除
           has_many: 由於%{record}依賴此記錄，無法移除
@@ -122,7 +122,7 @@ zh-HK:
       invalid: 是無效的
       less_than: 必須小於%{count}
       less_than_or_equal_to: 必須小於或等於%{count}
-      model_invalid: 驗證失敗︰%{errors}
+      model_invalid: 驗證失敗：%{errors}
       not_a_number: 必須是數字
       not_an_integer: 必須是整數
       odd: 必須是單數
@@ -140,7 +140,7 @@ zh-HK:
         one: 字數錯誤（應為一個字元）
         other: 字數錯誤（應為%{count}個字元）
     template:
-      body: 以下欄位發生問題︰
+      body: 以下欄位發生問題：
       header:
         one: 發生一項錯誤，以致%{model}未能儲存。
         other: 發生%{count}項錯誤，以致%{model}未能儲存。

--- a/rails/locale/zh-TW.yml
+++ b/rails/locale/zh-TW.yml
@@ -3,10 +3,10 @@ zh-TW:
   activerecord:
     errors:
       messages:
-        record_invalid: '校驗失敗: %{errors}'
+        record_invalid: 校驗失敗︰%{errors}
         restrict_dependent_destroy:
-          has_one: 由於 %{record} 需要此記錄，所以無法移除記錄
-          has_many: 由於 %{record} 需要此記錄，所以無法移除記錄
+          has_one: 由於%{record}需要此記錄，所以無法移除記錄
+          has_many: 由於%{record}需要此記錄，所以無法移除記錄
   date:
     abbr_day_names:
     - 周日
@@ -64,41 +64,41 @@ zh-TW:
     distance_in_words:
       about_x_hours:
         one: 大約一小時
-        other: 大約 %{count} 小時
+        other: 大約%{count}小時
       about_x_months:
         one: 大約一個月
-        other: 大約 %{count} 個月
+        other: 大約%{count}個月
       about_x_years:
         one: 大約一年
-        other: 大約 %{count} 年
+        other: 大約%{count}年
       almost_x_years:
         one: 接近一年
-        other: 接近 %{count} 年
+        other: 接近%{count}年
       half_a_minute: 半分鐘
       less_than_x_seconds:
         one: 不到一秒
-        other: 不到 %{count} 秒
+        other: 不到%{count}秒
       less_than_x_minutes:
         one: 不到一分鐘
-        other: 不到 %{count} 分鐘
+        other: 不到%{count}分鐘
       over_x_years:
         one: 一年多
-        other: "%{count} 年多"
+        other: "%{count}年多"
       x_seconds:
         one: 一秒
-        other: "%{count} 秒"
+        other: "%{count}秒"
       x_minutes:
         one: 一分鐘
-        other: "%{count} 分鐘"
+        other: "%{count}分鐘"
       x_days:
         one: 一天
-        other: "%{count} 天"
+        other: "%{count}天"
       x_months:
         one: 一個月
-        other: "%{count} 個月"
+        other: "%{count}個月"
       x_years:
         one: 一年
-        other: "%{count} 年"
+        other: "%{count}年"
     prompts:
       second: 秒
       minute: 分
@@ -111,39 +111,39 @@ zh-TW:
     messages:
       accepted: 必須是可被接受的
       blank: 不能為空白
-      confirmation: 與 %{attribute} 須一致
+      confirmation: 與%{attribute}須一致
       empty: 不能留空
-      equal_to: 必須等於 %{count}
+      equal_to: 必須等於%{count}
       even: 必須是偶數
       exclusion: 是被保留的關鍵字
-      greater_than: 必須大於 %{count}
-      greater_than_or_equal_to: 必須大於或等於 %{count}
+      greater_than: 必須大於%{count}
+      greater_than_or_equal_to: 必須大於或等於%{count}
       inclusion: 沒有包含在列表中
       invalid: 是無效的
-      less_than: 必須小於 %{count}
-      less_than_or_equal_to: 必須小於或等於 %{count}
-      model_invalid: '校驗失敗: %{errors}'
+      less_than: 必須小於%{count}
+      less_than_or_equal_to: 必須小於或等於%{count}
+      model_invalid: 校驗失敗︰%{errors}
       not_a_number: 不是數字
       not_an_integer: 必須是整數
       odd: 必須是奇數
-      other_than: 不可以是 %{count} 個字
+      other_than: 不可以是%{count}個字
       present: 必須是空白
       required: 必須存在
       taken: 已經被使用
       too_long:
         one: 過長（最長是一個字）
-        other: 過長（最長是 %{count} 個字）
+        other: 過長（最長是%{count}個字）
       too_short:
         one: 過短（最短是一個字）
-        other: 過短（最短是 %{count} 個字）
+        other: 過短（最短是%{count}個字）
       wrong_length:
-        one: 字數錯誤 (必須是一個字)
-        other: 字數錯誤 (必須是 %{count} 個字)
+        one: 字數錯誤（必須是一個字）
+        other: 字數錯誤（必須是%{count}個字）
     template:
       body: 以下欄位發生問題：
       header:
-        one: 有 1 個錯誤發生使得「%{model}」無法被儲存。
-        other: 有 %{count} 個錯誤發生使得「%{model}」無法被儲存。
+        one: 有1個錯誤發生使得「%{model}」無法被儲存。
+        other: 有%{count}個錯誤發生使得「%{model}」無法被儲存。
   helpers:
     select:
       prompt: 請選擇
@@ -201,9 +201,9 @@ zh-TW:
         delimiter: ''
   support:
     array:
-      last_word_connector: ", 和 "
-      two_words_connector: " 和 "
-      words_connector: ", "
+      last_word_connector: "、"
+      two_words_connector: 和
+      words_connector: "、"
   time:
     am: 上午
     formats:

--- a/rails/locale/zh-TW.yml
+++ b/rails/locale/zh-TW.yml
@@ -3,7 +3,7 @@ zh-TW:
   activerecord:
     errors:
       messages:
-        record_invalid: 校驗失敗︰%{errors}
+        record_invalid: 校驗失敗：%{errors}
         restrict_dependent_destroy:
           has_one: 由於%{record}需要此記錄，所以無法移除記錄
           has_many: 由於%{record}需要此記錄，所以無法移除記錄
@@ -122,7 +122,7 @@ zh-TW:
       invalid: 是無效的
       less_than: 必須小於%{count}
       less_than_or_equal_to: 必須小於或等於%{count}
-      model_invalid: 校驗失敗︰%{errors}
+      model_invalid: 校驗失敗：%{errors}
       not_a_number: 不是數字
       not_an_integer: 必須是整數
       odd: 必須是奇數

--- a/rails/locale/zh-YUE.yml
+++ b/rails/locale/zh-YUE.yml
@@ -3,7 +3,7 @@ zh-YUE:
   activerecord:
     errors:
       messages:
-        record_invalid: 驗證失敗︰%{errors}
+        record_invalid: 驗證失敗：%{errors}
         restrict_dependent_destroy:
           has_one: 唔可以刪除，因為%{record}要用佢
           has_many: 唔可以刪除，因為%{record}要用佢
@@ -122,7 +122,7 @@ zh-YUE:
       invalid: 無效
       less_than: 要細過%{count}
       less_than_or_equal_to: 要細過或者等於%{count}
-      model_invalid: 驗證失敗︰%{errors}
+      model_invalid: 驗證失敗：%{errors}
       not_a_number: 唔係一個數字
       not_an_integer: 要係整數
       odd: 要係單數
@@ -140,7 +140,7 @@ zh-YUE:
         one: 唔啱字數（要係1個字）
         other: 唔啱字數（要係%{count}個字）
     template:
-      body: 呢啲有問題︰
+      body: 呢啲有問題：
       header:
         one: 有一個問題，%{model}儲存唔到。
         other: 有%{count}個問題，%{model}儲存唔到。

--- a/rails/locale/zh-YUE.yml
+++ b/rails/locale/zh-YUE.yml
@@ -98,7 +98,7 @@ zh-YUE:
         other: "%{count}個月"
       x_years:
         one: 一年
-        other: "%{count} 年"
+        other: "%{count}年"
     prompts:
       second: 秒
       minute: 分
@@ -107,13 +107,13 @@ zh-YUE:
       month: 月
       year: 年
   errors:
-    format: "%{attribute} %{message}"
+    format: "%{attribute}%{message}"
     messages:
       accepted: 一定要被接受
       blank: 唔可以空白
-      confirmation: 與 %{attribute} 唔夾
+      confirmation: 與%{attribute}唔夾
       empty: 唔可以漏空
-      equal_to: 要等於 %{count}
+      equal_to: 要等於%{count}
       even: 要係雙數
       exclusion: 唔用得
       greater_than: 要大過%{count}
@@ -131,14 +131,14 @@ zh-YUE:
       required: 必須存在
       taken: 已經用緊
       too_long:
-        one: 太長（最多 1 個字）
-        other: 太長（最多 %{count} 個字）
+        one: 太長（最多1個字）
+        other: 太長（最多%{count}個字）
       too_short:
-        one: 太短（最少 1 個字）
-        other: 太短（最少 %{count} 個字）
+        one: 太短（最少1個字）
+        other: 太短（最少%{count}個字）
       wrong_length:
-        one: 唔啱字數 (要係 1 個字)
-        other: 唔啱字數 (要係 %{count} 個字)
+        one: 唔啱字數（要係1個字）
+        other: 唔啱字數（要係%{count}個字）
     template:
       body: 呢啲有問題︰
       header:
@@ -201,7 +201,7 @@ zh-YUE:
         delimiter: ''
   support:
     array:
-      last_word_connector: 同
+      last_word_connector: "、"
       two_words_connector: 同
       words_connector: "、"
   time:


### PR DESCRIPTION
This PR applies some standardization to the various Chinese locales. Before this PR, the files were not internally consistent; each file contained _multiple variants_ of the below:

1. Remove most whitespaces. Chinese in general does not use spaces, even around numbers.
2. Use double-width colons and parentheses chars consistently.
3. Use double-width enumeration comma for list delimiter, and use it as last_word_connector.

I have followed the rules here closely: https://en.wikipedia.org/wiki/Chinese_punctuation