### PR TITLE
README: Document locales without pluralization

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,11 @@ af, ar, az, be, bg, bn, bs, ca, cs, csb, da, de, de-AT, de-CH, de-DE, dsb, el, e
 
 **Complete locales:**
 
-af, da, de, de-AT, de-CH, de-DE, en-US, es, es-419, es-AR, es-CL, es-CO, es-CR, es-EC, es-ES, es-MX, es-NI, es-PA, es-PE, es-US, es-VE, et, fa, fr, fr-CA, fr-CH, fr-FR, fy, id, it, ja, ka, ml, nb, nl, nn, pt, pt-BR, sv, sv-SE, tr, zh-CN, zh-HK, zh-TW, zh-YUE, uk
+da, de, de-AT, de-CH, de-DE, en-US, es, es-419, es-AR, es-CL, es-CO, es-CR, es-EC, es-ES, es-MX, es-NI, es-PA, es-PE, es-US, es-VE, et, fa, fr, fr-CA, fr-CH, fr-FR, fy, id, it, ja, ka, ml, nb, nl, nn, pt, pt-BR, sv, sv-SE, tr, zh-CN, zh-HK, zh-TW, zh-YUE, uk
+
+**Locales with missing pluralization rules**
+
+af, csb, dsb, fur, gsw-CH, lb, rm, scr, sq, te, tt, ug, uz
 
 **Removed locales:**
 


### PR DESCRIPTION
- added section to README to list the locales with missing pluralization
- removed **ad** from list of complete locales since it is missing a pluralization file