### PR TITLE
Make short Portuguese date format consistent in length with other languages

### DIFF
--- a/rails/locale/pt-BR.yml
+++ b/rails/locale/pt-BR.yml
@@ -41,7 +41,7 @@ pt-BR:
     formats:
       default: "%d/%m/%Y"
       long: "%d de %B de %Y"
-      short: "%d de %B"
+      short: "%d de %b"
     month_names:
     -
     - janeiro

--- a/rails/locale/pt.yml
+++ b/rails/locale/pt.yml
@@ -41,7 +41,7 @@ pt:
     formats:
       default: "%d/%m/%Y"
       long: "%d de %B de %Y"
-      short: "%d de %B"
+      short: "%d de %b"
     month_names:
     -
     - janeiro


### PR DESCRIPTION
Both Portuguese and Brazilian Portuguese have abbreviated month names. It makes more sense to use them when printing a date in the short format, as is done in most other languages (including Spanish, where 'de' is also used in the short date format).