### PR TITLE
Croatian (hr): month names and weekday abbreviations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## unreleased
 - Update following locales:
   - Portuguese (pt): Fixed `number.currency.format.format` and `helpers.submit.update` #1122
+  - Croatian (hr): use genitive case for month names and put a period after weekday and month abbreviations #1126
 - Fix compatibility with frozen string literals. #1120
 
 ## 7.0.9 (2024-03-13)

--- a/rails/locale/hr.yml
+++ b/rails/locale/hr.yml
@@ -9,27 +9,27 @@ hr:
           has_many: Nije moguće izbrisati zapis jer postoje ovisni %{record}
   date:
     abbr_day_names:
-    - ned
-    - pon
-    - uto
-    - sri
-    - čet
-    - pet
-    - sub
+    - ned.
+    - pon.
+    - uto.
+    - sri.
+    - čet.
+    - pet.
+    - sub.
     abbr_month_names:
     -
-    - sij
-    - veǉ
-    - ožu
-    - tra
-    - svi
-    - lip
-    - srp
-    - kol
-    - ruj
-    - lis
-    - stu
-    - pro
+    - sij.
+    - velj.
+    - ožu.
+    - tra.
+    - svi.
+    - lip.
+    - srp.
+    - kol.
+    - ruj.
+    - lis.
+    - stu.
+    - pro.
     day_names:
     - nedjelja
     - ponedjeljak
@@ -44,18 +44,18 @@ hr:
       short: "%e.%-m."
     month_names:
     -
-    - siječanj
-    - veljača
-    - ožujak
-    - travanj
-    - svibanj
-    - lipanj
-    - srpanj
-    - kolovoz
-    - rujan
-    - listopad
-    - studeni
-    - prosinac
+    - siječnja
+    - veljače
+    - ožujka
+    - travnja
+    - svibnja
+    - lipnja
+    - srpnja
+    - kolovoza
+    - rujna
+    - listopada
+    - studenoga
+    - prosinca
     order:
     - :day
     - :month


### PR DESCRIPTION
I noticed the Croatian date & time localization could do with more improvements to be orthographically correct:

- Use the genitive case for formatting month names, such as: "13. kolovoza 2024."
- Use a period after abbreviation names, as is orthographically correct.

I'm not entirely sure the first change results in the expected string when looking at the month names by themselves. However, the most common use of these localizations seems to be using the month name in a date string such as the example above, where it would be correct. Since they are already represented in lowercase, it seems that they are mostly intended to from a date format string and not be used individually.

Basically, it would be unexpected to use "kolovoza" by itself, as it means "of August". I'm wondering if you have any input on whether I'm correct in assuming this is the intended or most frequent use of these translated strings.