### PR TITLE
Remove comma in date

### DIFF
--- a/rails/locale/tr.yml
+++ b/rails/locale/tr.yml
@@ -40,7 +40,7 @@ tr:
     - Cumartesi
     formats:
       default: "%d.%m.%Y"
-      long: "%e %B %Y, %A"
+      long: "%e %B %Y %A"
       short: "%e %b"
     month_names:
     - 


### PR DESCRIPTION
No punctuation marks are used in Turkish when writing dates. Fixes #1116