### PR TITLE
Add missing keys for `in` and `round_mode` in FR locales

### DIFF
--- a/rails/locale/fr-CA.yml
+++ b/rails/locale/fr-CA.yml
@@ -169,6 +169,7 @@ fr-CA:
     format:
       delimiter: " "
       precision: 3
+      round_mode: default
       separator: ","
       significant: false
       strip_insignificant_zeros: false

--- a/rails/locale/fr-CA.yml
+++ b/rails/locale/fr-CA.yml
@@ -122,6 +122,7 @@ fr-CA:
       exclusion: n'est pas disponible
       greater_than: doit être supérieur à %{count}
       greater_than_or_equal_to: doit être supérieur ou égal à %{count}
+      in: doit être dans l'intervalle %{count}
       inclusion: n'est pas inclus(e) dans la liste
       invalid: n'est pas valide
       less_than: doit être inférieur à %{count}

--- a/rails/locale/fr-CH.yml
+++ b/rails/locale/fr-CH.yml
@@ -169,6 +169,7 @@ fr-CH:
     format:
       delimiter: "'"
       precision: 3
+      round_mode: default
       separator: "."
       significant: false
       strip_insignificant_zeros: false

--- a/rails/locale/fr-CH.yml
+++ b/rails/locale/fr-CH.yml
@@ -122,6 +122,7 @@ fr-CH:
       exclusion: n'est pas disponible
       greater_than: doit être supérieur à %{count}
       greater_than_or_equal_to: doit être supérieur ou égal à %{count}
+      in: doit être dans l'intervalle %{count}
       inclusion: n'est pas inclus(e) dans la liste
       invalid: n'est pas valide
       less_than: doit être inférieur à %{count}

--- a/rails/locale/fr-FR.yml
+++ b/rails/locale/fr-FR.yml
@@ -122,6 +122,7 @@ fr-FR:
       exclusion: n'est pas disponible
       greater_than: doit être supérieur à %{count}
       greater_than_or_equal_to: doit être supérieur ou égal à %{count}
+      in: doit être dans l'intervalle %{count}
       inclusion: n'est pas inclus(e) dans la liste
       invalid: n'est pas valide
       less_than: doit être inférieur à %{count}

--- a/rails/locale/fr-FR.yml
+++ b/rails/locale/fr-FR.yml
@@ -169,6 +169,7 @@ fr-FR:
     format:
       delimiter: " "
       precision: 3
+      round_mode: default
       separator: ","
       significant: false
       strip_insignificant_zeros: false

--- a/rails/locale/fr.yml
+++ b/rails/locale/fr.yml
@@ -169,6 +169,7 @@ fr:
     format:
       delimiter: " "
       precision: 3
+      round_mode: default
       separator: ","
       significant: false
       strip_insignificant_zeros: false

--- a/rails/locale/fr.yml
+++ b/rails/locale/fr.yml
@@ -122,6 +122,7 @@ fr:
       exclusion: n'est pas disponible
       greater_than: doit être supérieur à %{count}
       greater_than_or_equal_to: doit être supérieur ou égal à %{count}
+      in: doit être dans l'intervalle %{count}
       inclusion: n'est pas inclus(e) dans la liste
       invalid: n'est pas valide
       less_than: doit être inférieur à %{count}


### PR DESCRIPTION
Add missing keys: `errors.messages.in` and `number.format.round_mode` to fr.yml,  fr_FR.yml,  fr_CA.yml and fr_CA.yml

Related to #1034 for French locales