### PR TITLE
Add indication of AM or PM to all locales where missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 7.0.9 (2023-11-16)
 
-- Fix empty `am` and `pm` keys to make AM and PM dates distinguishable in every language
+- Fix empty `am` and `pm` keys to make dates/times in the 12-hour time format distinguishable in every locale
 - Update following locales:
   - Bosnian (bs)
   - Danish (da)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## unreleased
 
-## 7.0.8 (2023-11-16)
+## 7.0.9 (2023-11-16)
 
-- Fix empty `am` and `pm` keys
+- Fix empty `am` and `pm` keys to make AM and PM dates distinguishable in every language
 - Update following locales:
   - Bosnian (bs)
   - Danish (da)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 ## unreleased
 
+## 7.0.8 (2023-11-16)
+
+- Fix empty `am` and `pm` keys
+- Update following locales:
+  - Bosnian (bs)
+  - Danish (da)
+  - Galician (gl)
+  - Icelandic (is)
+  - Norwegian Bokmål (nb)
+  - Norwegian Nynorsk (nn)
+  - Portuguese (pt-BR)
+  - Romanian (ro)
+  - Swedish (sv sv-FI sv-SE)
 
 ## 7.0.8 (2023-08-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 7.0.9 (2023-11-16)
 
-- Fix empty `am` and `pm` keys to make dates/times in the 12-hour time format distinguishable in every locale
+- Fix empty `am` and `pm` keys to make dates/times in the 12-hour time format distinguishable in every locale #1105
 - Update following locales:
   - Afrikaans (af): Fix translation of May #1110
   - Traditional Chinese (zh-HK, zh-TW, zh-YUE): Use traditional "week" character in `date.abbr_day_names` #1112

--- a/rails/locale/bs.yml
+++ b/rails/locale/bs.yml
@@ -240,9 +240,9 @@ bs:
       two_words_connector: " i "
       words_connector: ", "
   time:
-    am: ''
+    am: am
     formats:
       default: "%d.%m.%Y. %H:%M:%S"
       long: "%d. %B %Y. - %H:%M:%S"
       short: "%d. %b %Y. %H:%M"
-    pm: ''
+    pm: pm

--- a/rails/locale/da.yml
+++ b/rails/locale/da.yml
@@ -213,9 +213,9 @@ da:
       two_words_connector: " og "
       words_connector: ", "
   time:
-    am: ''
+    am: am
     formats:
       default: "%e. %B %Y, %H.%M"
       long: "%A d. %e. %B %Y, %H.%M"
       short: "%e. %b %Y, %H.%M"
-    pm: ''
+    pm: pm

--- a/rails/locale/gl.yml
+++ b/rails/locale/gl.yml
@@ -164,9 +164,9 @@ gl:
       two_words_connector: " e "
       words_connector: ", "
   time:
-    am: ''
+    am: am
     formats:
       default: "%A, %e de %B de %Y ás %H:%M"
       long: "%A %e de %B de %Y ás %H:%M"
       short: "%e/%m, %H:%M"
-    pm: ''
+    pm: pm

--- a/rails/locale/is.yml
+++ b/rails/locale/is.yml
@@ -208,9 +208,9 @@ is:
       two_words_connector: " og "
       words_connector: ", "
   time:
-    am: ''
+    am: am
     formats:
       default: "%A %e. %B %Y kl. %H:%M"
       long: "%A %e. %B %Y kl. %H:%M"
       short: "%e. %B kl. %H:%M"
-    pm: ''
+    pm: pm

--- a/rails/locale/nb.yml
+++ b/rails/locale/nb.yml
@@ -213,9 +213,9 @@ nb:
       two_words_connector: " og "
       words_connector: ", "
   time:
-    am: ''
+    am: am
     formats:
       default: "%A, %e. %B %Y, %H:%M"
       long: "%A, %e. %B %Y, %H:%M"
       short: "%e. %B, %H:%M"
-    pm: ''
+    pm: pm

--- a/rails/locale/nn.yml
+++ b/rails/locale/nn.yml
@@ -200,9 +200,9 @@ nn:
       two_words_connector: " og "
       words_connector: ", "
   time:
-    am: ''
+    am: am
     formats:
       default: "%A, %e. %B %Y, %H:%M"
       long: "%A, %e. %B %Y, %H:%M"
       short: "%e. %B, %H:%M"
-    pm: ''
+    pm: pm

--- a/rails/locale/pt-BR.yml
+++ b/rails/locale/pt-BR.yml
@@ -217,9 +217,9 @@ pt-BR:
       two_words_connector: " e "
       words_connector: ", "
   time:
-    am: ''
+    am: am
     formats:
       default: "%a, %d de %B de %Y, %H:%M:%S %z"
       long: "%d de %B de %Y, %H:%M"
       short: "%d de %B, %H:%M"
-    pm: ''
+    pm: pm

--- a/rails/locale/ro.yml
+++ b/rails/locale/ro.yml
@@ -201,9 +201,9 @@ ro:
       two_words_connector: " și "
       words_connector: ", "
   time:
-    am: ''
+    am: am
     formats:
       default: "%a %d %b %Y, %H:%M:%S %z"
       long: "%d %B %Y %H:%M"
       short: "%d %b %H:%M"
-    pm: ''
+    pm: pm

--- a/rails/locale/sv-FI.yml
+++ b/rails/locale/sv-FI.yml
@@ -199,9 +199,9 @@ sv-FI:
       two_words_connector: " och "
       words_connector: ", "
   time:
-    am: ""
+    am: am
     formats:
       default: "%a, %e %b %Y %H:%M:%S %z"
       long: "%e %B %Y %H:%M"
       short: "%e %b %H:%M"
-    pm: ""
+    pm: pm

--- a/rails/locale/sv-SE.yml
+++ b/rails/locale/sv-SE.yml
@@ -202,9 +202,9 @@ sv-SE:
       two_words_connector: " och "
       words_connector: ", "
   time:
-    am: ''
+    am: am
     formats:
       default: "%a, %e %b %Y %H:%M:%S %z"
       long: "%e %B %Y %H:%M"
       short: "%e %b %H:%M"
-    pm: ''
+    pm: pm

--- a/rails/locale/sv.yml
+++ b/rails/locale/sv.yml
@@ -202,9 +202,9 @@ sv:
       two_words_connector: " och "
       words_connector: ", "
   time:
-    am: ''
+    am: am
     formats:
       default: "%a, %e %b %Y %H:%M:%S %z"
       long: "%e %B %Y %H:%M"
       short: "%e %b %H:%M"
-    pm: ''
+    pm: pm


### PR DESCRIPTION
When specifically formatting a timestamp in the 12-hour clock format, it should be possible to distinguish between AM and PM, even if the 12-hour clock is not commonly used in said langauge. Also, "AM" and "PM" are pretty much universal and most people around the world should understand that.