### PR TITLE
Add Montenegrin translations (cnr)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   - Serbian Cyrillic (sr): Fix date format, February typo, and RSD unit
   - Basque (eu): Fixed week day abbreviations
   - Croatian (hr), Serbian Cyrillic (sr) and Serbian Latin (scr): Add proper plural forms to decimal units
+  - Add following locales:
+    - Montenegrin (cnr)
 
 ## 8.0.1 (2024-11-10)
 

--- a/rails/locale/cnr.yml
+++ b/rails/locale/cnr.yml
@@ -1,0 +1,248 @@
+---
+cnr:
+  activerecord:
+    errors:
+      messages:
+        record_invalid: 'Validacija nije uspjela: %{errors}'
+        restrict_dependent_destroy:
+          has_one: Nije moguće izbrisati zapis jer postoji zavisan %{record}
+          has_many: Nije moguće izbrisati zapis jer postoje zavisni %{record}
+  date:
+    abbr_day_names:
+    - ned
+    - pon
+    - uto
+    - sri
+    - čet
+    - pet
+    - sub
+    abbr_month_names:
+    - 
+    - jan
+    - feb
+    - mar
+    - apr
+    - maj
+    - jun
+    - jul
+    - avg
+    - sep
+    - okt
+    - nov
+    - dec
+    day_names:
+    - nedjelja
+    - poneđeljak
+    - utorak
+    - srijeda
+    - četvrtak
+    - petak
+    - subota
+    formats:
+      default: "%d.%m.%Y."
+      long: "%e. %B %Y."
+      short: "%e. %b. %Y."
+    month_names:
+    - 
+    - januar
+    - februar
+    - mart
+    - april
+    - maj
+    - jun
+    - jul
+    - avgust
+    - septembar
+    - oktobar
+    - novembar
+    - decembar
+    order:
+    - :day
+    - :month
+    - :year
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: oko sat
+        few: oko %{count} sata
+        many: oko %{count} sati
+        other: oko %{count} sati
+      about_x_months:
+        one: oko mjesec
+        few: oko %{count} mjeseca
+        many: oko %{count} mjeseci
+        other: oko %{count} mjeseci
+      about_x_years:
+        one: oko godine
+        few: oko %{count} godine
+        many: oko %{count} godina
+        other: oko %{count} godina
+      almost_x_years:
+        one: skoro %{count} godina
+        few: skoro %{count} godine
+        many: skoro %{count} godina
+        other: skoro %{count} godina
+      half_a_minute: pola minute
+      less_than_x_seconds:
+        one: manje od sekunde
+        few: manje od %{count} sekunde
+        many: manje od %{count} sekundi
+        other: manje od %{count} sekundi
+      less_than_x_minutes:
+        one: manje od minute
+        few: manje od %{count} minute
+        many: manje od %{count} minuta
+        other: manje od %{count} minuta
+      over_x_years:
+        one: preko godine
+        few: preko %{count} godine
+        many: preko %{count} godina
+        other: preko %{count} godina
+      x_seconds:
+        one: "%{count} sekund"
+        few: "%{count} sekunde"
+        many: "%{count} sekundi"
+        other: "%{count} sekundi"
+      x_minutes:
+        one: "%{count} minut"
+        few: "%{count} minute"
+        many: "%{count} minuta"
+        other: "%{count} minuta"
+      x_days:
+        one: "%{count} dan"
+        few: "%{count} dana"
+        many: "%{count} dana"
+        other: "%{count} dana"
+      x_months:
+        one: "%{count} mjesec"
+        few: "%{count} mjeseca"
+        many: "%{count} mjeseci"
+        other: "%{count} mjeseci"
+    prompts:
+      second: sekundi
+      minute: minut
+      hour: sat
+      day: dan
+      month: mjesec
+      year: godina
+  errors:
+    format: "%{attribute} %{message}"
+    messages:
+      accepted: mora biti prihvaćeno
+      blank: ne smije biti prazno
+      confirmation: se ne poklapa sa potvrdom
+      empty: ne smije biti prazno
+      equal_to: mora biti %{count}
+      even: mora biti parno
+      exclusion: je rezervisano
+      greater_than: mora biti veće od %{count}
+      greater_than_or_equal_to: mora biti veće ili jednako %{count}
+      inclusion: nije uključeno u listu
+      invalid: nije validno
+      less_than: mora biti manje od %{count}
+      less_than_or_equal_to: mora biti manje ili jednako %{count}
+      not_a_number: nije broj
+      not_an_integer: mora biti cijeli broj
+      odd: mora biti neparno
+      other_than: mora biti različito od %{count}
+      present: mora biti prazno
+      taken: je već zauzeto
+      too_long: je predugo (maksimalno je dozvoljeno %{count} znakova)
+      too_short: je prekratko (predviđeno je minimalno %{count} znakova)
+      wrong_length: je pogrešne dužine (trebalo bi biti tačno %{count} znakova)
+    template:
+      body: 'Desili su se problemi sa sljedećim poljima:'
+      header:
+        one: "%{count} greška je spriječila da se ovaj %{model} sačuva"
+        few: "%{count} greške su spriječile da se ovaj %{model} sačuva"
+        many: "%{count} grešaka je spriječilo da se ovaj %{model} sačuva"
+        other: "%{count} grešaka je spriječilo da se ovaj %{model} sačuva"
+  helpers:
+    select:
+      prompt: Molimo odaberite
+    submit:
+      create: Kreiraj %{model}
+      submit: Sačuvaj %{model}
+      update: Ažuriraj %{model}
+  number:
+    currency:
+      format:
+        delimiter: "."
+        format: "%n %u"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: true
+        unit: €
+    format:
+      delimiter: "."
+      precision: 3
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: true
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion:
+            one: milijarda
+            few: milijarde
+            many: milijardi
+            other: milijardi
+          million:
+            one: milion
+            few: miliona
+            many: miliona
+            other: miliona
+          quadrillion:
+            one: bilijarda
+            few: bilijarde
+            many: bilijardi
+            other: bilijardi
+          thousand:
+            one: hiljada
+            few: hiljade
+            many: hiljada
+            other: hiljada
+          trillion:
+            one: bilion
+            few: biliona
+            many: biliona
+            other: biliona
+          unit: ''
+      format:
+        delimiter: ","
+        precision: 0
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: bajt
+            few: bajta
+            many: bajtova
+            other: bajtova
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ","
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: " i "
+      two_words_connector: " i "
+      words_connector: ", "
+  time:
+    am: am
+    formats:
+      default: "%d.%m.%Y. %H:%M:%S"
+      long: "%d. %B %Y. - %H:%M:%S"
+      short: "%d. %b %Y. %H:%M"
+    pm: pm


### PR DESCRIPTION
This pull request includes the addition of a new locale, Montenegrin (cnr).

* [`rails/locale/cnr.yml`](diffhunk://#diff-01cee49beec406981be523925f5474a1984b91658ab33cb78f2edc389d569211R1-R248): Created a new locale file for Montenegrin