### PR TITLE
Update currency formatting for South African Rand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Update following locales:
   - Japanese (ja): Add `in` and `round_mode` keys #1059
+  - English (en-ZA): ZAR currency format #1066
+  - Afrikaan (af): ZAR currency format #1066
 
 ## 7.0.6 (2022-11-08)
 

--- a/rails/locale/af.yml
+++ b/rails/locale/af.yml
@@ -154,10 +154,10 @@ af:
   number:
     currency:
       format:
-        delimiter: ","
-        format: "%u%n"
+        delimiter: " "
+        format: "%u %n"
         precision: 2
-        separator: "."
+        separator: ","
         significant: false
         strip_insignificant_zeros: false
         unit: R

--- a/rails/locale/en-ZA.yml
+++ b/rails/locale/en-ZA.yml
@@ -154,10 +154,10 @@ en-ZA:
   number:
     currency:
       format:
-        delimiter: ","
-        format: "%u%n"
+        delimiter: " "
+        format: "%u %n"
         precision: 2
-        separator: "."
+        separator: ","
         significant: false
         strip_insignificant_zeros: false
         unit: R


### PR DESCRIPTION
Not a native speaker, but this would match how js formats it:

```
> new Intl.NumberFormat('en-ZA', { style: 'currency', currency: 'ZAR'}).format(10000)
> 'R 10 000,00'
```
Also, from a quick google search it seems this is the correct way (https://www.sadev.co.za/content/how-correctly-format-currency-south-africa):

> The so-called Continental System (also used in South Africa) requires that the decimal point be replaced by a comma
> ...
> Use a space, not commas, to indicate thousands