### PR TITLE
French: fix typo on almost_x_years

### DIFF
--- a/rails/locale/fr-CA.yml
+++ b/rails/locale/fr-CA.yml
@@ -74,7 +74,7 @@ fr-CA:
         one: environ un an
         other: environ %{count} ans
       almost_x_years:
-        one: presqu'un an
+        one: presque un an
         other: presque %{count} ans
       half_a_minute: une demi-minute
       less_than_x_seconds:

--- a/rails/locale/fr-CH.yml
+++ b/rails/locale/fr-CH.yml
@@ -74,7 +74,7 @@ fr-CH:
         one: environ un an
         other: environ %{count} ans
       almost_x_years:
-        one: presqu'un an
+        one: presque un an
         other: presque %{count} ans
       half_a_minute: une demi-minute
       less_than_x_seconds:

--- a/rails/locale/fr-FR.yml
+++ b/rails/locale/fr-FR.yml
@@ -74,7 +74,7 @@ fr-FR:
         one: environ un an
         other: environ %{count} ans
       almost_x_years:
-        one: presqu'un an
+        one: presque un an
         other: presque %{count} ans
       half_a_minute: une demi-minute
       less_than_x_seconds:

--- a/rails/locale/fr.yml
+++ b/rails/locale/fr.yml
@@ -74,7 +74,7 @@ fr:
         one: environ un an
         other: environ %{count} ans
       almost_x_years:
-        one: presqu'un an
+        one: presque un an
         other: presque %{count} ans
       half_a_minute: une demi‑minute
       less_than_x_seconds:


### PR DESCRIPTION
The datetime: distance_in_words: almost_x_years: one: translation in all French versions read "presqu'un an".
However, the word "presque" should only be spelled "presqu'" in the word "presqu'île".

Here are some references to support that:
Larousse dictionary: https://www.larousse.fr/dictionnaires/francais/presque/63734
Office québécois de la langue française: https://vitrinelinguistique.oqlf.gouv.qc.ca/index.php?id=21745