### PR TITLE
Adds ordinal translation for spanish, portuguese and german.

### DIFF
--- a/rails/ordinals/de-AT.rb
+++ b/rails/ordinals/de-AT.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+{
+  :"de-AT" => {
+    :ordinal => proc { |number| "#{number}." }
+  }
+}

--- a/rails/ordinals/de-CH.rb
+++ b/rails/ordinals/de-CH.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+{
+  :"de-CH" => {
+    :ordinal => proc { |number| "#{number}." }
+  }
+}

--- a/rails/ordinals/de-DE.rb
+++ b/rails/ordinals/de-DE.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+{
+  :"de-DE" => {
+    :ordinal => proc { |number| "#{number}." }
+  }
+}

--- a/rails/ordinals/de.rb
+++ b/rails/ordinals/de.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+{
+  :de => {
+    :ordinal => proc { |number| "#{number}." }
+  }
+}

--- a/rails/ordinals/es-419.rb
+++ b/rails/ordinals/es-419.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+{
+  "es-419": {
+    number: {
+      nth: {
+        ordinals: lambda do |_key, number:, **_options|
+          abs_number = number.to_i.abs
+          "º"
+        end,
+
+        ordinalized: lambda do |_key, number:, **_options|
+          "#{number}#{ActiveSupport::Inflector.ordinal(number)}"
+        end
+      }
+    }
+  }
+}

--- a/rails/ordinals/es-AR.rb
+++ b/rails/ordinals/es-AR.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+{
+  "es-AR": {
+    number: {
+      nth: {
+        ordinals: lambda do |_key, number:, **_options|
+          abs_number = number.to_i.abs
+          "º"
+        end,
+
+        ordinalized: lambda do |_key, number:, **_options|
+          "#{number}#{ActiveSupport::Inflector.ordinal(number)}"
+        end
+      }
+    }
+  }
+}

--- a/rails/ordinals/es-CL.rb
+++ b/rails/ordinals/es-CL.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+{
+  "es-CL": {
+    number: {
+      nth: {
+        ordinals: lambda do |_key, number:, **_options|
+          abs_number = number.to_i.abs
+          "º"
+        end,
+
+        ordinalized: lambda do |_key, number:, **_options|
+          "#{number}#{ActiveSupport::Inflector.ordinal(number)}"
+        end
+      }
+    }
+  }
+}

--- a/rails/ordinals/es-CO.rb
+++ b/rails/ordinals/es-CO.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+{
+  "es-CO": {
+    number: {
+      nth: {
+        ordinals: lambda do |_key, number:, **_options|
+          abs_number = number.to_i.abs
+          "º"
+        end,
+
+        ordinalized: lambda do |_key, number:, **_options|
+          "#{number}#{ActiveSupport::Inflector.ordinal(number)}"
+        end
+      }
+    }
+  }
+}

--- a/rails/ordinals/es-CR.rb
+++ b/rails/ordinals/es-CR.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+{
+  "es-CR": {
+    number: {
+      nth: {
+        ordinals: lambda do |_key, number:, **_options|
+          abs_number = number.to_i.abs
+          "º"
+        end,
+
+        ordinalized: lambda do |_key, number:, **_options|
+          "#{number}#{ActiveSupport::Inflector.ordinal(number)}"
+        end
+      }
+    }
+  }
+}

--- a/rails/ordinals/es-EC.rb
+++ b/rails/ordinals/es-EC.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+{
+  "es-EC": {
+    number: {
+      nth: {
+        ordinals: lambda do |_key, number:, **_options|
+          abs_number = number.to_i.abs
+          "º"
+        end,
+
+        ordinalized: lambda do |_key, number:, **_options|
+          "#{number}#{ActiveSupport::Inflector.ordinal(number)}"
+        end
+      }
+    }
+  }
+}

--- a/rails/ordinals/es-ES.rb
+++ b/rails/ordinals/es-ES.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+{
+  "es-ES": {
+    number: {
+      nth: {
+        ordinals: lambda do |_key, number:, **_options|
+          abs_number = number.to_i.abs
+          "º"
+        end,
+
+        ordinalized: lambda do |_key, number:, **_options|
+          "#{number}#{ActiveSupport::Inflector.ordinal(number)}"
+        end
+      }
+    }
+  }
+}

--- a/rails/ordinals/es-MX.rb
+++ b/rails/ordinals/es-MX.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+{
+  "es-MX": {
+    number: {
+      nth: {
+        ordinals: lambda do |_key, number:, **_options|
+          abs_number = number.to_i.abs
+          "º"
+        end,
+
+        ordinalized: lambda do |_key, number:, **_options|
+          "#{number}#{ActiveSupport::Inflector.ordinal(number)}"
+        end
+      }
+    }
+  }
+}

--- a/rails/ordinals/es-NI.rb
+++ b/rails/ordinals/es-NI.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+{
+  "es-NI": {
+    number: {
+      nth: {
+        ordinals: lambda do |_key, number:, **_options|
+          abs_number = number.to_i.abs
+          "º"
+        end,
+
+        ordinalized: lambda do |_key, number:, **_options|
+          "#{number}#{ActiveSupport::Inflector.ordinal(number)}"
+        end
+      }
+    }
+  }
+}

--- a/rails/ordinals/es-PA.rb
+++ b/rails/ordinals/es-PA.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+{
+  "es-PA": {
+    number: {
+      nth: {
+        ordinals: lambda do |_key, number:, **_options|
+          abs_number = number.to_i.abs
+          "º"
+        end,
+
+        ordinalized: lambda do |_key, number:, **_options|
+          "#{number}#{ActiveSupport::Inflector.ordinal(number)}"
+        end
+      }
+    }
+  }
+}

--- a/rails/ordinals/es-PE.rb
+++ b/rails/ordinals/es-PE.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+{
+  "es-PE": {
+    number: {
+      nth: {
+        ordinals: lambda do |_key, number:, **_options|
+          abs_number = number.to_i.abs
+          "º"
+        end,
+
+        ordinalized: lambda do |_key, number:, **_options|
+          "#{number}#{ActiveSupport::Inflector.ordinal(number)}"
+        end
+      }
+    }
+  }
+}

--- a/rails/ordinals/es-US.rb
+++ b/rails/ordinals/es-US.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+{
+  "es-US": {
+    number: {
+      nth: {
+        ordinals: lambda do |_key, number:, **_options|
+          abs_number = number.to_i.abs
+          "º"
+        end,
+
+        ordinalized: lambda do |_key, number:, **_options|
+          "#{number}#{ActiveSupport::Inflector.ordinal(number)}"
+        end
+      }
+    }
+  }
+}

--- a/rails/ordinals/es-VE.rb
+++ b/rails/ordinals/es-VE.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+{
+  "es-VE": {
+    number: {
+      nth: {
+        ordinals: lambda do |_key, number:, **_options|
+          abs_number = number.to_i.abs
+          "º"
+        end,
+
+        ordinalized: lambda do |_key, number:, **_options|
+          "#{number}#{ActiveSupport::Inflector.ordinal(number)}"
+        end
+      }
+    }
+  }
+}

--- a/rails/ordinals/es.rb
+++ b/rails/ordinals/es.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+{
+  es: {
+    number: {
+      nth: {
+        ordinals: lambda do |_key, number:, **_options|
+          abs_number = number.to_i.abs
+          "º"
+        end,
+
+        ordinalized: lambda do |_key, number:, **_options|
+          "#{number}#{ActiveSupport::Inflector.ordinal(number)}"
+        end
+      }
+    }
+  }
+}

--- a/rails/ordinals/fr-CA.rb
+++ b/rails/ordinals/fr-CA.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 {
   "fr-CA": {
     number: {

--- a/rails/ordinals/fr-CH.rb
+++ b/rails/ordinals/fr-CH.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 {
   "fr-CH": {
     number: {

--- a/rails/ordinals/fr-FR.rb
+++ b/rails/ordinals/fr-FR.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 {
   "fr-FR": {
     number: {

--- a/rails/ordinals/fr.rb
+++ b/rails/ordinals/fr.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 {
   fr: {
     number: {

--- a/rails/ordinals/pt-BR.rb
+++ b/rails/ordinals/pt-BR.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+{
+  "pt-BR": {
+    number: {
+      nth: {
+        ordinals: lambda do |_key, number:, **_options|
+          abs_number = number.to_i.abs
+          "º"
+        end,
+
+        ordinalized: lambda do |_key, number:, **_options|
+          "#{number}#{ActiveSupport::Inflector.ordinal(number)}"
+        end
+      }
+    }
+  }
+}

--- a/rails/ordinals/pt.rb
+++ b/rails/ordinals/pt.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+{
+  pt: {
+    number: {
+      nth: {
+        ordinals: lambda do |_key, number:, **_options|
+          abs_number = number.to_i.abs
+          "º"
+        end,
+
+        ordinalized: lambda do |_key, number:, **_options|
+          "#{number}#{ActiveSupport::Inflector.ordinal(number)}"
+        end
+      }
+    }
+  }
+}

--- a/spec/unit/ordinals_spec.rb
+++ b/spec/unit/ordinals_spec.rb
@@ -15,7 +15,7 @@ describe 'Ordinals for' do
 
   describe 'French' do
     it 'uses the custom rules' do
-      %w[fr fr-CA fr-CH fr-FR ].each do |locale|
+      %i[fr fr-CA fr-CH fr-FR].each do |locale|
         I18n.with_locale(locale) do
           ActiveSupport::Inflector.ordinalize(1).should == "1er"
           ActiveSupport::Inflector.ordinalize(2).should == "2e"
@@ -31,6 +31,44 @@ describe 'Ordinals for' do
         ActiveSupport::Inflector.ordinalize(1).should == "1st"
         ActiveSupport::Inflector.ordinalize(2).should == "2nd"
         ActiveSupport::Inflector.ordinalize(3).should == "3rd"
+      end
+    end
+  end
+
+  describe 'Spanish' do
+    it 'uses the custom rules' do
+      %i[es es-419 es-AR es-CL es-CO es-CR es-EC es-ES es-MX es-NI es-PA es-PE es-US es-VE].each do |locale|
+        I18n.with_locale(locale) do
+          ActiveSupport::Inflector.ordinalize(1).should == "1º"
+          ActiveSupport::Inflector.ordinalize(2).should == "2º"
+          ActiveSupport::Inflector.ordinalize(3).should == "3º"
+        end
+      end
+    end
+  end
+
+  describe 'Portuguese' do
+    it 'uses the custom rules' do
+      %i[pt pt-BR].each do |locale|
+        I18n.with_locale(locale) do
+          ActiveSupport::Inflector.ordinalize(1).should == "1º"
+          ActiveSupport::Inflector.ordinalize(2).should == "2º"
+          ActiveSupport::Inflector.ordinalize(3).should == "3º"
+        end
+      end
+    end
+  end
+
+  describe 'German' do
+    it 'uses the custom rules' do
+
+
+      %i[de-AT de-CH de-DE de].each do |locale|
+        I18n.with_locale(locale) do
+          ActiveSupport::Inflector.ordinalize(1).should == "1."
+          ActiveSupport::Inflector.ordinalize(2).should == "2."
+          ActiveSupport::Inflector.ordinalize(3).should == "3."
+        end
       end
     end
   end


### PR DESCRIPTION
For spanish, adds a º to right of the number.
For portuguese, adds a º to right of the number.
For german, adds a . to right of the number.

Also added `# frozen_string_literal: true` to existing files, as it is done on the rails codebase to convert the keys to symbols.