### PR TITLE
Add password_too_long to the German locales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Update following locales:
   - Japanese (ja): Add missing key (`password_too_long`)
+  - German (de, de-DE, de-AT, de-CH): Add missing key (`password_too_long`)
 
 ## 8.0.1 (2024-11-10)
 

--- a/rails/locale/de-AT.yml
+++ b/rails/locale/de-AT.yml
@@ -125,6 +125,7 @@ de-AT:
       not_an_integer: muss ganzzahlig sein
       odd: muss ungerade sein
       other_than: darf nicht gleich %{count} sein
+      password_too_long: ist zu lang
       present: darf nicht ausgefüllt werden
       required: muss ausgefüllt werden
       taken: ist bereits vergeben

--- a/rails/locale/de-CH.yml
+++ b/rails/locale/de-CH.yml
@@ -125,6 +125,7 @@ de-CH:
       not_an_integer: muss ganzzahlig sein
       odd: muss ungerade sein
       other_than: darf nicht gleich %{count} sein
+      password_too_long: ist zu lang
       present: darf nicht ausgefüllt werden
       required: muss ausgefüllt werden
       taken: ist bereits vergeben

--- a/rails/locale/de-DE.yml
+++ b/rails/locale/de-DE.yml
@@ -125,6 +125,7 @@ de-DE:
       not_an_integer: muss ganzzahlig sein
       odd: muss ungerade sein
       other_than: darf nicht gleich %{count} sein
+      password_too_long: ist zu lang
       present: darf nicht ausgefüllt werden
       required: muss ausgefüllt werden
       taken: ist bereits vergeben

--- a/rails/locale/de.yml
+++ b/rails/locale/de.yml
@@ -128,6 +128,7 @@ de:
       not_an_integer: muss ganzzahlig sein
       odd: muss ungerade sein
       other_than: darf nicht gleich %{count} sein
+      password_too_long: ist zu lang
       present: darf nicht ausgefüllt werden
       required: muss ausgefüllt werden
       taken: ist bereits vergeben


### PR DESCRIPTION
This PR adds the missing `password_too_long` key to the German (`de, de-DE, de-AT, de-CH`) locales.