### PR TITLE
cs capitalise date abbr_month_names, day_names, month_names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Update following locales:
   - Afrikaans (af): Fix translation of May #1110
+  - Czech (cs): Capitalise date day and month names for consistency #1113
   - Traditional Chinese (zh-HK, zh-TW, zh-YUE): Use traditional "week" character in `date.abbr_day_names` #1112
   - Italian (it): Fix translation for `second` prompt #1111
 

--- a/rails/locale/cs.yml
+++ b/rails/locale/cs.yml
@@ -18,44 +18,44 @@ cs:
     - So
     abbr_month_names:
     - 
-    - led
-    - úno
-    - bře
-    - dub
-    - kvě
-    - čvn
-    - čvc
-    - srp
-    - zář
-    - říj
-    - lis
-    - pro
+    - Led
+    - Úno
+    - Bře
+    - Dub
+    - Kvě
+    - Čvn
+    - Čvc
+    - Srp
+    - Zář
+    - Říj
+    - Lis
+    - Pro
     day_names:
-    - neděle
-    - pondělí
-    - úterý
-    - středa
-    - čtvrtek
-    - pátek
-    - sobota
+    - Neděle
+    - Pondělí
+    - Úterý
+    - Středa
+    - Čtvrtek
+    - Pátek
+    - Sobota
     formats:
       default: "%d. %m. %Y"
       long: "%d. %B %Y"
       short: "%d %b"
     month_names:
     - 
-    - leden
-    - únor
-    - březen
-    - duben
-    - květen
-    - červen
-    - červenec
-    - srpen
-    - září
-    - říjen
-    - listopad
-    - prosinec
+    - Leden
+    - Únor
+    - Březen
+    - Duben
+    - Květen
+    - Červen
+    - Červenec
+    - Srpen
+    - Září
+    - Říjen
+    - Listopad
+    - Prosinec
     order:
     - :day
     - :month


### PR DESCRIPTION
Whilst it is correct that Czech (cs) does not capitalise day or month names appearing in the middle of a sentence, there is a choice when it comes to abbreviated or full days or months appearing on their own, in a menu or chart, etc. `date.abbr_day_names` used initial capitals, but `date.abbr_month_names`, `date.day_names`, `date.month_names` did not. Whichever style is used should likely be standardised, particularly between `date.abbr_day_names` and `date.abbr_month_names`.

The translations for Slovak (sk), a close language in the same family with similar (but by no means identical) grammar, use initial capitals for all these day and month translations.

Standardise these day and month translations to use initial capitals.

Note I am not a native Czech speaker. However, I work a lot with multilingual translations, and checked this matter with a professional native Czech translator working for me. Their opinion was that both initial capital and lowercase translations are acceptable, but that an initial capital was more common and felt more natural. I also checked this with a native Slovak speaker who is also fluent in Czech, and they had the same opinion.

Greetings from Prague!