### PR TITLE
Update EU language abbreviations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   - Japanese (ja): Add missing key (`password_too_long`)
   - German (de, de-DE, de-AT, de-CH): Add missing key (`password_too_long`)
   - Malayalam (ml): Add missing key (`datetime.distance_in_words.x_years.one`, `datetime.distance_in_words.x_years.other`, `errors.messages.in`, `errors.messages.password_too_long`, `currency.format.negative_format`, `number.format.round_mode`, `storage_units.units.eb`, `storage_units.units.pb`, `storage_units.units.zb`). Fix translation (`activerecord.errors.messages.record_invalid`, `errors.messages.other_than`, `number.currency.format.unit`)
+  - Basque (eu): Fixed week day abbreviations
 
 ## 8.0.1 (2024-11-10)
 

--- a/rails/locale/eu.yml
+++ b/rails/locale/eu.yml
@@ -9,13 +9,13 @@ eu:
           has_many: Ezin da erregistroa ezabat menpeko %{record}ak daudelako
   date:
     abbr_day_names:
-    - Igan
-    - Astel
-    - Astear
-    - Asteaz
-    - Oste
-    - Osti
-    - Lar
+    - Ig
+    - Al
+    - Ar
+    - Az
+    - Og
+    - Or
+    - Lr
     abbr_month_names:
     - 
     - Urt


### PR DESCRIPTION
The current abbreviations for the Basque language are not correct.  Here are the correct ones in case you want to merge