### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/rails-i18n

### DIFF
--- a/rails-i18n.gemspec
+++ b/rails-i18n.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "i18n-spec", "~> 0.6.0"
   s.add_development_dependency "i18n-tasks", "~> 0.9.37"
 
-  s.metadata["changelog_uri"] = s.homepage + "/blob/master/CHANGELOG.md"
+  s.metadata["changelog_uri"] = "#{s.homepage}/blob/master/CHANGELOG.md"
 end

--- a/rails-i18n.gemspec
+++ b/rails-i18n.gemspec
@@ -21,4 +21,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec-rails", "~> 3.7"
   s.add_development_dependency "i18n-spec", "~> 0.6.0"
   s.add_development_dependency "i18n-tasks", "~> 0.9.37"
+
+  s.metadata["changelog_uri"] = s.homepage + "/blob/master/CHANGELOG.md"
 end


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/rails-i18n which makes it quick and easy for someone to check on the changes introduced with a new version.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/#metadata