### PR TITLE
Move entries from non-existent 7.0.9 to Unreleased section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 - Add following locales:
   - Welsh (cy)
-## 7.0.9 (2023-11-16)
-
 - Fix empty `am` and `pm` keys to make dates/times in the 12-hour time format distinguishable in every locale #1105
 - Update following locales:
   - Afrikaans (af): Fix translation of May #1110


### PR DESCRIPTION
#### Move Entries to 'Unreleased' for Version 7.0.9 (2023-11-16)
This PR addresses the absence of version 7.0.9 (2023-11-16) by moving relevant entries to the 'Unreleased' section, ensuring an accurate representation of changes