### PR TITLE
Update gl.yml, "incluído" missing accent in gl.

### DIFF
--- a/rails/locale/gl.yml
+++ b/rails/locale/gl.yml
@@ -10,7 +10,7 @@ gl:
     - Ven
     - Sab
     abbr_month_names:
-    -
+    - 
     - Xan
     - Feb
     - Mar
@@ -36,7 +36,7 @@ gl:
       long: "%A %e de %B de %Y"
       short: "%e %b"
     month_names:
-    -
+    - 
     - Xaneiro
     - Febreiro
     - Marzo

--- a/rails/locale/gl.yml
+++ b/rails/locale/gl.yml
@@ -10,7 +10,7 @@ gl:
     - Ven
     - Sab
     abbr_month_names:
-    - 
+    -
     - Xan
     - Feb
     - Mar
@@ -36,7 +36,7 @@ gl:
       long: "%A %e de %B de %Y"
       short: "%e %b"
     month_names:
-    - 
+    -
     - Xaneiro
     - Febreiro
     - Marzo
@@ -101,7 +101,7 @@ gl:
       exclusion: xa existe
       greater_than: debe ser maior que %{count}
       greater_than_or_equal_to: debe ser maior ou igual que %{count}
-      inclusion: non está incluido na lista
+      inclusion: non está incluído na lista
       invalid: non é válido
       less_than: debe ser menor que %{count}
       less_than_or_equal_to: debe ser menor ou igual que %{count}


### PR DESCRIPTION
- Incluido [participle without accent does not exist](https://academia.gal/dicionario/-/termo/busca/incluir), press "Conxugar" first form of "Participio" is "incluído".