### PR TITLE
Arabic: fix ar.errors.messages.greater_than typo

### DIFF
--- a/rails/locale/ar.yml
+++ b/rails/locale/ar.yml
@@ -157,7 +157,7 @@ ar:
       equal_to: يجب أن يساوي طول %{attribute} %{count}
       even: يجب أن يكون عدد %{attribute} زوجياً
       exclusion: حقل %{attribute} محجوز
-      greater_than: ميجب أن يكون عدد %{attribute} أكبر من %{count}
+      greater_than: يجب أن يكون عدد %{attribute} أكبر من %{count}
       greater_than_or_equal_to: يجب أن يكون عدد %{attribute} أكبر أو يساوي %{count}
       inclusion: "%{attribute} غير وارد في القائمة"
       invalid: محتوى %{attribute} غير صالح


### PR DESCRIPTION
Fixing an Arabic word typo in ar.yml
it should be `يجب` instead of `ميجب`