### PR TITLE
Fix Rails' update script branch

### DIFF
--- a/rails/rails/active_model.yml
+++ b/rails/rails/active_model.yml
@@ -10,15 +10,14 @@ en:
       inclusion: "is not included in the list"
       exclusion: "is reserved"
       invalid: "is invalid"
-      confirmation: "doesn’t match %{attribute}"
+      confirmation: "doesn't match %{attribute}"
       accepted: "must be accepted"
-      empty: "can’t be empty"
-      blank: "can’t be blank"
+      empty: "can't be empty"
+      blank: "can't be blank"
       present: "must be blank"
       too_long:
         one: "is too long (maximum is 1 character)"
         other: "is too long (maximum is %{count} characters)"
-      password_too_long: "is too long"
       too_short:
         one: "is too short (minimum is 1 character)"
         other: "is too short (minimum is %{count} characters)"

--- a/rails/rails/active_support.yml
+++ b/rails/rails/active_support.yml
@@ -57,7 +57,6 @@ en:
       format:
         # Where is the currency sign? %u is the currency unit, %n is the number (default: $5.00)
         format: "%u%n"
-        negative_format: "-%u%n"
         unit: "$"
         # These six are to override number.format and are optional
         separator: "."
@@ -113,7 +112,6 @@ en:
           tb: "TB"
           pb: "PB"
           eb: "EB"
-          zb: "ZB"
       # Used in NumberHelper.number_to_human()
       decimal_units:
         format: "%n %u"

--- a/rails/script/update.rb
+++ b/rails/script/update.rb
@@ -4,11 +4,11 @@ rails_locale_dir = File.expand_path(File.join(curr_dir, "..", "rails"))
 puts "Fetching latest Rails locale files to #{rails_locale_dir}"
 
 exec %(
-  curl -Lo '#{rails_locale_dir}/action_view.yml' https://raw.github.com/rails/rails/main/actionview/lib/action_view/locale/en.yml
+  curl -Lo '#{rails_locale_dir}/action_view.yml' https://raw.githubusercontent.com/rails/rails/7-0-stable/actionview/lib/action_view/locale/en.yml
 
-  curl -Lo '#{rails_locale_dir}/active_model.yml' https://raw.github.com/rails/rails/main/activemodel/lib/active_model/locale/en.yml
+  curl -Lo '#{rails_locale_dir}/active_model.yml' https://raw.githubusercontent.com/rails/rails/7-0-stable/activemodel/lib/active_model/locale/en.yml
 
-  curl -Lo '#{rails_locale_dir}/active_record.yml' https://raw.github.com/rails/rails/main/activerecord/lib/active_record/locale/en.yml
+  curl -Lo '#{rails_locale_dir}/active_record.yml' https://raw.githubusercontent.com/rails/rails/7-0-stable/activerecord/lib/active_record/locale/en.yml
 
-  curl -Lo '#{rails_locale_dir}/active_support.yml' https://raw.github.com/rails/rails/main/activesupport/lib/active_support/locale/en.yml
+  curl -Lo '#{rails_locale_dir}/active_support.yml' https://raw.githubusercontent.com/rails/rails/7-0-stable/activesupport/lib/active_support/locale/en.yml
 )


### PR DESCRIPTION
We should track the latest Rails release, not the main branch.

Fix 30a8745 by pointing the update script to the proper Rails branch.

Perhaps changing to a git model that more closely mimics Rails' is a better approach long-term.  In the meantime, keep bumping the branch in the update script as Rails releases are published.

Fix #1086.