### PR TITLE
Add proper plural forms to Croatian and Serbian decimal units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   - Malayalam (ml): Add missing key (`datetime.distance_in_words.x_years.one`, `datetime.distance_in_words.x_years.other`, `errors.messages.in`, `errors.messages.password_too_long`, `currency.format.negative_format`, `number.format.round_mode`, `storage_units.units.eb`, `storage_units.units.pb`, `storage_units.units.zb`). Fix translation (`activerecord.errors.messages.record_invalid`, `errors.messages.other_than`, `number.currency.format.unit`)
   - Serbian Cyrillic (sr): Fix date format, February typo, and RSD unit
   - Basque (eu): Fixed week day abbreviations
+  - Croatian (hr), Serbian Cyrillic (sr) and Serbian Latin (scr): Add proper plural forms to decimal units
 
 ## 8.0.1 (2024-11-10)
 

--- a/rails/locale/hr.yml
+++ b/rails/locale/hr.yml
@@ -203,11 +203,31 @@ hr:
       decimal_units:
         format: "%n %u"
         units:
-          billion: milijarda
-          million: milijun
-          quadrillion: bilijarda
-          thousand: tisuća
-          trillion: bilijun
+          billion:
+            one: milijarda
+            few: milijarde
+            many: milijardi
+            other: milijardi
+          million:
+            one: milijun
+            few: milijuna
+            many: milijuna
+            other: milijuna
+          quadrillion:
+            one: bilijarda
+            few: bilijarde
+            many: bilijardi
+            other: bilijardi
+          thousand:
+            one: tisuća
+            few: tisuće
+            many: tisuća
+            other: tisuća
+          trillion:
+            one: bilijun
+            few: bilijuna
+            many: bilijuna
+            other: bilijuna
           unit: ''
       format:
         delimiter: ''

--- a/rails/locale/iso-639-2/scr.yml
+++ b/rails/locale/iso-639-2/scr.yml
@@ -192,11 +192,31 @@ scr:
       decimal_units:
         format: ! '%n %u'
         units:
-          thousand: Hiljadu
-          million: Milion
-          billion: Milijarda
-          trillion: Trilion
-          quadrillion: Kvadrilion
+          thousand:
+            one: hiljada
+            few: hiljade
+            many: hiljada
+            other: hiljada
+          million:
+            one: milion
+            few: miliona
+            many: miliona
+            other: miliona
+          billion:
+            one: milijarda
+            few: milijarde
+            many: milijardi
+            other: milijardi
+          trillion:
+            one: trilion
+            few: triliona
+            many: triliona
+            other: triliona
+          quadrillion:
+            one: kvadrilion
+            few: kvadriliona
+            many: kvadriliona
+            other: kvadriliona
           unit: ''
       format:
         delimiter: ''

--- a/rails/locale/sr.yml
+++ b/rails/locale/sr.yml
@@ -198,11 +198,31 @@ sr:
       decimal_units:
         format: "%n %u"
         units:
-          billion: Милијарда
-          million: Милион
-          quadrillion: Квадрилион
-          thousand: Хиљаду
-          trillion: Трилион
+          billion:
+            one: милијарда
+            few: милијарде
+            many: милијарди
+            other: милијарди
+          million:
+            one: милион
+            few: милиона
+            many: милиона
+            other: милиона
+          quadrillion:
+            one: квадрилион
+            few: квадрилиона
+            many: квадрилиона
+            other: квадрилиона
+          thousand:
+            one: хиљада
+            few: хиљаде
+            many: хиљада
+            other: хиљада
+          trillion:
+            one: трилион
+            few: трилиона
+            many: трилиона
+            other: трилиона
           unit: ''
       format:
         delimiter: ''


### PR DESCRIPTION
This PR adds proper plural forms (one, few, many, other) to decimal units in both 
Croatian (`hr.yml`) and Serbian (`sr.yml`) translations.

Before this change, these translations were using simplified strings without proper 
plural support, unlike other Slavic language files (`bs.yml` for example) in the repository.

These changes ensure grammatically correct output when different numeric values 
are displayed.