### PR TITLE
Transform to decimal to select pluralization rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## unreleased
 
-- Transform to decimal when checking pluralization rules #1065
+- Transform to decimal to select pluralization rule #1065
 - Update following locales:
   - Japanese (ja): Add `in` and `round_mode` keys #1059
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## unreleased
 
+- Transform to decimal when checking pluralization rules #1065
 - Update following locales:
   - Japanese (ja): Add `in` and `round_mode` keys #1059
 

--- a/lib/rails_i18n/common_pluralizations/east_slavic.rb
+++ b/lib/rails_i18n/common_pluralizations/east_slavic.rb
@@ -14,7 +14,7 @@ module RailsI18n
 
       def self.rule
         lambda do |n|
-          n ||= 0
+          n = n.to_d
           mod10 = n % 10
           mod100 = n % 100
 

--- a/lib/rails_i18n/common_pluralizations/one_few_other.rb
+++ b/lib/rails_i18n/common_pluralizations/one_few_other.rb
@@ -6,7 +6,7 @@ module RailsI18n
 
       def self.rule
         lambda do |n|
-          n ||= 0
+          n = n.to_d
           frac = (n.to_d % 1)
 
           if frac.nonzero?

--- a/lib/rails_i18n/common_pluralizations/one_other.rb
+++ b/lib/rails_i18n/common_pluralizations/one_other.rb
@@ -4,7 +4,7 @@ module RailsI18n
   module Pluralization
     module OneOther
       def self.rule
-        lambda { |n| n == 1 ? :one : :other }
+        lambda { |n| n.to_d == 1 ? :one : :other }
       end
 
       def self.with_locale(locale)

--- a/lib/rails_i18n/common_pluralizations/one_two_other.rb
+++ b/lib/rails_i18n/common_pluralizations/one_two_other.rb
@@ -6,12 +6,10 @@ module RailsI18n
     module OneTwoOther
       def self.rule
         lambda do |n|
-          if n == 1
-            :one
-          elsif n == 2
-            :two
-          else
-            :other
+          case n.to_d
+          when 1 then :one
+          when 2 then :two
+          else :other
           end
         end
       end

--- a/lib/rails_i18n/common_pluralizations/one_upto_two_other.rb
+++ b/lib/rails_i18n/common_pluralizations/one_upto_two_other.rb
@@ -4,7 +4,12 @@ module RailsI18n
   module Pluralization
     module OneUptoTwoOther
       def self.rule
-        lambda { |n| n && n >= 0 && n < 2 ? :one : :other }
+        lambda do |n|
+          return :other if n.nil?
+
+          n = n.to_d
+          n >= 0 && n < 2 ? :one : :other
+        end
       end
 
       def self.with_locale(locale)

--- a/lib/rails_i18n/common_pluralizations/one_with_zero_other.rb
+++ b/lib/rails_i18n/common_pluralizations/one_with_zero_other.rb
@@ -6,8 +6,10 @@ module RailsI18n
     module OneWithZeroOther
       def self.rule
         lambda do |n|
-          n = n.to_d
-          n == 0 || n == 1 ? :one : :other
+          case n.to_d
+          when 0, 1 then :one
+          else :other
+          end
         end
       end
 

--- a/lib/rails_i18n/common_pluralizations/one_with_zero_other.rb
+++ b/lib/rails_i18n/common_pluralizations/one_with_zero_other.rb
@@ -5,7 +5,10 @@ module RailsI18n
   module Pluralization
     module OneWithZeroOther
       def self.rule
-        lambda { |n| n == 0 || n == 1 ? :one : :other }
+        lambda do |n|
+          n = n.to_d
+          n == 0 || n == 1 ? :one : :other
+        end
       end
 
       def self.with_locale(locale)

--- a/lib/rails_i18n/common_pluralizations/romanian.rb
+++ b/lib/rails_i18n/common_pluralizations/romanian.rb
@@ -3,12 +3,15 @@
 module RailsI18n
   module Pluralization
     module Romanian
+      FEW = (1..19).to_a
+      private_constant :FEW
+
       def self.rule
         lambda do |n|
           n = n.to_d
           if n == 1
             :one
-          elsif n == 0 || (1..19).to_a.include?(n % 100)
+          elsif n == 0 || FEW.include?(n % 100)
             :few
           else
             :other

--- a/lib/rails_i18n/common_pluralizations/romanian.rb
+++ b/lib/rails_i18n/common_pluralizations/romanian.rb
@@ -5,7 +5,7 @@ module RailsI18n
     module Romanian
       def self.rule
         lambda do |n|
-          n ||= 0
+          n = n.to_d
           if n == 1
             :one
           elsif n == 0 || (1..19).to_a.include?(n % 100)

--- a/lib/rails_i18n/common_pluralizations/west_slavic.rb
+++ b/lib/rails_i18n/common_pluralizations/west_slavic.rb
@@ -5,6 +5,7 @@ module RailsI18n
     module WestSlavic
       def self.rule
         lambda do |n|
+          n = n.to_d
           if n == 1
             :one
           elsif [2, 3, 4].include?(n)

--- a/spec/unit/pluralization/east_slavic.rb
+++ b/spec/unit/pluralization/east_slavic.rb
@@ -16,7 +16,8 @@ shared_examples 'East Slavic' do
     end
   end
 
-  [0, "0", 5, "5", 8, 10, 11, 18, 20, 25, 27, 30, 35, 38, 40].each do |count|
+  [0, "0", 5, "5", 8, 10, 11, 18, 20, 25, 27, 30, 35, 38, 40,
+   nil].each do |count|
     it "detects that #{count.inspect} in category 'many'" do
       rule.call(count).should == :many
     end

--- a/spec/unit/pluralization/east_slavic.rb
+++ b/spec/unit/pluralization/east_slavic.rb
@@ -4,26 +4,26 @@ shared_examples 'East Slavic' do
     plural_keys.should include(:one, :few, :many, :other)
   end
 
-  [1, 21, 51, 71, 101, 1031].each do |count|
-    it "detects that #{count} in category 'one'" do
+  [1, "1", 21, 51, 71, 101, 1031].each do |count|
+    it "detects that #{count.inspect} in category 'one'" do
       rule.call(count).should == :one
     end
   end
 
-  [2, 3, 4, 22, 23, 24, 92, 93, 94].each do |count|
-    it "detects that #{count} in category 'few'" do
+  [2, "2", 3, 4, 22, 23, 24, 92, 93, 94].each do |count|
+    it "detects that #{count.inspect} in category 'few'" do
       rule.call(count).should == :few
     end
   end
 
-  [0, 5, 8, 10, 11, 18, 20, 25, 27, 30, 35, 38, 40].each do |count|
-    it "detects that #{count} in category 'many'" do
+  [0, "0", 5, "5", 8, 10, 11, 18, 20, 25, 27, 30, 35, 38, 40].each do |count|
+    it "detects that #{count.inspect} in category 'many'" do
       rule.call(count).should == :many
     end
   end
 
-  [1.2, 3.7, 11.5, 20.8, 1004.3].each do |count|
-    it "detects that #{count} in category 'other'" do
+  [1.2, "1.2", 3.7, 11.5, 20.8, 1004.3].each do |count|
+    it "detects that #{count.inspect} in category 'other'" do
       rule.call(count).should == :other
     end
   end

--- a/spec/unit/pluralization/one_few_other.rb
+++ b/spec/unit/pluralization/one_few_other.rb
@@ -17,7 +17,7 @@ shared_examples 'one-few-other forms language' do
 
   [0, "0", 5, "5", 6, 7, 17, 18, 19, 100, 1_000, 10_000, 100_000, 1_000_000,
    0.0, 0.5, "0.5", 0.6, 0.7, 0.8, 0.9, 1.5, 1.6, 1.7, 2.5, 2.6, 2.7, 10.0,
-   100.0, 1_000.0, 10_000.0, 100_000.0, 1_000_000.0].each do |count|
+   100.0, 1_000.0, 10_000.0, 100_000.0, 1_000_000.0, nil].each do |count|
     it "detects that #{count.inspect} in category 'other'" do
       rule.call(count).should == :other
     end

--- a/spec/unit/pluralization/one_few_other.rb
+++ b/spec/unit/pluralization/one_few_other.rb
@@ -1,21 +1,24 @@
 shared_examples 'one-few-other forms language' do
-  [1, 21, 31, 41, 51, 61, 71, 81, 101, 1001,
-   0.1, 1.1, 2.1, 3.1, 4.1, 5.1, 6.1, 7.1, 10.1, 100.1, 1000.1].each do |count|
-    it "detects that #{count} in category 'one'" do
+  [1, "1", 21, 31, 41, 51, 61, 71, 81, 101, 1001,
+   0.1, "0.1", 1.1, 2.1, 3.1, 4.1, 5.1, 6.1, 7.1, 10.1, 100.1,
+   1_000.1].each do |count|
+    it "detects that #{count.inspect} in category 'one'" do
       rule.call(count).should == :one
     end
   end
-  
-  [2, 3, 4, 22, 23, 24, 32, 33, 34, 42, 43, 44, 52, 53, 54, 62, 102, 1002,
-   0.2, 0.3, 0.4, 1.2, 1.3, 1.4, 2.2, 2.3, 2.4, 3.2, 3.3, 3.4, 4.2, 4.3, 4.4, 5.2, 10.2, 100.2, 1000.2].each do |count|
-    it "detects that #{count} in category 'few'" do
+
+  [2, "2", 3, 4, 22, 23, 24, 32, 33, 34, 42, 43, 44, 52, 53, 54, 62, 102, 1_002,
+   0.2, "0.2", 0.3, 0.4, 1.2, 1.3, 1.4, 2.2, 2.3, 2.4, 3.2, 3.3, 3.4, 4.2, 4.3,
+   4.4, 5.2, 10.2, 100.2, 1_000.2].each do |count|
+    it "detects that #{count.inspect} in category 'few'" do
       rule.call(count).should == :few
     end
   end
 
-  [0, 5, 6, 7, 17, 18, 19, 100, 1000, 10000, 100000, 1000000,
-   0.0, 0.5, 0.6, 0.7, 0.8, 0.9, 1.5, 1.6, 1.7, 2.5, 2.6, 2.7, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0].each do |count|
-    it "detects that #{count} in category 'other'" do
+  [0, "0", 5, "5", 6, 7, 17, 18, 19, 100, 1_000, 10_000, 100_000, 1_000_000,
+   0.0, 0.5, "0.5", 0.6, 0.7, 0.8, 0.9, 1.5, 1.6, 1.7, 2.5, 2.6, 2.7, 10.0,
+   100.0, 1_000.0, 10_000.0, 100_000.0, 1_000_000.0].each do |count|
+    it "detects that #{count.inspect} in category 'other'" do
       rule.call(count).should == :other
     end
   end

--- a/spec/unit/pluralization/one_other.rb
+++ b/spec/unit/pluralization/one_other.rb
@@ -11,7 +11,7 @@ shared_examples 'one-other forms language' do
   end
 
   [0, "0", 0.3, 1.2, 2, "2", 3, 5, 10, 11, 21, 23, 31, 50, 81,
-   99, 100].each do |count|
+   99, 100, nil].each do |count|
     it "detects that #{count.inspect.inspect} in category 'other'" do
       rule.call(count).should == :other
     end

--- a/spec/unit/pluralization/one_other.rb
+++ b/spec/unit/pluralization/one_other.rb
@@ -4,12 +4,15 @@ shared_examples 'one-other forms language' do
     plural_keys.should include(:one, :other)
   end
 
-  it "detects that 1 in category 'one'" do
-    rule.call(1).should == :one
+  [1, "1"].each do |count|
+    it "detects that #{count.inspect} in category 'one'" do
+      rule.call(count).should == :one
+    end
   end
 
-  [0, 0.3, 1.2, 2, 3, 5, 10, 11, 21, 23, 31, 50, 81, 99, 100].each do |count|
-    it "detects that #{count} in category 'other'" do
+  [0, "0", 0.3, 1.2, 2, "2", 3, 5, 10, 11, 21, 23, 31, 50, 81,
+   99, 100].each do |count|
+    it "detects that #{count.inspect.inspect} in category 'other'" do
       rule.call(count).should == :other
     end
   end

--- a/spec/unit/pluralization/one_two_other.rb
+++ b/spec/unit/pluralization/one_two_other.rb
@@ -16,7 +16,8 @@ shared_examples 'one-two-other forms language' do
     end
   end
 
-  [0, 0.3, 1.2, 3, "3", 5, 10, 11, 21, 23, 31, 50, 81, 99, 100].each do |count|
+  [0, 0.3, 1.2, 3, "3", 5, 10, 11, 21, 23, 31, 50, 81, 99, 100,
+   nil].each do |count|
     it "detects that #{count.inspect} in category 'other'" do
       rule.call(count).should == :other
     end

--- a/spec/unit/pluralization/one_two_other.rb
+++ b/spec/unit/pluralization/one_two_other.rb
@@ -4,16 +4,20 @@ shared_examples 'one-two-other forms language' do
     plural_keys.should include(:one, :two, :other)
   end
 
-  it "detects that 1 in category 'one'" do
-    rule.call(1).should == :one
+  [1, "1"].each do |count|
+    it "detects that #{count.inspect} in category 'one'" do
+      rule.call(count).should == :one
+    end
   end
 
-  it "detects that 2 in category 'two'" do
-    rule.call(2).should == :two
+  [2, "2"].each do |count|
+    it "detects that #{count.inspect} in category 'two'" do
+      rule.call(count).should == :two
+    end
   end
 
-  [0, 0.3, 1.2, 3, 5, 10, 11, 21, 23, 31, 50, 81, 99, 100].each do |count|
-    it "detects that #{count} in category 'other'" do
+  [0, 0.3, 1.2, 3, "3", 5, 10, 11, 21, 23, 31, 50, 81, 99, 100].each do |count|
+    it "detects that #{count.inspect} in category 'other'" do
       rule.call(count).should == :other
     end
   end

--- a/spec/unit/pluralization/one_upto_two_other.rb
+++ b/spec/unit/pluralization/one_upto_two_other.rb
@@ -4,14 +4,14 @@ shared_examples 'one(upto 2)-other forms language' do
     plural_keys.should include(:one, :other)
   end
 
-  [0, 0.5, 1, 1.2, 1.8].each do |count|
-    it "detects that #{count} in category 'one'" do
+  [0, "0", 0.5, 1, "1", 1.2, 1.8].each do |count|
+    it "detects that #{count.inspect} in category 'one'" do
       rule.call(count).should == :one
     end
   end
 
-  [2, 2.1, 5, 11, 21, 22, 37, 40, 900.5].each do |count|
-    it "detects that #{count} in category 'other'" do
+  [2, "2", 2.1, 5, 11, 21, 22, 37, 40, 900.5].each do |count|
+    it "detects that #{count.inspect} in category 'other'" do
       rule.call(count).should == :other
     end
   end

--- a/spec/unit/pluralization/one_upto_two_other.rb
+++ b/spec/unit/pluralization/one_upto_two_other.rb
@@ -10,7 +10,7 @@ shared_examples 'one(upto 2)-other forms language' do
     end
   end
 
-  [2, "2", 2.1, 5, 11, 21, 22, 37, 40, 900.5].each do |count|
+  [2, "2", 2.1, 5, 11, 21, 22, 37, 40, 900.5, nil].each do |count|
     it "detects that #{count.inspect} in category 'other'" do
       rule.call(count).should == :other
     end

--- a/spec/unit/pluralization/one_with_zero_other.rb
+++ b/spec/unit/pluralization/one_with_zero_other.rb
@@ -4,16 +4,14 @@ shared_examples 'one(with zero)-other forms language' do
     plural_keys.should include(:one, :other)
   end
 
-  it "detects that 0 in category 'one'" do
-    rule.call(0).should == :one
+  [0, "0", 1, "1"].each do |count|
+    it "detects that #{count.inspect} in category 'one'" do
+      rule.call(count).should == :one
+    end
   end
 
-  it "detects that 1 in category 'one'" do
-    rule.call(1).should == :one
-  end
-
-  [0.4, 1.2, 2, 5, 11, 21, 22, 27, 99, 1000].each do |count|
-    it "detects that #{count} in category 'other'" do
+  [0.4, 1.2, 2, "2", 5, 11, 21, 22, 27, 99, 1_000].each do |count|
+    it "detects that #{count.inspect} in category 'other'" do
       rule.call(count).should == :other
     end
   end

--- a/spec/unit/pluralization/one_with_zero_other.rb
+++ b/spec/unit/pluralization/one_with_zero_other.rb
@@ -4,7 +4,7 @@ shared_examples 'one(with zero)-other forms language' do
     plural_keys.should include(:one, :other)
   end
 
-  [0, "0", 1, "1"].each do |count|
+  [0, "0", 1, "1", nil].each do |count|
     it "detects that #{count.inspect} in category 'one'" do
       rule.call(count).should == :one
     end

--- a/spec/unit/pluralization/other.rb
+++ b/spec/unit/pluralization/other.rb
@@ -3,7 +3,7 @@ shared_examples 'other form language' do
     plural_keys.should == [:other]
   end
 
-  [0, 1, "1", 1.2, "1.2", 2, 5, 11, 21, 22, 27, 99, 1_000].each do |count|
+  [0, 1, "1", 1.2, "1.2", 2, 5, 11, 21, 22, 27, 99, 1_000, nil].each do |count|
     it "detects that #{count.inspect} in category 'other'" do
       rule.call(count).should == :other
     end

--- a/spec/unit/pluralization/other.rb
+++ b/spec/unit/pluralization/other.rb
@@ -3,8 +3,8 @@ shared_examples 'other form language' do
     plural_keys.should == [:other]
   end
 
-  [0, 1, 1.2, 2, 5, 11, 21, 22, 27, 99, 1000].each do |count|
-    it "detects that #{count} in category 'other'" do
+  [0, 1, "1", 1.2, "1.2", 2, 5, 11, 21, 22, 27, 99, 1_000].each do |count|
+    it "detects that #{count.inspect} in category 'other'" do
       rule.call(count).should == :other
     end
   end

--- a/spec/unit/pluralization/romanian.rb
+++ b/spec/unit/pluralization/romanian.rb
@@ -9,7 +9,7 @@ shared_examples 'Romanian language' do
   end
 
   [0, "0", 2, "2", 3, 5, 8, 9, 10, 11, 15, 19, 101, 106, 112, 117,
-   119, 201].each do |count|
+   119, 201, nil].each do |count|
     it "detects that #{count.inspect} in category 'few'" do
       rule.call(count).should == :few
     end

--- a/spec/unit/pluralization/romanian.rb
+++ b/spec/unit/pluralization/romanian.rb
@@ -8,14 +8,15 @@ shared_examples 'Romanian language' do
     rule.call(1).should == :one
   end
 
-  [0, 2, 3, 5, 8, 9, 10, 11, 15, 19, 101, 106, 112, 117, 119, 201].each do |count|
-    it "detects that #{count} in category 'few'" do
+  [0, "0", 2, "2", 3, 5, 8, 9, 10, 11, 15, 19, 101, 106, 112, 117,
+   119, 201].each do |count|
+    it "detects that #{count.inspect} in category 'few'" do
       rule.call(count).should == :few
     end
   end
 
-  [0.4, 1.7, 20, 21, 23, 34, 45, 66, 89, 100, 120, 138].each do |count|
-    it "detects that #{count} in category 'other'" do
+  [0.4, "0.4", 1.7, 20, 21, 23, 34, 45, 66, 89, 100, 120, 138].each do |count|
+    it "detects that #{count.inspect} in category 'other'" do
       rule.call(count).should == :other
     end
   end

--- a/spec/unit/pluralization/west_slavic.rb
+++ b/spec/unit/pluralization/west_slavic.rb
@@ -8,14 +8,14 @@ shared_examples 'West Slavic' do
     rule.call(1).should == :one
   end
 
-  [2, 3, 4].each do |count|
-    it "detects that #{count} in category 'few'" do
+  [2, "2", 3, 4].each do |count|
+    it "detects that #{count.inspect} in category 'few'" do
       rule.call(count).should == :few
     end
   end
 
-  [0, 0.5, 1.7, 2.1, 5, 7.8, 10, 875].each do |count|
-    it "detects that #{count} in category 'other'" do
+  [0, "0", 0.5, "0.5", 1.7, 2.1, 5, 7.8, 10, 875].each do |count|
+    it "detects that #{count.inspect} in category 'other'" do
       rule.call(count).should == :other
     end
   end

--- a/spec/unit/pluralization/west_slavic.rb
+++ b/spec/unit/pluralization/west_slavic.rb
@@ -14,7 +14,7 @@ shared_examples 'West Slavic' do
     end
   end
 
-  [0, "0", 0.5, "0.5", 1.7, 2.1, 5, 7.8, 10, 875].each do |count|
+  [0, "0", 0.5, "0.5", 1.7, 2.1, 5, 7.8, 10, 875, nil].each do |count|
     it "detects that #{count.inspect} in category 'other'" do
       rule.call(count).should == :other
     end


### PR DESCRIPTION
Closes #1064

There are several ways the issue could be solved:

- **Raise an error when given a non-numeric**
  This could break apps that don’t check that are passing strings.
  For example this would raise an `ArgumentError` when given `"1"`.

- **Consider all non-numerics as `other`**
  This is closer to the current `en` implementation however that is probably not what the user intended when passing numeric-looking strings.
  For example this would return `1 apples` when given `"1"`.

- **Try to be helpful and transform it to a numeric**
  For example this would return `1 apple` when given `"1"`.

I went for the latter. Let me know what you think.