### PR TITLE
French (fr, fr-CA, fr-CH, fr-CA) : change an abreviation for March month in abbr_month_names

### DIFF
--- a/rails/locale/fr-CA.yml
+++ b/rails/locale/fr-CA.yml
@@ -22,7 +22,7 @@ fr-CA:
     - 
     - jan.
     - fév.
-    - mar.
+    - mars
     - avr.
     - mai
     - juin

--- a/rails/locale/fr-CH.yml
+++ b/rails/locale/fr-CH.yml
@@ -22,7 +22,7 @@ fr-CH:
     - 
     - jan.
     - fév.
-    - mar.
+    - mars
     - avr.
     - mai
     - juin

--- a/rails/locale/fr-FR.yml
+++ b/rails/locale/fr-FR.yml
@@ -22,7 +22,7 @@ fr-FR:
     - 
     - jan.
     - fév.
-    - mar.
+    - mars
     - avr.
     - mai
     - juin

--- a/rails/locale/fr.yml
+++ b/rails/locale/fr.yml
@@ -22,7 +22,7 @@ fr:
     - 
     - jan.
     - fév.
-    - mar.
+    - mars
     - avr.
     - mai
     - juin


### PR DESCRIPTION
Because `Mars` is not supposed to be abbreviated in french, as for `Mai`, `Juin` and `Août`