### PR TITLE
Add errors.messages.in translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   - German (de, de-DE, de-AT, de-CH): Use abbreviated months in the short time format #1062
   - Japanese (ja): Add `in` and `round_mode` keys #1059
   - Korean (ko): Fix typo in `equal_to` keys #1061
+  - Portuguese (pt, pt-BR): add translation for `errors.messages.in` #1071
+  - Spanish (es): add translation for `errors.messages.in` #1071
 - Add ordinalization for German (de, de-AT, de-CH, de-DE)
 
 ## 7.0.6 (2022-11-08)

--- a/rails/locale/es.yml
+++ b/rails/locale/es.yml
@@ -17,7 +17,7 @@ es:
     - vie
     - sáb
     abbr_month_names:
-    - 
+    -
     - ene
     - feb
     - mar
@@ -43,7 +43,7 @@ es:
       long: "%-d de %B de %Y"
       short: "%-d de %b"
     month_names:
-    - 
+    -
     - enero
     - febrero
     - marzo
@@ -118,6 +118,7 @@ es:
       exclusion: está reservado
       greater_than: debe ser mayor que %{count}
       greater_than_or_equal_to: debe ser mayor que o igual a %{count}
+      in: debe estar en %{count}
       inclusion: no está incluido en la lista
       invalid: no es válido
       less_than: debe ser menor que %{count}

--- a/rails/locale/pt-BR.yml
+++ b/rails/locale/pt-BR.yml
@@ -17,7 +17,7 @@ pt-BR:
     - sex
     - sáb
     abbr_month_names:
-    - 
+    -
     - jan
     - fev
     - mar
@@ -43,7 +43,7 @@ pt-BR:
       long: "%d de %B de %Y"
       short: "%d de %B"
     month_names:
-    - 
+    -
     - janeiro
     - fevereiro
     - março
@@ -118,6 +118,7 @@ pt-BR:
       exclusion: não está disponível
       greater_than: deve ser maior que %{count}
       greater_than_or_equal_to: deve ser maior ou igual a %{count}
+      in: deve estar em %{count}
       inclusion: não está incluído na lista
       invalid: não é válido
       less_than: deve ser menor que %{count}

--- a/rails/locale/pt.yml
+++ b/rails/locale/pt.yml
@@ -17,7 +17,7 @@ pt:
     - sex
     - sáb
     abbr_month_names:
-    - 
+    -
     - jan
     - fev
     - mar
@@ -43,7 +43,7 @@ pt:
       long: "%d de %B de %Y"
       short: "%d de %B"
     month_names:
-    - 
+    -
     - janeiro
     - fevereiro
     - março
@@ -118,6 +118,7 @@ pt:
       exclusion: é reservado
       greater_than: tem de ser maior que %{count}
       greater_than_or_equal_to: tem de ser maior ou igual a %{count}
+      in: deve estar em %{count}
       inclusion: não está incluído na lista
       invalid: é inválido
       less_than: tem de ser menor que %{count}


### PR DESCRIPTION
Add translations:

- Portuguse `pt.errors.messages.in` to `"deve estar em %{count}"`
- Brazilian Portuguse `pt-br.errors.messages.in` to `"deve estar em %{count}"`
- Spanish `es.errors.messages.in` to `"debe estar en %{count}"`