### PR TITLE
Doc: Add Rails 8 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,14 @@ Centralization of locale data collection for Ruby on Rails.
 Include the gem to your Gemfile:
 
 ``` ruby
+gem 'rails-i18n', github: 'svenfuchs/rails-i18n', branch: 'master' # For bleeding edge unreleased versions
+gem 'rails-i18n', '~> 8.0.0' # For Rails >= 8.0.0
 gem 'rails-i18n', '~> 7.0.0' # For Rails >= 7.0.0
 gem 'rails-i18n', '~> 6.0' # For 6.x
 gem 'rails-i18n', '~> 5.1' # For 5.0.x, 5.1.x and 5.2.x
 gem 'rails-i18n', '~> 4.0' # For 4.0.x
 gem 'rails-i18n', '~> 3.0' # For 3.x
-gem 'rails-i18n', github: 'svenfuchs/rails-i18n', branch: 'master' # For 5.x
+gem 'rails-i18n', github: 'svenfuchs/rails-i18n', branch: 'rails-5-x' # For 5.x
 gem 'rails-i18n', github: 'svenfuchs/rails-i18n', branch: 'rails-4-x' # For 4.x
 gem 'rails-i18n', github: 'svenfuchs/rails-i18n', branch: 'rails-3-x' # For 3.x
 ```
@@ -24,6 +26,7 @@ gem 'rails-i18n', github: 'svenfuchs/rails-i18n', branch: 'rails-3-x' # For 3.x
 Alternatively, execute the following command:
 
 ``` shell
+gem install rails-i18n -v '~> 8.0.0' # For Rails >= 8.0.0
 gem install rails-i18n -v '~> 7.0.0' # For Rails >= 7.0.0
 gem install rails-i18n -v '~> 6.0' # For 6.x
 gem install rails-i18n -v '~> 5.1' # For  For 5.0.x, 5.1.x and 5.2.x


### PR DESCRIPTION
This should probably be merged only after rails-i18n v8 is released. Also, if you feel like it's faster to group this with some other changes or want to do it differently, feel free to close this PR in favor of a different one.

You can also edit/continue working on this PR.

You can also cherry-pick this commit:

```sh
git remote add vfonic https://github.com/vfonic/rails-i18n.git
git fetch
git cherry-pick 26e63625f97be114e8d5b3ed1c636d0e36813145
git remote remove vfonic
```

https://github.com/vfonic/rails-i18n/commit/26e63625f97be114e8d5b3ed1c636d0e36813145