### PR TITLE
Add translations: ru.errors.messages.in, ru.number.format.round_mode.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
   - Japanese (ja): Add `in` and `round_mode` keys #1059
   - Korean (ko): Fix typo in `equal_to` keys #1061
   - Portuguese (pt, pt-BR): add translation for `errors.messages.in` #1071
-  - Russian (ru): fix some errors in 'datetime' section
+  - Russian (ru): fix some errors in 'datetime' section, add `errors.messages.in` and `number.format.round_mode` keys #1077
   - Spanish (es): add translation for `errors.messages.in` #1071
   - French (fr, fr-CA, fr-CH, fr-FR): fix typo on 'almost_x_years: one' #1074
 - Add ordinalization for German (de, de-AT, de-CH, de-DE)

--- a/rails/locale/ru.yml
+++ b/rails/locale/ru.yml
@@ -142,6 +142,7 @@ ru:
       exclusion: имеет зарезервированное значение
       greater_than: может иметь значение большее %{count}
       greater_than_or_equal_to: может иметь значение большее или равное %{count}
+      in: должно быть в диапазоне %{count}
       inclusion: имеет непредусмотренное значение
       invalid: имеет неверное значение
       less_than: может иметь значение меньшее чем %{count}
@@ -196,6 +197,7 @@ ru:
     format:
       delimiter: " "
       precision: 3
+      round_mode: default
       separator: ","
       significant: false
       strip_insignificant_zeros: false


### PR DESCRIPTION
Hello guys!
I would like to add some translations for Russian locale:
```
ru:
  errors: 
    messages: 
      in: должно быть в диапазоне %{count}

  number:
    format:
      round_mode: default
``` 

Changelog actualized.
Thank you in advance.