### PR TITLE
Punjabi Gurmukhi minor corrections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## unreleased
 
+- Punjabi Gurmukhi (pa): typographical corrections, native large number names, unit expansion, removal of Oxford comma #1049
 - French (fr, fr-CA, fr-CH, fr-CA): change an abreviation for March month in abbr_month_names #1002
 
 ## 7.0.5 (2022-07-03)

--- a/rails/locale/pa.yml
+++ b/rails/locale/pa.yml
@@ -9,10 +9,10 @@ pa:
           has_many: ਮਿਟਾ ਨਹੀਂ ਸਕਦੇ ਕਿਉਂਕਿ ਨਿਰਭਰ %{record} ਮੌਜੂਦ ਹਨ
   date:
     abbr_day_names:
-    - ਅੈਤ
+    - ਐਤ
     - ਸੋਮ
     - ਮੰਗਲ
-    - ਬੱੁਧ
+    - ਬੁੱਧ
     - ਵੀਰ
     - ਸ਼ੁੱਕਰ
     - ਸ਼ਨਿੱਚਰ
@@ -63,38 +63,38 @@ pa:
   datetime:
     distance_in_words:
       about_x_hours:
-        one: ਲਗਭਗ 1 ਘੰਟਾ
+        one: ਲਗਭਗ ਇੱਕ ਘੰਟਾ
         other: ਲਗਭਗ %{count} ਘੰਟੇ
       about_x_months:
-        one: ਲਗਭਗ 1 ਮਹੀਨਾ
+        one: ਲਗਭਗ ਇੱਕ ਮਹੀਨਾ
         other: ਲਗਭਗ %{count} ਮਹੀਨੇ
       about_x_years:
-        one: ਲਗਭਗ 1 ਸਾਲ
+        one: ਲਗਭਗ ਇੱਕ ਸਾਲ
         other: ਲਗਭਗ %{count} ਸਾਲ
       almost_x_years:
-        one: ਤਕਰੀਬਨ 1 ਸਾਲ
+        one: ਤਕਰੀਬਨ ਇੱਕ ਸਾਲ
         other: ਤਕਰੀਬਨ %{count} ਸਾਲ
       half_a_minute: ਅੱਧਾ ਮਿੰਟ
       less_than_x_seconds:
-        one: 1 ਸਕਿੰਟ ਤੋਂ ਘੱਟ
+        one: ਇੱਕ ਸਕਿੰਟ ਤੋਂ ਘੱਟ
         other: "%{count} ਸਕਿੰਟਾਂ ਤੋਂ ਘੱਟ"
       less_than_x_minutes:
-        one: 1 ਮਿੰਟ ਤੋਂ ਘੱਟ
+        one: ਇੱਕ ਮਿੰਟ ਤੋਂ ਘੱਟ
         other: "%{count} ਮਿੰਟਾਂ ਤੋਂ ਘੱਟ"
       over_x_years:
-        one: 1 ਸਾਲ ਤੋਂ ਵੱਧ
+        one: ਇੱਕ ਸਾਲ ਤੋਂ ਵੱਧ
         other: "%{count} ਸਾਲਾਂ ਤੋਂ ਵੱਧ"
       x_seconds:
-        one: 1 ਸਕਿੰਟ
+        one: ਇੱਕ ਸਕਿੰਟ
         other: "%{count} ਸਕਿੰਟ"
       x_minutes:
-        one: 1 ਮਿੰਟ
+        one: ਇੱਕ ਮਿੰਟ
         other: "%{count} ਮਿੰਟ"
       x_days:
-        one: 1 ਦਿਨ
+        one: ਇੱਕ ਦਿਨ
         other: "%{count} ਦਿਨ"
       x_months:
-        one: 1 ਮਹੀਨਾ
+        one: ਇੱਕ ਮਹੀਨਾ
         other: "%{count} ਮਹੀਨੇ"
     prompts:
       second: ਸਕਿੰਟ
@@ -106,39 +106,39 @@ pa:
   errors:
     format: "%{attribute} %{message}"
     messages:
-      accepted: ਜਰੂਰ ਮੰਜੂਰ ਹੋਵੇ
+      accepted: ਜ਼ਰੂਰ ਮੰਜ਼ੂਰ ਹੋਵੇ
       blank: ਖਾਲੀ ਨਹੀਂ ਹੋ ਸਕਦਾ
       confirmation: "%{attribute} ਨਹੀਂ ਰਲਦੇ"
       empty: ਖਾਲੀ ਨਹੀਂ ਹੋ ਸਕਦਾ
       equal_to: "%{count} ਦੇ ਬਰਾਬਰ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ"
-      even: ਜਰੂਰੀ ਹੈ ਕੇ ਜੋਟਾ ਹੋਵੇ
+      even: ਜ਼ਰੂਰੀ ਹੈ ਕੇ ਜੋਟਾ ਹੋਵੇ
       exclusion: ਮੱਲਿਆ ਹੋਇਆ ਹੈ
-      greater_than: "%{count} ਤੋਂ ਵਧੇਰੇ ਹੋਣਾ ਜਰੂਰੀ ਹੈ"
-      greater_than_or_equal_to: "%{count} ਤੋਂ ਵਧੇਰੇ ਜਾਂ ਬਰਾਬਰ ਹੋਣਾ ਜਰੂਰੀ ਹੈ"
+      greater_than: "%{count} ਤੋਂ ਵਧੇਰੇ ਹੋਣਾ ਜ਼ਰੂਰੀ ਹੈ"
+      greater_than_or_equal_to: "%{count} ਤੋਂ ਵਧੇਰੇ ਜਾਂ ਬਰਾਬਰ ਹੋਣਾ ਜ਼ਰੂਰੀ ਹੈ"
       inclusion: ਇਸ ਲਿਸਟ ਵਿੱਚ ਸ਼ਾਮਿਲ ਨਹੀਂ ਹੈ
       invalid: ਨਾ-ਮੰਜੂਰਸ਼ੁਦਾ ਹੈ
-      less_than: "%{count} ਤੋਂ ਘੱਟ ਹੋਣਾ ਜਰੂਰੀ ਹੈ"
-      less_than_or_equal_to: "%{count} ਤੋਂ ਘੱਟ ਜਾਂ ਬਰਾਬਰ ਹੋਣਾ ਜਰੂਰੀ ਹੈ"
+      less_than: "%{count} ਤੋਂ ਘੱਟ ਹੋਣਾ ਜ਼ਰੂਰੀ ਹੈ"
+      less_than_or_equal_to: "%{count} ਤੋਂ ਘੱਟ ਜਾਂ ਬਰਾਬਰ ਹੋਣਾ ਜ਼ਰੂਰੀ ਹੈ"
       not_a_number: ਸੰਖਿਆ ਨਹੀਂ ਹੈ
-      not_an_integer: ਜਰੂਰੀ ਹੈ ਕੇ ਪੂਰਨ ਅੰਕ ਹੋਵੇ
-      odd: ਜਰੂਰੀ ਹੈ ਕੇ ਕਲ਼ੀ ਹੋਵੇ
+      not_an_integer: ਜ਼ਰੂਰੀ ਹੈ ਕੇ ਪੂਰਨ ਅੰਕ ਹੋਵੇ
+      odd: ਜ਼ਰੂਰੀ ਹੈ ਕੇ ਕਲ਼ੀ ਹੋਵੇ
       other_than: "%{count} ਦੀ ਜਗ੍ਹਾ ਹੋਰ ਹੋਣੀ ਚਾਹੀਦੀ ਹੈ"
-      present: ਜਰੂਰ ਖਾਲੀ ਹੋਵੇ
+      present: ਜ਼ਰੂਰ ਖਾਲੀ ਹੋਵੇ
       taken: ਪਹਿਲਾਂ ਹੀ ਮੱਲਿਆ ਹੋਇਆ ਹੈ
       too_long:
-        one: ਲੰਬਾਈ ਜ਼ਿਆਦਾ ਹੈ (ਵੱਧ ਤੋਂ ਵੱਧ 1 ਅੱਖਰ)
+        one: ਲੰਬਾਈ ਜ਼ਿਆਦਾ ਹੈ (ਵੱਧ ਤੋਂ ਵੱਧ ਇੱਕ ਅੱਖਰ)
         other: ਲੰਬਾਈ ਜ਼ਿਆਦਾ ਹੈ (ਵੱਧ ਤੋਂ ਵੱਧ %{count} ਅੱਖਰ)
       too_short:
-        one: ਲੰਬਾਈ ਘੱਟ ਹੈ (ਘੱਟ ਤੋਂ ਘੱਟ 1 ਅੱਖਰ)
+        one: ਲੰਬਾਈ ਘੱਟ ਹੈ (ਘੱਟ ਤੋਂ ਘੱਟ ਇੱਕ ਅੱਖਰ)
         other: ਲੰਬਾਈ ਘੱਟ ਹੈ (ਘੱਟ ਤੋਂ ਘੱਟ %{count} ਅੱਖਰ)
       wrong_length:
-        one: ਲੰਬਾਈ ਗਲਤ ਹੈ (1 ਅੱਖਰ ਹੋਣੀ ਚਾਹੀਦੀ ਹੈ)
+        one: ਲੰਬਾਈ ਗਲਤ ਹੈ (ਇੱਕ ਅੱਖਰ ਹੋਣੀ ਚਾਹੀਦੀ ਹੈ)
         other: ਲੰਬਾਈ ਗਲਤ ਹੈ (%{count} ਅੱਖਰ ਹੋਣੀ ਚਾਹੀਦੀ ਹੈ)
     template:
       body: 'ਹੇਠਲੇ ਖੇਤਰਾਂ ਵਿੱਚ ਗਲਤੀਆਂ ਹਨ:'
       header:
-        one: 1 ਗਲਤੀ ਕਰਕੇ ਇਹ %{model} ਸੰਭਾਲਿ਼ਆ ਨਹੀਂ ਗਿਆ
-        other: "%{count} ਗਲਤੀਆਂ ਕਰਕੇ ਇਹ %{model} ਸੰਭਾਲਿ਼ਆ ਨਹੀਂ ਗਿਆ"
+        one: ਇੱਕ ਗਲਤੀ ਕਰਕੇ ਇਹ %{model} ਸੰਭਾਲ਼ਿਆ ਨਹੀਂ ਗਿਆ
+        other: "%{count} ਗਲਤੀਆਂ ਕਰਕੇ ਇਹ %{model} ਸੰਭਾਲ਼ਿਆ ਨਹੀਂ ਗਿਆ"
   helpers:
     select:
       prompt: ਕਿਰਪਾ ਕਰਕੇ ਚੁਣੋ
@@ -155,7 +155,7 @@ pa:
         separator: "."
         significant: false
         strip_insignificant_zeros: false
-        unit: "$"
+        unit: "₹"
     format:
       delimiter: ","
       precision: 3
@@ -166,11 +166,11 @@ pa:
       decimal_units:
         format: "%n %u"
         units:
-          billion: ਬਿਲੀਅਨ
-          million: ਮਿਲੀਅਨ
-          quadrillion: ਕ੍ਵਾਡਰਿਲੀਅਨ
+          billion: ਦਸ ਕਰੋੜ
+          million: ਦਸ ਲੱਖ
+          quadrillion: ਲੱਖ ਅਰਬ
           thousand: ਹਜ਼ਾਰ
-          trillion: ਟ੍ਰਿਲੀਅਨ
+          trillion: ਸੌ ਅਰਬ
           unit: ''
       format:
         delimiter: ''
@@ -183,10 +183,10 @@ pa:
           byte:
             one: ਬਾਈਟ
             other: ਬਾਈਟ
-          gb: GB
-          kb: KB
-          mb: MB
-          tb: TB
+          gb: ਗਿਗਾ ਬਾਈਟ
+          kb: ਕਿਲੋ ਬਾਈਟ
+          mb: ਮੈਗਾ ਬਾਈਟ
+          tb: ਟੈਰਾ ਬਾਈਟ
     percentage:
       format:
         delimiter: ''
@@ -196,7 +196,7 @@ pa:
         delimiter: ''
   support:
     array:
-      last_word_connector: ", ਅਤੇ "
+      last_word_connector: " ਅਤੇ "
       two_words_connector: " ਅਤੇ "
       words_connector: ", "
   time:


### PR DESCRIPTION
Punjabi Gurmukhi adjustments (Gurmukhi being the script used in India - I will submit a PR for Punjabi Shahmukhi `pnb` / `pa-PK`, the script used in Pakistan, soon)

Notes on the changes:

* Correction to order of attaching characters and diacritics, as well as addition of nukta 'dots' to words like ਜ਼ਰੂਰੀ where their typical spelling and pronunciation warrants their distinction. ਅੈ and ਬੱੁ render incorrectly in most fonts, including the fonts used on GitHub, so these are the most important fixes of this kind.

* The words for all the large numbers except 1000 were transliterations of the English, but there are Punjabi words for these numbers so I changed them to these. "Quadrillion" is particularly hard to pronounce in Punjabi as it involves multiple sounds which do not exist in the language.

* Used ਇੱਕ instead of 1 where applicable. This was already done in the first string, and I noticed this is done already in the Urdu locale as well (Urdu having the same word for one, just in a different script). The main reason for this is that multiple numeral systems may be used with Punjabi, so if the application allows the rendering of ੨ rather than 2, it would look strange for 1 to always only be 1.

* Translated the file size units to full words. This just makes things a little more cohesive; although the day/month abbreviations in this context are fine, abbreviations are only used sparingly in Punjabi if at all, and it is common for kilometre for example to be written out like this. (In the other script, Shahmukhi, abbreviations are almost never used for anything as they are not legible in that system.)

* Changed the last word separator to not use a comma. There is not a strict rule about this for Punjabi, but more often than not I do not really see much use of the Oxford comma like this. It is also less necessary within the context of how the grammar works compared to English - there would be no ambiguity in "the panda eats, shoots and leaves" vs "the panda eats, shoots, and leaves," for example. The word forms would have to change in order for the meaning to change like that, and in similar sentences the "and" may even be omitted or implied while remaining clear.

---

Relatedly, I have a question. I noticed the introduction of some ordinal format rules for French. Are these meant just for calender dates, or to be used with anything? I ask because Punjabi ordinals inflect for grammatical gender (and gender and case). However, the names of all the months are all masculine and singular if being used in a date, so if the ordinal formatter is only for dates, it could produce 6ਵਾਂ ਅਕਤੂਬਰ (6th of October). If it is generalizable to say, "the sixth cat," though then the format should be 6ਵੀਂ ਬਿੱਲੀ to agree with the common "cat" word being feminine, which complicates things. (Huge cats can be masculine but that's another story.)