### PR TITLE
[it] Fix `second` prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## unreleased
 
+- Update following locales:
+  - Italian (it): Fix translation for `second` prompt #1111
 
 ## 7.0.8 (2023-08-15)
 

--- a/rails/locale/it.yml
+++ b/rails/locale/it.yml
@@ -100,7 +100,7 @@ it:
         one: "%{count} anno"
         other: "%{count} anni"
     prompts:
-      second: Secondi
+      second: Secondo
       minute: Minuto
       hour: Ora
       day: Giorno


### PR DESCRIPTION
I don't speak any Italian, but AFAICT the `second` prompt uses a plural form unlike the other prompts and unlike its English counterpart.