### PR TITLE
Added sv-FI to locales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   ordinals) are enabled #1019
 - Add following locales:
   - Sardinian (sc) #1030
+  - Swedish (sv-FI): Finland’s native Swedish-speakers #1055
 - Update following locales:
   - Bengali (bn): Fix date and spelling issues #1031
   - Chinese (zh-HK, zh-TW, zh-YUE, zh-CN):

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Locale data whose structure is compatible with Rails 2.3 are available on the se
 
 **Available locales:**
 
-af, ar, az, be, bg, bn, bs, ca, cs, csb, da, de, de-AT, de-CH, de-DE, dsb, dz, el, el-CY, en, en-AU, en-CA, en-CY, en-GB, en-IE, en-IN, en-NZ, en-TT, en-US, en-ZA, eo, es, es-419, es-AR, es-CL, es-CO, es-CR, es-EC, es-ES, es-MX, es-NI, es-PA, es-PE, es-US, es-VE, et, eu, fa, fi, fr, fr-CA, fr-CH, fr-FR, fur, fy, gl, gsw-CH, he, hi, hi-IN, hr, hsb, hu, id, is, it, it-CH, ja, ka, kk, km, kn, ko, lb, lo, lt, lv, mg, mk, ml, mn, mr-IN, ms, nb, ne, nl, nn, oc, or, pa, pap-AW, pap-CW, pl, pt, pt-BR, rm, ro, ru, sc, scr, sk, sl, sq, sr, st, sv, sv-SE, sw, ta, te, th, tl, tr, tt, ug, uk, ur, uz, vi, wo, zh-CN, zh-HK, zh-TW, zh-YUE
+af, ar, az, be, bg, bn, bs, ca, cs, csb, da, de, de-AT, de-CH, de-DE, dsb, dz, el, el-CY, en, en-AU, en-CA, en-CY, en-GB, en-IE, en-IN, en-NZ, en-TT, en-US, en-ZA, eo, es, es-419, es-AR, es-CL, es-CO, es-CR, es-EC, es-ES, es-MX, es-NI, es-PA, es-PE, es-US, es-VE, et, eu, fa, fi, fr, fr-CA, fr-CH, fr-FR, fur, fy, gl, gsw-CH, he, hi, hi-IN, hr, hsb, hu, id, is, it, it-CH, ja, ka, kk, km, kn, ko, lb, lo, lt, lv, mg, mk, ml, mn, mr-IN, ms, nb, ne, nl, nn, oc, or, pa, pap-AW, pap-CW, pl, pt, pt-BR, rm, ro, ru, sc, scr, sk, sl, sq, sr, st, sv, sv-FI, sv-SE, sw, ta, te, th, tl, tr, tt, ug, uk, ur, uz, vi, wo, zh-CN, zh-HK, zh-TW, zh-YUE
 
 **Complete locales:**
 
@@ -102,7 +102,7 @@ af, csb, dsb, fur, gsw-CH, lb, rm, scr, sq, te, tt, ug, uz
 
 cy
 
-The cy locale was removed in commit 84f6c6b9b7a3e50df2b1fb1ccf7add329f7eab4f since unfortunately we could not find a Welsh speaker to support it. 
+The cy locale was removed in commit 84f6c6b9b7a3e50df2b1fb1ccf7add329f7eab4f since unfortunately we could not find a Welsh speaker to support it.
 We would welcome contributions to add it back to the project.
 The locale is mostly complete for the missing translations please refer to [#1006](https://github.com/svenfuchs/rails-i18n/issues/1006)
 

--- a/rails/locale/sv-FI.yml
+++ b/rails/locale/sv-FI.yml
@@ -39,9 +39,9 @@ sv-FI:
       - fredag
       - lördag
     formats:
-      default: "%Y-%m-%d"
-      long: "%e %B %Y"
-      short: "%e %b"
+      default: "%-d.%-m.%Y"
+      long: "%d. %Bta %Y"
+      short: "%d. %b"
     month_names:
       -
       - januari

--- a/rails/locale/sv-FI.yml
+++ b/rails/locale/sv-FI.yml
@@ -1,0 +1,210 @@
+---
+sv-FI:
+  activerecord:
+    errors:
+      messages:
+        record_invalid: "Ett fel uppstod: %{errors}"
+        restrict_dependent_destroy:
+          has_one: Kan inte ta bort post då beroende %{record} finns
+          has_many: Kan inte ta bort poster då beroende %{record} finns
+  date:
+    abbr_day_names:
+      - sön
+      - mån
+      - tis
+      - ons
+      - tor
+      - fre
+      - lör
+    abbr_month_names:
+      -
+      - jan
+      - feb
+      - mar
+      - apr
+      - maj
+      - jun
+      - jul
+      - aug
+      - sep
+      - okt
+      - nov
+      - dec
+    day_names:
+      - söndag
+      - måndag
+      - tisdag
+      - onsdag
+      - torsdag
+      - fredag
+      - lördag
+    formats:
+      default: "%Y-%m-%d"
+      long: "%e %B %Y"
+      short: "%e %b"
+    month_names:
+      -
+      - januari
+      - februari
+      - mars
+      - april
+      - maj
+      - juni
+      - juli
+      - augusti
+      - september
+      - oktober
+      - november
+      - december
+    order:
+      - :day
+      - :month
+      - :year
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: ungefär en timme
+        other: ungefär %{count} timmar
+      about_x_months:
+        one: ungefär en månad
+        other: ungefär %{count} månader
+      about_x_years:
+        one: ungefär ett år
+        other: ungefär %{count} år
+      almost_x_years:
+        one: nästan ett år
+        other: nästan %{count} år
+      half_a_minute: en halv minut
+      less_than_x_seconds:
+        one: mindre än en sekund
+        other: mindre än %{count} sekunder
+      less_than_x_minutes:
+        one: mindre än en minut
+        other: mindre än %{count} minuter
+      over_x_years:
+        one: mer än ett år
+        other: mer än %{count} år
+      x_seconds:
+        one: en sekund
+        other: "%{count} sekunder"
+      x_minutes:
+        one: en minut
+        other: "%{count} minuter"
+      x_days:
+        one: en dag
+        other: "%{count} dagar"
+      x_months:
+        one: en månad
+        other: "%{count} månader"
+      x_years:
+        one: ett år
+        other: "%{count} år"
+    prompts:
+      second: Sekund
+      minute: Minut
+      hour: Timme
+      day: Dag
+      month: Månad
+      year: År
+  errors:
+    format: "%{attribute} %{message}"
+    messages:
+      accepted: måste vara accepterad
+      blank: måste anges
+      confirmation: stämmer inte överens
+      empty: får ej vara tom
+      equal_to: måste vara lika med %{count}
+      even: måste vara jämnt
+      exclusion: är reserverat
+      greater_than: måste vara större än %{count}
+      greater_than_or_equal_to: måste vara större än eller lika med %{count}
+      inclusion: finns inte i listan
+      invalid: har fel format
+      less_than: måste vara mindre än %{count}
+      less_than_or_equal_to: måste vara mindre än eller lika med %{count}
+      model_invalid: "Validering misslyckades: %{errors}"
+      not_a_number: är inte ett nummer
+      not_an_integer: måste vara ett heltal
+      odd: måste vara udda
+      other_than: måste vara annat än %{count}
+      present: får inte anges
+      required: måste finnas
+      taken: används redan
+      too_long: är för lång (maximum är %{count} tecken)
+      too_short: är för kort (minimum är %{count} tecken)
+      wrong_length: har fel längd (ska vara %{count} tecken)
+    template:
+      body: "Det var problem med följande fält:"
+      header:
+        one: Ett fel förhindrade ifrågavarande %{model} från att sparas
+        other: "%{count} fel förhindrade ifrågavarande %{model} från att sparas"
+  helpers:
+    select:
+      prompt: Välj
+    submit:
+      create: Skapa %{model}
+      submit: Spara %{model}
+      update: Ändra %{model}
+  number:
+    currency:
+      format:
+        delimiter: " "
+        format: "%n %u"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: kr
+    format:
+      delimiter: " "
+      precision: 2
+      round_mode: default
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: Miljard
+          million: Miljon
+          quadrillion: Biljard
+          thousand: Tusen
+          trillion: Biljon
+          unit: ""
+      format:
+        delimiter: ""
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: " "
+        format: "%n %"
+    precision:
+      format:
+        delimiter: ""
+  support:
+    array:
+      last_word_connector: " och "
+      two_words_connector: " och "
+      words_connector: ", "
+  time:
+    am: ""
+    formats:
+      default: "%a, %e %b %Y %H:%M:%S %z"
+      long: "%e %B %Y %H:%M"
+      short: "%e %b %H:%M"
+    pm: ""

--- a/rails/locale/sv-FI.yml
+++ b/rails/locale/sv-FI.yml
@@ -40,8 +40,8 @@ sv-FI:
       - lördag
     formats:
       default: "%-d.%-m.%Y"
-      long: "%d. %Bta %Y"
-      short: "%d. %b"
+      long: "%e %B %Y"
+      short: "%e %b"
     month_names:
       -
       - januari

--- a/rails/locale/sv-FI.yml
+++ b/rails/locale/sv-FI.yml
@@ -96,9 +96,6 @@ sv-FI:
       x_months:
         one: en månad
         other: "%{count} månader"
-      x_years:
-        one: ett år
-        other: "%{count} år"
     prompts:
       second: Sekund
       minute: Minut

--- a/rails/locale/sv-FI.yml
+++ b/rails/locale/sv-FI.yml
@@ -154,7 +154,7 @@ sv-FI:
         separator: ","
         significant: false
         strip_insignificant_zeros: false
-        unit: kr
+        unit: "€"
     format:
       delimiter: " "
       precision: 2


### PR DESCRIPTION
Added sv-FI to the list of locales. Finland has a large minority of native Swedish-speakers, who speak a slightly differing version of the language than those in Sweden. It can be benefitial to differentiate between the locales for platforms that operate in both countries.

The locale implemented has differing date format and currency from the sv locale.