### PR TITLE
Add gd locale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   - Korean (ko): Fix typo in `equal_to` keys #1061
   - Portuguese (pt, pt-BR): add translation for `errors.messages.in` #1071
   - Russian (ru): fix some errors in 'datetime' section
+  - Scottish Gaelic (gd): Add locale
   - Spanish (es): add translation for `errors.messages.in` #1071
   - French (fr, fr-CA, fr-CH, fr-FR): fix typo on 'almost_x_years: one' #1074
 - Add ordinalization for German (de, de-AT, de-CH, de-DE)

--- a/rails/locale/gd.yml
+++ b/rails/locale/gd.yml
@@ -1,0 +1,252 @@
+---
+gd:
+  activerecord:
+    errors:
+      messages:
+        record_invalid: 'Dh’fhàillig leis an dearbhadh: %{errors}'
+        restrict_dependent_destroy:
+          has_one: Cha b’ urrainn dhuinn an reacord a sguabadh às on a tha %{record} ann a tha an eisimeil air
+          has_many: Cha b’ urrainn dhuinn an reacord a sguabadh às on a tha %{record} ann a tha an eisimeil air
+  date:
+    abbr_day_names:
+    - DiD
+    - DiL
+    - DiM
+    - DiC
+    - Dia
+    - Dih
+    - DiS
+    abbr_month_names:
+    -
+    - Faoi
+    - Gearr
+    - Màrt
+    - Gibl
+    - Cèit
+    - Ògmh
+    - Iuch
+    - Lùna
+    - Sult
+    - Dàmh
+    - Samh
+    - Dùbh
+    day_names:
+    - DiDòmhnaich
+    - DiLuain
+    - DiMàirt
+    - DiCiadain
+    - DiarDaoin
+    - DihAoine
+    - DiSathairne
+    formats:
+      default: "%Y-%m-%d"
+      long: "%d %B %Y"
+      short: "%d %b"
+    month_names:
+    -
+    - Am Faoilleach
+    - An Gearran
+    - Am Màrt
+    - An Giblean
+    - An Cèitean
+    - An t-Ògmhios
+    - An t-Iuchar
+    - An Lùnastal
+    - An t-Sultain
+    - An Dàmhair
+    - An t-Samhain
+    - An Dùbhlachd
+    order:
+    - :day
+    - :month
+    - :year
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: mu %{count} uair a thìde
+        two: mu %{count} uair a thìde
+        few: mu %{count} uairean a thìde
+        other: mu %{count} uair a thìde
+      about_x_months:
+        one: mu %{count} mhìos
+        two: mu %{count} mhìos
+        few: mu %{count} mìosan
+        other: mu %{count} mìos
+      about_x_years:
+        one: mu %{count} bhliadhna
+        two: mu %{count} bhliadhna
+        few: mu %{count} bliadhnaichean
+        other: mu %{count} bliadhna
+      almost_x_years:
+        one: cha mhòr %{count} bhliadhna
+        two: cha mhòr %{count} bhliadhna
+        few: cha mhòr %{count} bliadhnaichean
+        other: cha mhòr %{count} bliadhna
+      half_a_minute: leth-mhionaid
+      less_than_x_seconds:
+        one: nas lugha na %{count} diog
+        two: nas lugha na %{count} dhiog
+        few: nas lugha na %{count} diogan
+        other: nas lugha na %{count} diog
+      less_than_x_minutes:
+        one: nas lugha na %{count} mhionaid
+        two: nas lugha na %{count} mhionaid
+        few: nas lugha na %{count} mionaidean
+        other: nas lugha na %{count} mionaid
+        one: nas lugha na mionaid
+      over_x_years:
+        one: còrr is %{count} bhliadhna
+        two: còrr is %{count} bhliadhna
+        few: còrr is %{count} bliadhnaichean
+        other: còrr is %{count} bliadhna
+      x_seconds:
+        one: "%{count} diog"
+        two: "%{count} dhiog"
+        few: "%{count} diogan"
+        other: "%{count} diog"
+      x_minutes:
+        one: "%{count} mhionaid"
+        two: "%{count} mhionaid"
+        few: "%{count} mionaidean"
+        other: "%{count} mionaid"
+      x_days:
+        one: "%{count} latha"
+        two: "%{count} latha"
+        few: "%{count} làithean"
+        other: "%{count} latha"
+      x_months:
+        one: "%{count} mhìos"
+        two: "%{count} mhìos"
+        few: "%{count} mìosan"
+        other: "%{count} mìos"
+      x_years:
+        one: "%{count} bhliadhna"
+        two: "%{count} bhliadhna"
+        few: "%{count} bliadhnaichean"
+        other: "%{count} bliadhna"
+    prompts:
+      second: Diog
+      minute: Mionaid
+      hour: Uair a thìde
+      day: Latha
+      month: Mìos
+      year: Bliadhna
+  errors:
+    format: "%{attribute}: %{message}"
+    messages:
+      accepted: feumach air aontachadh
+      blank: chan fhaod seo a bhith bàn
+      confirmation: chan eil e ’na mhaids dha %{attribute}
+      empty: chan fhaod seo a bhith falamh
+      equal_to: feumaidh seo a bhith co-ionnan ri %{count}
+      even: feumaidh seo a bhith ’na àireamh chothrom
+      exclusion: tha seo glèidhte
+      greater_than: feumaidh seo a bhith nas motha na %{count}
+      greater_than_or_equal_to: feumaidh seo a bhith nas motha na no co-ionann ri %{count}
+      in: feumaidh seo a bhith am broinn %{count}
+      inclusion: chan eil seo am broinn na liosta
+      invalid: chan eil seo dligheach
+      less_than: feumaidh seo a bhith nas lugha na %{count}
+      less_than_or_equal_to: feumaidh seo a bhith nas lugha na no co-ionann ri %{count}
+      model_invalid: 'Dh’fhàillig leis an dearbhadh: %{errors}'
+      not_a_number: chan eil seo ’na àireamh
+      not_an_integer: feumaidh seo a bhith ’na àireamh shlàn
+      odd: feumaidh seo a bhith ’na àireamh chòrr
+      other_than: chan fhaod seo a bhith %{count}
+      present: feumaidh seo a bhith bàn
+      required: feumaidh seo a bhith ann
+      taken: tha seo aig rud eile mu thràth
+      too_long:
+        one: tha seo ro fhada (tha %{count} charactar ceadaichte air a char as motha)
+        two: tha seo ro fhada (tha %{count} charactar ceadaichte air a char as motha)
+        few: tha seo ro fhada (tha %{count} caractaran ceadaichte air a char as motha)
+        other: tha seo ro fhada (tha %{count} caractar ceadaichte air a char as motha)
+      too_short:
+        one: tha seo ro ghoirid (tha %{count} charactar ceadaichte air a char as lugha)
+        two: tha seo ro ghoirid (tha %{count} charactar ceadaichte air a char as lugha)
+        few: tha seo ro ghoirid (tha %{count} caractaran ceadaichte air a char as lugha)
+        other: tha seo ro ghoirid (tha %{count} caractar ceadaichte air a char as lugha)
+      wrong_length:
+        one: chan eil an fhaide mar bu chòir (bu chòir dha a bhith %{count} charactar)
+        two: chan eil an fhaide mar bu chòir (bu chòir dha a bhith %{count} charactar)
+        few: chan eil an fhaide mar bu chòir (bu chòir dha a bhith %{count} caractaran)
+        other: chan eil an fhaide mar bu chòir (bu chòir dha a bhith %{count} caractar)
+    template:
+      body: 'Bha duilgheadasan ann leis na raointean seo:'
+      header:
+        one: "Dh’adhbharaich %{count} mhearachd nach gabh a’ %{model} seo a shàbhaladh"
+        two: "Dh’adhbharaich %{count} mhearachd nach gabh a’ %{model} seo a shàbhaladh"
+        few: "Dh’adhbharaich %{count} mearachdan nach gabh a’ %{model} seo a shàbhaladh"
+        other: "Dh’adhbharaich %{count} mearachd nach gabh a’ %{model} seo a shàbhaladh"
+  helpers:
+    select:
+      prompt: Tagh
+    submit:
+      create: Cruthaich %{model}
+      submit: Sàbhail %{model}
+      update: Ùraich %{model}
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u%n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "£"
+    format:
+      delimiter: ","
+      precision: 3
+      round_mode: default
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: billean
+          million: millean
+          quadrillion: quadrillean
+          thousand: mìle
+          trillion: trillean
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: bhaidht
+            two: bhaidht
+            few: baidhtean
+            other: baidht
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: " agus "
+      two_words_connector: " agus "
+      words_connector: ", "
+  time:
+    am: m
+    formats:
+      default: "%a, %d %b %Y %H:%M:%S %z"
+      long: "%d %b %Y, %H:%M"
+      short: "%d %b %H:%M"
+    pm: f

--- a/rails/ordinals/gd.rb
+++ b/rails/ordinals/gd.rb
@@ -1,0 +1,23 @@
+{
+  gd: {
+    number: {
+      nth: {
+        ordinals: -> (_key, number:, **_options) {
+          if number.to_i.abs == 1
+            'ᵈ'
+          elsif number.to_i.abs == 2
+            'ⁿᵃ'
+          elsif number.to_i.abs == 3
+            'ˢ'
+          else
+            'ᵐʰ'
+          end
+        },
+
+        ordinalized:  -> (_key, number:, **_options) {
+          "#{number}#{ActiveSupport::Inflector.ordinal(number)}"
+        }
+      }
+    }
+  }
+}

--- a/rails/ordinals/gd.rb
+++ b/rails/ordinals/gd.rb
@@ -3,11 +3,12 @@
     number: {
       nth: {
         ordinals: -> (_key, number:, **_options) {
-          if number.to_i.abs == 1
+          case number.to_i.abs
+          when 1
             'ᵈ'
-          elsif number.to_i.abs == 2
+          when 2
             'ⁿᵃ'
-          elsif number.to_i.abs == 3
+          when 3
             'ˢ'
           else
             'ᵐʰ'

--- a/rails/pluralization/gd.rb
+++ b/rails/pluralization/gd.rb
@@ -1,0 +1,29 @@
+module RailsI18n
+  module Pluralization
+    module ScottishGaelic
+      def self.rule
+        lambda do |n|
+          return :other unless n.is_a?(Numeric)
+
+          floorn = floor(n)
+
+          if floorn == 1 || floorn == 11
+            :one
+          elsif floorn == 2 || floorn == 12
+            :two
+          elsif (3..19).member?(floorn)
+            :few
+          else
+            :other
+          end
+        end
+      end
+    end
+  end
+end
+
+{ :gd => {
+    :'i18n' => {
+      :plural => {
+        :keys => [:one, :few, :many, :other],
+        :rule => RailsI18n::Pluralization::ScottishGaelic.rule }}}}

--- a/rails/pluralization/gd.rb
+++ b/rails/pluralization/gd.rb
@@ -25,5 +25,5 @@ end
 { :gd => {
     :'i18n' => {
       :plural => {
-        :keys => [:one, :few, :many, :other],
+        :keys => [:one, :two, :few, :other],
         :rule => RailsI18n::Pluralization::ScottishGaelic.rule }}}}

--- a/rails/pluralization/gd.rb
+++ b/rails/pluralization/gd.rb
@@ -5,7 +5,7 @@ module RailsI18n
         lambda do |n|
           return :other unless n.is_a?(Numeric)
 
-          floorn = n.floor()
+          floorn = n.floor
 
           if floorn == 1 || floorn == 11
             :one

--- a/rails/pluralization/gd.rb
+++ b/rails/pluralization/gd.rb
@@ -5,7 +5,7 @@ module RailsI18n
         lambda do |n|
           return :other unless n.is_a?(Numeric)
 
-          floorn = floor(n)
+          floorn = n.floor()
 
           if floorn == 1 || floorn == 11
             :one

--- a/spec/unit/ordinals_spec.rb
+++ b/spec/unit/ordinals_spec.rb
@@ -34,4 +34,15 @@ describe 'Ordinals for' do
       end
     end
   end
+
+  describe 'ScottishGaelic' do
+    it 'uses the default rules' do
+      I18n.with_locale(:gd) do
+        ActiveSupport::Inflector.ordinalize(1).should == "1ᵈ"
+        ActiveSupport::Inflector.ordinalize(2).should == "2ⁿᵃ"
+        ActiveSupport::Inflector.ordinalize(3).should == "3ˢ"
+        ActiveSupport::Inflector.ordinalize(4).should == "4ᵐʰ"
+      end
+    end
+  end
 end

--- a/spec/unit/ordinals_spec.rb
+++ b/spec/unit/ordinals_spec.rb
@@ -7,7 +7,7 @@ describe 'Ordinals for' do
   let(:config) { double :config, eager_load_namespaces: [], i18n: I18n, rails_i18n: RailsI18n }
 
   before do
-    I18n.available_locales = %w[fr en fr-CA fr-CH fr-FR]
+    I18n.available_locales = %w[fr en fr-CA fr-CH fr-FR gd]
 
     RailsI18n::Railtie.initializers.each { |init| init.run(app) }
     I18n.backend.reload!
@@ -36,7 +36,7 @@ describe 'Ordinals for' do
   end
 
   describe 'ScottishGaelic' do
-    it 'uses the default rules' do
+    it 'uses the custom rules' do
       I18n.with_locale(:gd) do
         ActiveSupport::Inflector.ordinalize(1).should == "1ᵈ"
         ActiveSupport::Inflector.ordinalize(2).should == "2ⁿᵃ"

--- a/spec/unit/pluralization_spec.rb
+++ b/spec/unit/pluralization_spec.rb
@@ -295,6 +295,39 @@ describe 'Pluralization rule for' do
     it_behaves_like 'East Slavic'
   end
 
+  describe 'ScottishGaelic', :locale => :gd do
+    it_behaves_like 'an ordinary pluralization rule'
+
+    it 'has "one", "two", "few" and "other" plural keys' do
+      plural_keys.size.should == 4
+      plural_keys.should include(:one, :two, :few, :other)
+    end
+
+    [1, 11, 1.2, 11.99].each do |count|
+      it "detects that #{count.inspect} in category 'one'" do
+        rule.call(count).should == :one
+      end
+    end
+
+    [2, 12, 2.2, 12.99].each do |count|
+      it "detects that #{count.inspect} in category 'two'" do
+        rule.call(count).should == :two
+      end
+    end
+
+    [3, 3.5, 4, 4.5, 5, 5.5, 6, 6.5, 7, 7.5, 8, 9, 10, 13, 14, 15, 16, 17, 18, 19, 19.5].each do |count|
+      it "detects that #{count.inspect} in category 'few'" do
+        rule.call(count).should == :few
+      end
+    end
+
+    [0, 20, 21, 23, 100, 20.8, 1_004.3, nil, "abc"].each do |count|
+      it "detects that #{count.inspect} in category 'other'" do
+        rule.call(count).should == :other
+      end
+    end
+  end
+
     describe 'Sardinian', :locale => :sc do
     it_behaves_like 'an ordinary pluralization rule'
     it_behaves_like 'one-other forms language'


### PR DESCRIPTION
Let me know if I need to define the plural rules somewhere. They are described at https://unicode-org.github.io/cldr-staging/charts/latest/supplemental/language_plural_rules.html#gd

I have a question regarding `month_names`: Are these being used standalone as well as being part of `long: "%d %B %Y"`? If there is no standalone usage, I should change these before we merge.

Also, I don't have a ruby environment set up, so this is not tested. Will the CI do an adequate job to prevent any crashes?