### PR TITLE
feat: module initialization options

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,31 @@ Note that your Ruby on Rails version must be 3.0 or higher in order to install t
 
 ## Configuration
 
+### Enabled modules
+
+By default, all `rails-i18n` modules (locales, pluralization, transliteration, ordinals) are enabled.
+
+If you would like to only enable specific modules, you can do so in your Rails configuration:
+
+```ruby
+# to enable only pluralization rules, but disable all other features
+config.rails_i18n.enabled_modules = [:pluralization]
+
+# to enable pluralization and ordinals
+config.rails_i18n.enabled_modules = [:pluralization, :ordinals]
+```
+
+The possible module names:
+
+* `:locale`
+* `:ordinals`
+* `:pluralization`
+* `:transliteration`
+
+Setting `enabled_modules` will restrict the gem's loaded features to only the specific types.
+
+### Available locales
+
 `rails-i18n` gem initially loads all available locale files, pluralization and transliteration rules. This default behaviour can be changed. If you specify in `config/environments/*` the locales which have to be loaded via `I18n.available_locales` option:
 
 ``` ruby

--- a/lib/rails_i18n.rb
+++ b/lib/rails_i18n.rb
@@ -1,1 +1,11 @@
+module RailsI18n
+  def self.enabled_modules
+    @enabled_modules ||= Set.new
+  end
+
+  def self.enabled_modules=(other)
+    @enabled_modules = Set.new(other)
+  end
+end
+
 require 'rails_i18n/railtie'

--- a/lib/rails_i18n/railtie.rb
+++ b/lib/rails_i18n/railtie.rb
@@ -2,14 +2,19 @@ require 'rails'
 
 module RailsI18n
   class Railtie < ::Rails::Railtie #:nodoc:
+    config.rails_i18n = RailsI18n
+
     initializer 'rails-i18n' do |app|
       RailsI18n::Railtie.instance_eval do
         pattern = pattern_from app.config.i18n.available_locales
 
-        add("rails/locale/#{pattern}.yml")
-        add("rails/pluralization/#{pattern}.rb")
-        add("rails/ordinals/#{pattern}.rb")
-        add("rails/transliteration/#{pattern}.{rb,yml}")
+        if app.config.rails_i18n.enabled_modules.empty?
+          RailsI18n.enabled_modules = Set.new([:locale, :pluralization, :ordinals, :transliteration])
+        end
+
+        RailsI18n.enabled_modules.each do |feature|
+          add("rails/#{feature}/#{pattern}.{rb,yml}")
+        end
 
         init_pluralization_module
       end

--- a/spec/unit/ordinals_spec.rb
+++ b/spec/unit/ordinals_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
-require 'rails_i18n/railtie'
+require 'rails_i18n'
 
 describe 'Ordinals for' do
   # Mock Rails app in order to trigger the Railtie
   let(:app) { double :app, config: config }
-  let(:config) { double :config, eager_load_namespaces: [], i18n: I18n }
+  let(:config) { double :config, eager_load_namespaces: [], i18n: I18n, rails_i18n: RailsI18n }
 
   before do
     I18n.available_locales = %w[fr en fr-CA fr-CH fr-FR]


### PR DESCRIPTION
Allows the separate features of the gem to be selectively enabled. This allows an app to use only the pluralization rules, for example, and not the locale rules.

On my team, we have our own locale formatting rules that we want to keep using. However, we also want to add pluralization rules. We would like to use this gem to provide the pluralization rules, but we don't need the other parts of the gem. While we could manually add the appropriate files from this gem to the I18n load path, it would be nicer if the gem allowed us to configure which features we want to use.

The module names are just taken from the names of the directories passed to `add`. So `rails/locale` gets added if the `:locale` module is enabled.

Users would configure the gem in their `config/application.rb` like

```ruby
config.rails_i18n.enabled_modules = [:pluralization]
```

If they don't configure anything (the default) then the gem adds all features to the enabled list and functions as before. This ensures backwards compatibility.