### PR TITLE
Use abbreviated months in German short time format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   - Japanese (ja): Add `in` and `round_mode` keys #1059
   - English (en-ZA): ZAR currency format #1066
   - Afrikaan (af): ZAR currency format #1066
+  - German (de, de-DE, de-AT, de-CH): Use abbreviated months in the short time format #1062
 - Add ordinalization for German (de, de-AT, de-CH, de-DE)
 
 ## 7.0.6 (2022-11-08)

--- a/rails/locale/de-AT.yml
+++ b/rails/locale/de-AT.yml
@@ -218,5 +218,5 @@ de-AT:
     formats:
       default: "%A, %d. %B %Y, %H:%M Uhr"
       long: "%A, %d. %B %Y, %H:%M Uhr"
-      short: "%d. %B, %H:%M Uhr"
+      short: "%d. %b, %H:%M Uhr"
     pm: nachmittags

--- a/rails/locale/de-CH.yml
+++ b/rails/locale/de-CH.yml
@@ -218,5 +218,5 @@ de-CH:
     formats:
       default: "%A, %d. %B %Y, %H:%M Uhr"
       long: "%A, %d. %B %Y, %H:%M Uhr"
-      short: "%d. %B, %H:%M Uhr"
+      short: "%d. %b, %H:%M Uhr"
     pm: nachmittags

--- a/rails/locale/de-DE.yml
+++ b/rails/locale/de-DE.yml
@@ -218,5 +218,5 @@ de-DE:
     formats:
       default: "%A, %d. %B %Y, %H:%M Uhr"
       long: "%A, %d. %B %Y, %H:%M Uhr"
-      short: "%d. %B, %H:%M Uhr"
+      short: "%d. %b, %H:%M Uhr"
     pm: nachmittags

--- a/rails/locale/de.yml
+++ b/rails/locale/de.yml
@@ -221,5 +221,5 @@ de:
     formats:
       default: "%A, %d. %B %Y, %H:%M Uhr"
       long: "%A, %d. %B %Y, %H:%M Uhr"
-      short: "%d. %B, %H:%M Uhr"
+      short: "%d. %b, %H:%M Uhr"
     pm: nachmittags


### PR DESCRIPTION
Fix #1062: use abbreviated months in the short time format for all German languages. 