### PR TITLE
Add password_too_long to Japanese locale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## unreleased
 
+- Update following locales:
+  - Japanese (ja): Add missing key (`password_too_long`)
 
 ## 8.0.1 (2024-11-10)
 

--- a/rails/locale/ja.yml
+++ b/rails/locale/ja.yml
@@ -104,6 +104,7 @@ ja:
       not_an_integer: は整数で入力してください
       odd: は奇数にしてください
       other_than: は%{count}以外の値にしてください
+      password_too_long: が長すぎます
       present: は入力しないでください
       required: を入力してください
       taken: はすでに存在します


### PR DESCRIPTION
With reference to [#1129](https://github.com/svenfuchs/rails-i18n/issues/1129)