### PR TITLE
Add support for German ordinalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   - Japanese (ja): Add `in` and `round_mode` keys #1059
   - English (en-ZA): ZAR currency format #1066
   - Afrikaan (af): ZAR currency format #1066
+- Add ordinalization for German (de, de-AT, de-CH, de-DE)
 
 ## 7.0.6 (2022-11-08)
 

--- a/rails/ordinals/de-AT.rb
+++ b/rails/ordinals/de-AT.rb
@@ -1,0 +1,15 @@
+{
+  de: {
+    number: {
+      nth: {
+        ordinals: -> (_key, number:, **_options) {
+          '.'
+        },
+
+        ordinalized:  -> (_key, number:, **_options) {
+          "#{number}#{ActiveSupport::Inflector.ordinal(number)}"
+        }
+      }
+    }
+  }
+}

--- a/rails/ordinals/de-CH.rb
+++ b/rails/ordinals/de-CH.rb
@@ -1,0 +1,15 @@
+{
+  de: {
+    number: {
+      nth: {
+        ordinals: -> (_key, number:, **_options) {
+          '.'
+        },
+
+        ordinalized:  -> (_key, number:, **_options) {
+          "#{number}#{ActiveSupport::Inflector.ordinal(number)}"
+        }
+      }
+    }
+  }
+}

--- a/rails/ordinals/de-DE.rb
+++ b/rails/ordinals/de-DE.rb
@@ -1,0 +1,15 @@
+{
+  de: {
+    number: {
+      nth: {
+        ordinals: -> (_key, number:, **_options) {
+          '.'
+        },
+
+        ordinalized:  -> (_key, number:, **_options) {
+          "#{number}#{ActiveSupport::Inflector.ordinal(number)}"
+        }
+      }
+    }
+  }
+}

--- a/rails/ordinals/de.rb
+++ b/rails/ordinals/de.rb
@@ -1,0 +1,15 @@
+{
+  de: {
+    number: {
+      nth: {
+        ordinals: -> (_key, number:, **_options) {
+          '.'
+        },
+
+        ordinalized:  -> (_key, number:, **_options) {
+          "#{number}#{ActiveSupport::Inflector.ordinal(number)}"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This pull request adds German ordinalization. It's trivial (for once, German is actually simple (!)) but fixes the missing translation problem for German.

BEFORE:

```ruby
irb(main):001:0> 1.ordinalize
=> "translation missing: de.number.nth.ordinalized"
```

NOW: 

```ruby
irb(main):001:0> 1.ordinalize
=> "1."
```