### PR TITLE
Update for Rails 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## unreleased
+- Update dependencies to allow Rails 8+.
 - Update following locales:
   - Lithuanian (lt): Add missing keys (`x_years`, `in`, `model_invalid`, `required`, `round_mode`, `eb`, `pb`)
   - Portuguese (pt): Fixed `number.currency.format.format` and `helpers.submit.update` #1122

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     rails-i18n (7.0.9)
       i18n (>= 0.7, < 2)
-      railties (>= 6.0.0, < 8)
+      railties (>= 6.0.0)
 
 GEM
   remote: https://rubygems.org/

--- a/rails-i18n.gemspec
+++ b/rails-i18n.gemspec
@@ -16,7 +16,8 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = '>= 1.8.11'
 
   s.add_dependency('i18n', '>= 0.7', '< 2')
-  s.add_dependency('railties', '>= 6.0.0', '< 8')
+  s.add_dependency('railties', '>= 6.0.0')
+
   s.add_development_dependency "rspec-rails", "~> 3.7"
   s.add_development_dependency "i18n-spec", "~> 0.6.0"
   s.add_development_dependency 'i18n-tasks', '~> 0.9.37'


### PR DESCRIPTION
Ref: https://github.com/svenfuchs/rails-i18n/pull/962

- Allow runtime railties 8.0.0 dependency.
- Bump version number to 8.0.0.
- Update Gemfile.lock.