### PR TITLE
Fix compatibility with `--frozen-string-literal`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,16 @@ jobs:
           - '3.0'
           - '3.1'
           - '3.2'
+          - '3.3'
+        rubyopt: [""]
+        include:
+          - ruby-version: '3.3'
+            rubyopt: "--enable-frozen-string-literal --debug-frozen-string-literal"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "${{ matrix.ruby-version }}"
           bundler-cache: true
-      - run: bundle exec rake
+      - run: bundle exec rake RUBYOPT="${{ matrix.rubyopt }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## unreleased
 - Update following locales:
   - Portuguese (pt): Fixed `number.currency.format.format` and `helpers.submit.update` #1122
+- Fix compatibility with frozen string literals. #1120
 
 ## 7.0.9 (2024-03-13)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rails-i18n (7.0.8)
+    rails-i18n (7.0.9)
       i18n (>= 0.7, < 2)
       railties (>= 6.0.0, < 8)
 

--- a/rails/transliteration/ru.rb
+++ b/rails/transliteration/ru.rb
@@ -13,7 +13,7 @@ module RailsI18n
 
             chars = string.scan(%r{#{multi_keys.join '|'}|\w|.})
 
-            result = ""
+            result = +""
 
             chars.each_with_index do |char, index|
               if upper.has_key?(char) && lower.has_key?(chars[index+1])

--- a/spec/support/ruby_content.rb
+++ b/spec/support/ruby_content.rb
@@ -4,7 +4,7 @@ module RailsI18n
   module Spec
     module RubyContent
       def content
-        @content ||= eval(IO.read(@filepath), TOPLEVEL_BINDING)
+        @content ||= eval(File.read(@filepath), TOPLEVEL_BINDING, @filepath)
       end
     end
   end


### PR DESCRIPTION
This option has been available since a long time, but many gems don't support it, I'm trying to fix that.

Also it's not unlikely that this will become the default a few years down the line: https://bugs.ruby-lang.org/issues/20205