### PR TITLE
Update Gemfile.lock to run specs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rails-i18n (7.0.9)
+    rails-i18n (7.0.10)
       i18n (>= 0.7, < 2)
       railties (>= 6.0.0)
 


### PR DESCRIPTION
I notice that specs are failing since [7.0.10 release](https://github.com/svenfuchs/rails-i18n/commit/9259183a35c5acd6bb28456589ecc9814928aad7) because 

```
The gemspecs for path gems changed, but the lockfile can't be updated because
```

The PR add the changes after running `bundle update` to solve this.

I understand that v8.0.0 is going to be released soon to support Rails 8.0 but I think this PR make sense anyway