### PR TITLE
zh-TW, zh-HK, zh-YUE: Write abbr_day_names using traditional character

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## unreleased
 
+- Update following locales:
+  - Traditional Chinese (zh-HK, zh-TW, zh-YUE): Use traditional "week" character in `date.abbr_day_names`.
 
 ## 7.0.8 (2023-08-15)
 

--- a/rails/locale/zh-HK.yml
+++ b/rails/locale/zh-HK.yml
@@ -9,13 +9,13 @@ zh-HK:
           has_many: 由於%{record}依賴此記錄，無法移除
   date:
     abbr_day_names:
-    - 周日
-    - 周一
-    - 周二
-    - 周三
-    - 周四
-    - 周五
-    - 周六
+    - 週日
+    - 週一
+    - 週二
+    - 週三
+    - 週四
+    - 週五
+    - 週六
     abbr_month_names:
     - 
     - 1月

--- a/rails/locale/zh-TW.yml
+++ b/rails/locale/zh-TW.yml
@@ -9,13 +9,13 @@ zh-TW:
           has_many: 由於%{record}需要此記錄，所以無法移除記錄
   date:
     abbr_day_names:
-    - 周日
-    - 周一
-    - 周二
-    - 周三
-    - 周四
-    - 周五
-    - 周六
+    - 週日
+    - 週一
+    - 週二
+    - 週三
+    - 週四
+    - 週五
+    - 週六
     abbr_month_names:
     - 
     - 1月

--- a/rails/locale/zh-YUE.yml
+++ b/rails/locale/zh-YUE.yml
@@ -9,13 +9,13 @@ zh-YUE:
           has_many: 唔可以刪除，因為%{record}要用佢
   date:
     abbr_day_names:
-    - 周日
-    - 周一
-    - 周二
-    - 周三
-    - 周四
-    - 周五
-    - 周六
+    - 週日
+    - 週一
+    - 週二
+    - 週三
+    - 週四
+    - 週五
+    - 週六
     abbr_month_names:
     - 
     - 1月


### PR DESCRIPTION
Although `周` is possible in these scripts, the character `週` is preferred.

`zh-CN` is not changed.