### PR TITLE
Better capitalization of months and weekdays for Croatian

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   - Russian (ru): fix some errors in 'datetime' section, add `errors.messages.in` and `number.format.round_mode` keys #1077
   - Spanish (es): add translation for `errors.messages.in` #1071
   - French (fr, fr-CA, fr-CH, fr-FR): fix typo on 'almost_x_years: one' #1074
+  - Croatian (hr): use lowercase for month and weekday names #1081
 - Add ordinalization for German (de, de-AT, de-CH, de-DE)
 
 ## 7.0.6 (2022-11-08)

--- a/rails/locale/hr.yml
+++ b/rails/locale/hr.yml
@@ -9,53 +9,53 @@ hr:
           has_many: Nije moguće izbrisati zapis jer postoje ovisni %{record}
   date:
     abbr_day_names:
-    - Ned
-    - Pon
-    - Uto
-    - Sri
-    - Čet
-    - Pet
-    - Sub
+    - ned
+    - pon
+    - uto
+    - sri
+    - čet
+    - pet
+    - sub
     abbr_month_names:
-    - 
-    - Sij
-    - Veǉ
-    - Ožu
-    - Tra
-    - Svi
-    - Lip
-    - Srp
-    - Kol
-    - Ruj
-    - Lis
-    - Stu
-    - Pro
+    -
+    - sij
+    - veǉ
+    - ožu
+    - tra
+    - svi
+    - lip
+    - srp
+    - kol
+    - ruj
+    - lis
+    - stu
+    - pro
     day_names:
-    - Nedjelja
-    - Ponedjeljak
-    - Utorak
-    - Srijeda
-    - Četvrtak
-    - Petak
-    - Subota
+    - nedjelja
+    - ponedjeljak
+    - utorak
+    - srijeda
+    - četvrtak
+    - petak
+    - subota
     formats:
       default: "%d.%m.%Y."
       long: "%e. %B %Y."
       short: "%e.%-m."
     month_names:
-    - 
-    - Siječanj
-    - Veljača
-    - Ožujak
-    - Travanj
-    - Svibanj
-    - Lipanj
-    - Srpanj
-    - Kolovoz
-    - Rujan
-    - Listopad
-    - Studeni
-    - Prosinac
+    -
+    - siječanj
+    - veljača
+    - ožujak
+    - travanj
+    - svibanj
+    - lipanj
+    - srpanj
+    - kolovoz
+    - rujan
+    - listopad
+    - studeni
+    - prosinac
     order:
     - :day
     - :month
@@ -203,11 +203,11 @@ hr:
       decimal_units:
         format: "%n %u"
         units:
-          billion: Milijarda
-          million: Milijun
-          quadrillion: Bilijarda
-          thousand: Tisuća
-          trillion: Bilijun
+          billion: milijarda
+          million: milijun
+          quadrillion: bilijarda
+          thousand: tisuća
+          trillion: bilijun
           unit: ''
       format:
         delimiter: ''


### PR DESCRIPTION
Days of week and month names are only capitalized in Croatian when they appear at the beginning of a sentence.

This PR changes the locale to reflect that. Lowercase localizations are in line with others such as Italian, Hungarian, French, Spanish, etc.