### PR TITLE
es: Change caracter -> carácter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Update following locales:
   - Norwegian (nb): Fix extra `%{count}` interpolation in `has_one` key #1082
+  - Spanish (es-419 es-AR es-CL es-CO es-CR es-EC es-MX es-NI es-PA es-PE es-US es-VE): Fix typo in word _carácter_ #1090
 
 ## 7.0.7 (2022-05-12)
 

--- a/rails/locale/es-419.yml
+++ b/rails/locale/es-419.yml
@@ -132,13 +132,13 @@ es-419:
       required: debe existir
       taken: ya ha sido tomado
       too_long:
-        one: es demasiado largo (máximo %{count} caracter)
+        one: es demasiado largo (máximo %{count} carácter)
         other: es demasiado largo (máximo %{count} caracteres)
       too_short:
-        one: es demasiado corto (mínimo %{count} caracter)
+        one: es demasiado corto (mínimo %{count} carácter)
         other: es demasiado corto (mínimo %{count} caracteres)
       wrong_length:
-        one: longitud errónea (debe ser de %{count} caracter)
+        one: longitud errónea (debe ser de %{count} carácter)
         other: longitud errónea (debe ser de %{count} caracteres)
     template:
       body: 'Revise que los siguientes campos sean válidos:'

--- a/rails/locale/es-AR.yml
+++ b/rails/locale/es-AR.yml
@@ -131,13 +131,13 @@ es-AR:
       required: debe existir
       taken: ya ha sido tomado
       too_long:
-        one: es demasiado largo (máximo %{count} caracter)
+        one: es demasiado largo (máximo %{count} carácter)
         other: es demasiado largo (máximo %{count} caracteres)
       too_short:
-        one: es demasiado corto (mínimo %{count} caracter)
+        one: es demasiado corto (mínimo %{count} carácter)
         other: es demasiado corto (mínimo %{count} caracteres)
       wrong_length:
-        one: longitud errónea (debe ser de %{count} caracter)
+        one: longitud errónea (debe ser de %{count} carácter)
         other: longitud errónea (debe ser de %{count} caracteres)
     template:
       body: 'Revise que los siguientes campos sean válidos:'

--- a/rails/locale/es-CL.yml
+++ b/rails/locale/es-CL.yml
@@ -131,13 +131,13 @@ es-CL:
       required: debe existir
       taken: ya está en uso
       too_long:
-        one: es demasiado largo (%{count} caracter máximo)
+        one: es demasiado largo (%{count} carácter máximo)
         other: es demasiado largo (%{count} caracteres máximo)
       too_short:
-        one: es demasiado corto (%{count} caracter mínimo)
+        one: es demasiado corto (%{count} carácter mínimo)
         other: es demasiado corto (%{count} caracteres mínimo)
       wrong_length:
-        one: no tiene la longitud correcta (%{count} caracter exacto)
+        one: no tiene la longitud correcta (%{count} carácter exacto)
         other: no tiene la longitud correcta (%{count} caracteres exactos)
     template:
       body: 'Se encontraron problemas con los siguientes campos:'

--- a/rails/locale/es-CO.yml
+++ b/rails/locale/es-CO.yml
@@ -131,13 +131,13 @@ es-CO:
       required: debe existir
       taken: ya ha sido tomado
       too_long:
-        one: es demasiado largo (máximo %{count} caracter)
+        one: es demasiado largo (máximo %{count} carácter)
         other: es demasiado largo (máximo %{count} caracteres)
       too_short:
-        one: es demasiado corto (mínimo %{count} caracter)
+        one: es demasiado corto (mínimo %{count} carácter)
         other: es demasiado corto (mínimo %{count} caracteres)
       wrong_length:
-        one: longitud errónea (debe ser de %{count} caracter)
+        one: longitud errónea (debe ser de %{count} carácter)
         other: longitud errónea (debe ser de %{count} caracteres)
     template:
       body: 'Revise que los siguientes campos sean válidos:'

--- a/rails/locale/es-CR.yml
+++ b/rails/locale/es-CR.yml
@@ -131,13 +131,13 @@ es-CR:
       required: debe existir
       taken: ya ha sido utilizado
       too_long:
-        one: es demasiado largo (máximo %{count} caracter)
+        one: es demasiado largo (máximo %{count} carácter)
         other: es demasiado largo (máximo %{count} caracteres)
       too_short:
-        one: es demasiado corto (mínimo %{count} caracter)
+        one: es demasiado corto (mínimo %{count} carácter)
         other: es demasiado corto (mínimo %{count} caracteres)
       wrong_length:
-        one: longitud errónea (debe ser de %{count} caracter)
+        one: longitud errónea (debe ser de %{count} carácter)
         other: longitud errónea (debe ser de %{count} caracteres)
     template:
       body: 'Revise que los siguientes campos sean válidos:'

--- a/rails/locale/es-EC.yml
+++ b/rails/locale/es-EC.yml
@@ -132,13 +132,13 @@ es-EC:
       required: debe existir
       taken: ya está en uso
       too_long:
-        one: es demasiado largo (máximo %{count} caracter)
+        one: es demasiado largo (máximo %{count} carácter)
         other: es demasiado largo (máximo %{count} caracteres)
       too_short:
-        one: es demasiado corto (mínimo %{count} caracter)
+        one: es demasiado corto (mínimo %{count} carácter)
         other: es demasiado corto (mínimo %{count} caracteres)
       wrong_length:
-        one: no tiene la longitud correcta (debe ser de %{count} caracter)
+        one: no tiene la longitud correcta (debe ser de %{count} carácter)
         other: no tiene la longitud correcta (debe ser de %{count} caracteres)
     template:
       body: 'Revise que los siguientes campos sean válidos:'

--- a/rails/locale/es-MX.yml
+++ b/rails/locale/es-MX.yml
@@ -131,13 +131,13 @@ es-MX:
       required: debe existir
       taken: ya ha sido tomado
       too_long:
-        one: es demasiado largo (máximo %{count} caracter)
+        one: es demasiado largo (máximo %{count} carácter)
         other: es demasiado largo (máximo %{count} caracteres)
       too_short:
-        one: es demasiado corto (mínimo %{count} caracter)
+        one: es demasiado corto (mínimo %{count} carácter)
         other: es demasiado corto (mínimo %{count} caracteres)
       wrong_length:
-        one: longitud errónea (debe ser de %{count} caracter)
+        one: longitud errónea (debe ser de %{count} carácter)
         other: longitud errónea (debe ser de %{count} caracteres)
     template:
       body: 'Revise que los siguientes campos sean válidos:'

--- a/rails/locale/es-NI.yml
+++ b/rails/locale/es-NI.yml
@@ -131,13 +131,13 @@ es-NI:
       required: debe existir
       taken: ya ha sido utilizado
       too_long:
-        one: es demasiado largo (máximo %{count} caracter)
+        one: es demasiado largo (máximo %{count} carácter)
         other: es demasiado largo (máximo %{count} caracteres)
       too_short:
-        one: es demasiado corto (mínimo %{count} caracter)
+        one: es demasiado corto (mínimo %{count} carácter)
         other: es demasiado corto (mínimo %{count} caracteres)
       wrong_length:
-        one: longitud errónea (debe ser de %{count} caracter)
+        one: longitud errónea (debe ser de %{count} carácter)
         other: longitud errónea (debe ser de %{count} caracteres)
     template:
       body: 'Revise que los siguientes campos sean válidos:'

--- a/rails/locale/es-PA.yml
+++ b/rails/locale/es-PA.yml
@@ -132,13 +132,13 @@ es-PA:
       required: debe existir
       taken: ya está en uso
       too_long:
-        one: es demasiado largo(a) (máximo %{count} caracter)
+        one: es demasiado largo(a) (máximo %{count} carácter)
         other: es demasiado largo(a) (máximo %{count} caracteres)
       too_short:
-        one: es demasiado corto(a) (mínimo %{count} caracter)
+        one: es demasiado corto(a) (mínimo %{count} carácter)
         other: es demasiado corto(a) (mínimo %{count} caracteres)
       wrong_length:
-        one: no tiene la longitud correcta (debe ser de %{count} caracter)
+        one: no tiene la longitud correcta (debe ser de %{count} carácter)
         other: no tiene la longitud correcta (debe ser de %{count} caracteres)
     template:
       body: 'Revise que los siguientes campos sean válidos:'

--- a/rails/locale/es-PE.yml
+++ b/rails/locale/es-PE.yml
@@ -131,13 +131,13 @@ es-PE:
       required: debe existir
       taken: ya ha sido tomado
       too_long:
-        one: es demasiado largo (máximo %{count} caracter)
+        one: es demasiado largo (máximo %{count} carácter)
         other: es demasiado largo (máximo %{count} caracteres)
       too_short:
-        one: es demasiado corto (mínimo %{count} caracter)
+        one: es demasiado corto (mínimo %{count} carácter)
         other: es demasiado corto (mínimo %{count} caracteres)
       wrong_length:
-        one: longitud errónea (debe ser de %{count} caracter)
+        one: longitud errónea (debe ser de %{count} carácter)
         other: longitud errónea (debe ser de %{count} caracteres)
     template:
       body: 'Revise que los siguientes campos sean válidos:'

--- a/rails/locale/es-US.yml
+++ b/rails/locale/es-US.yml
@@ -131,13 +131,13 @@ es-US:
       required: debe existir
       taken: ya ha sido tomado
       too_long:
-        one: es demasiado largo (máximo %{count} caracter)
+        one: es demasiado largo (máximo %{count} carácter)
         other: es demasiado largo (máximo %{count} caracteres)
       too_short:
-        one: es demasiado corto (mínimo %{count} caracter)
+        one: es demasiado corto (mínimo %{count} carácter)
         other: es demasiado corto (mínimo %{count} caracteres)
       wrong_length:
-        one: longitud errónea (debe ser de %{count} caracter)
+        one: longitud errónea (debe ser de %{count} carácter)
         other: longitud errónea (debe ser de %{count} caracteres)
     template:
       body: 'Revise que los siguientes campos sean válidos:'

--- a/rails/locale/es-VE.yml
+++ b/rails/locale/es-VE.yml
@@ -131,13 +131,13 @@ es-VE:
       required: debe existir
       taken: ya está en uso
       too_long:
-        one: es demasiado largo (máximo %{count} caracter)
+        one: es demasiado largo (máximo %{count} carácter)
         other: es demasiado largo (máximo %{count} caracteres)
       too_short:
-        one: es demasiado corto (mínimo %{count} caracter)
+        one: es demasiado corto (mínimo %{count} carácter)
         other: es demasiado corto (mínimo %{count} caracteres)
       wrong_length:
-        one: longitud errónea (debe ser de %{count} caracter)
+        one: longitud errónea (debe ser de %{count} carácter)
         other: longitud errónea (debe ser de %{count} caracteres)
     template:
       body: 'Revise que los siguientes campos sean válidos:'


### PR DESCRIPTION
The word _caracter_ (without accent) does not exist.
It should be spelled _carácter_ regardless of region.
The plural form _caracteres_ is correct.

Source: https://www.rae.es/dpd/carácter