### PR TITLE
Serbian Cyrillic: Fix date format, February typo, and RSD unit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   - Japanese (ja): Add missing key (`password_too_long`)
   - German (de, de-DE, de-AT, de-CH): Add missing key (`password_too_long`)
   - Malayalam (ml): Add missing key (`datetime.distance_in_words.x_years.one`, `datetime.distance_in_words.x_years.other`, `errors.messages.in`, `errors.messages.password_too_long`, `currency.format.negative_format`, `number.format.round_mode`, `storage_units.units.eb`, `storage_units.units.pb`, `storage_units.units.zb`). Fix translation (`activerecord.errors.messages.record_invalid`, `errors.messages.other_than`, `number.currency.format.unit`)
+  - Serbian Cyrillic (sr): Fix date format, February typo, and RSD unit
 
 ## 8.0.1 (2024-11-10)
 

--- a/rails/locale/sr.yml
+++ b/rails/locale/sr.yml
@@ -17,7 +17,7 @@ sr:
     - Пет
     - Суб
     abbr_month_names:
-    - 
+    -
     - Јан
     - Феб
     - Мар
@@ -39,13 +39,13 @@ sr:
     - Петак
     - Субота
     formats:
-      default: "%d/%m/%Y"
-      long: "%B %e, %Y"
-      short: "%e %b"
+      default: "%d. %m. %Y"
+      long: "%-d. %B %Y"
+      short: "%-d. %b"
     month_names:
-    - 
+    -
     - Јануар
-    - Фабруар
+    - Фебруар
     - Март
     - Април
     - Мај
@@ -187,7 +187,7 @@ sr:
         separator: "."
         significant: false
         strip_insignificant_zeros: false
-        unit: ДИН
+        unit: РСД
     format:
       delimiter: "."
       precision: 3


### PR DESCRIPTION
Hey, thanks for the library.

I noticed that date formatting is off for Serbian, so this PR changes that.

How to format a date:
https://www.opismenise.com/nedoumice/kako-se-pise-datum-u-srpskom-jeziku/

I also changed unit to `РСД` because that's what people use in cyrillic now. For international  use there is RSD which is also its' ISO code. 

<img width="472" alt="Screenshot 2025-03-22 at 16 09 42" src="https://github.com/user-attachments/assets/e22a264e-d0db-4c84-85b6-c167e8a7446a" />

This is a screenshot from the app where I pay for electricity to prove the point. 

The next step would be adding a sr-el encoding and renaming sr to sr-ec, because Serbian allows two alphabets. 