### PR TITLE
thor locales: fix list_locales to list all locales

### DIFF
--- a/locales.thor
+++ b/locales.thor
@@ -107,12 +107,10 @@ class Locales < Thor
 
   desc 'list_locales', 'List all locales'
   def list_locales
-    locales = []
-    Dir.glob(File.dirname(__FILE__) + '/rails/locale/*.{rb,yml}') do |filename|
-      if md = filename.match(/([\w\-]+)\.(rb|yml)$/)
-        locales << md[1]
-      end
-    end
+    path_to_locales = 'rails/locale'
+    Dir.chdir(path_to_locales)
+    locale_files = Dir.glob('**/*.yml')
+    locales = locale_files.map{ |f| File.basename(f, '.yml') }
     return locales.sort
   end
 


### PR DESCRIPTION
Fixes #1013
list_locales now also lists locales in the iso-639-2 sub-directory