### PR TITLE
[af] Fix translation of May

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## unreleased
 
+- Update following locales:
+  - Afrikaans (af): Fix translation of May #1110
 
 ## 7.0.8 (2023-08-15)
 

--- a/rails/locale/af.yml
+++ b/rails/locale/af.yml
@@ -48,7 +48,7 @@ af:
     - Februarie
     - Maart
     - April
-    - Mai
+    - Mei
     - Junie
     - Julie
     - Augustus


### PR DESCRIPTION
I don't speak any Afrikaans, but [according to CLDR](https://github.com/unicode-org/cldr/blob/dc6b3fe/common/main/af.xml#L1361C1-L1361C8) and e.g. [Wikipedia](https://af.wikipedia.org/wiki/Maand), entry for May in `month_names` should be _Mei_, not _Mai_. This will make it match the corresponding entry in `abbr_month_names`, [which is already _Mei_](https://github.com/svenfuchs/rails-i18n/blob/64e3b0e59994cc65fbc47046f9a12cf95737f9eb/rails/locale/af.yml#L25). 
