### PR TITLE
Portuguese: fix helpers.submit.update and number.currency.format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## unreleased
+- Update following locales:
+  - Portuguese (pt): Fixed `number.currency.format.format` and `helpers.submit.update` #1122
 
 ## 7.0.9 (2024-03-13)
 

--- a/rails/locale/pt.yml
+++ b/rails/locale/pt.yml
@@ -145,7 +145,7 @@ pt:
     submit:
       create: Criar %{model}
       submit: Gravar %{model}
-      update: Actualizar %{model}
+      update: Atualizar %{model}
   number:
     currency:
       format:

--- a/rails/locale/pt.yml
+++ b/rails/locale/pt.yml
@@ -150,7 +150,7 @@ pt:
     currency:
       format:
         delimiter: "."
-        format: "%u %n"
+        format: "%n %u"
         precision: 2
         separator: ","
         significant: false


### PR DESCRIPTION
Hello. 👋  First for the great work with this gem, really helpful! 👍 

I've just noticed two small issues with the `:pt` translations, namely:
- the `helpers.submit.update` translation does not follow the changes introduced by "Acordo Ortográfico de 1990" which removed a few nuances between pt-PT and pt-BR, namely "Actualizar" is spelled "Atualizar" ([source](http://www.portaldalinguaportuguesa.org/novoacordo.php?action=novoacordo&act=list&version=all));
- I believe the currency formatting is also off (maybe based on pt-BR or just overlooked when translating from English?). Currently it will display "€ 100.000,00" rather than "100.000,00 €". I've checked a couple of banking apps before making this change, the latter seems to be the standard (Google Sheets also follows the same pattern with the locale set to Portugal).