### PR TITLE
Specify Rails 7.1+ gem version

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Centralization of locale data collection for Ruby on Rails.
 Include the gem to your Gemfile:
 
 ``` ruby
-gem 'rails-i18n', '~> 7.0.0' # For 7.0.0
+gem 'rails-i18n', '~> 7.0.0' # For Rails >= 7.0.0
 gem 'rails-i18n', '~> 6.0' # For 6.x
 gem 'rails-i18n', '~> 5.1' # For 5.0.x, 5.1.x and 5.2.x
 gem 'rails-i18n', '~> 4.0' # For 4.0.x
@@ -24,7 +24,7 @@ gem 'rails-i18n', github: 'svenfuchs/rails-i18n', branch: 'rails-3-x' # For 3.x
 Alternatively, execute the following command:
 
 ``` shell
-gem install rails-i18n -v '~> 7.0.0' # For 7.0.0
+gem install rails-i18n -v '~> 7.0.0' # For Rails >= 7.0.0
 gem install rails-i18n -v '~> 6.0' # For 6.x
 gem install rails-i18n -v '~> 5.1' # For  For 5.0.x, 5.1.x and 5.2.x
 gem install rails-i18n -v '~> 4.0' # For 4.0.x


### PR DESCRIPTION
I noticed that Rails 7.1 has been released two months ago on October 5 and I couldn't figure out which rails-i18n gem version I needed to use for Rails 7.1+.

I tried using `gem 'rails-i18n', '~> 7.0.0'` and that seems to work just fine, so I updated the `README.md` accordingly.

Let me know if this is incorrect and which gem version should be used instead.

Thanks!
