### PR TITLE
add relative time translations for de, en, es, pt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 - Update following locales:
   - Japanese (ja): Add missing key (`password_too_long`)
+  - English (en, en-\*): Add new key (`datetime.relative`, see rails/rails#55405)
   - German (de, de-DE, de-AT, de-CH): Add missing key (`password_too_long`)
+  - German (de, de-\*): Add new key (`datetime.relative`, see rails/rails#55405)
   - Malayalam (ml): Add missing key (`datetime.distance_in_words.x_years.one`, `datetime.distance_in_words.x_years.other`, `errors.messages.in`, `errors.messages.password_too_long`, `currency.format.negative_format`, `number.format.round_mode`, `storage_units.units.eb`, `storage_units.units.pb`, `storage_units.units.zb`). Fix translation (`activerecord.errors.messages.record_invalid`, `errors.messages.other_than`, `number.currency.format.unit`)
   - Serbian Cyrillic (sr): Fix date format, February typo, and RSD unit
   - Basque (eu): Fixed week day abbreviations, fix percentage symbol position (`number.percentage.format`)
   - Croatian (hr), Serbian Cyrillic (sr) and Serbian Latin (scr): Add proper plural forms to decimal units
+  - Portuguese (pt, pt-\*): Add new key (`datetime.relative`, see rails/rails#55405)
+  - Spanish (es, es-\*): Add new key (`datetime.relative`, see rails/rails#55405)
   - Add following locales:
     - Montenegrin (cnr)
     - Armenian (hy)

--- a/rails/locale/de-AT.yml
+++ b/rails/locale/de-AT.yml
@@ -104,6 +104,9 @@ de-AT:
       day: Tag
       month: Monat
       year: Jahr
+    relative:
+      future: "in %{time}"
+      past: "vor %{time}"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/de-CH.yml
+++ b/rails/locale/de-CH.yml
@@ -104,6 +104,9 @@ de-CH:
       day: Tag
       month: Monat
       year: Jahr
+    relative:
+      future: "in %{time}"
+      past: "vor %{time}"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/de-DE.yml
+++ b/rails/locale/de-DE.yml
@@ -104,6 +104,9 @@ de-DE:
       day: Tag
       month: Monat
       year: Jahr
+    relative:
+      future: "in %{time}"
+      past: "vor %{time}"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/de.yml
+++ b/rails/locale/de.yml
@@ -107,6 +107,9 @@ de:
       day: Tag
       month: Monat
       year: Jahr
+    relative:
+      future: "in %{time}"
+      past: "vor %{time}"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/en-AU.yml
+++ b/rails/locale/en-AU.yml
@@ -106,6 +106,9 @@ en-AU:
       day: Day
       month: Month
       year: Year
+    relative:
+      future: "in %{time}"
+      past: "%{time} ago"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/en-CA.yml
+++ b/rails/locale/en-CA.yml
@@ -106,6 +106,9 @@ en-CA:
       day: Day
       month: Month
       year: Year
+    relative:
+      future: "in %{time}"
+      past: "%{time} ago"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/en-CY.yml
+++ b/rails/locale/en-CY.yml
@@ -106,6 +106,9 @@ en-CY:
       day: Day
       month: Month
       year: Year
+    relative:
+      future: "in %{time}"
+      past: "%{time} ago"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/en-GB.yml
+++ b/rails/locale/en-GB.yml
@@ -106,6 +106,9 @@ en-GB:
       day: Day
       month: Month
       year: Year
+    relative:
+      future: "in %{time}"
+      past: "%{time} ago"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/en-IE.yml
+++ b/rails/locale/en-IE.yml
@@ -106,6 +106,9 @@ en-IE:
       day: Day
       month: Month
       year: Year
+    relative:
+      future: "in %{time}"
+      past: "%{time} ago"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/en-IN.yml
+++ b/rails/locale/en-IN.yml
@@ -106,6 +106,9 @@ en-IN:
       day: Day
       month: Month
       year: Year
+    relative:
+      future: "in %{time}"
+      past: "%{time} ago"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/en-NZ.yml
+++ b/rails/locale/en-NZ.yml
@@ -106,6 +106,9 @@ en-NZ:
       day: Day
       month: Month
       year: Year
+    relative:
+      future: "in %{time}"
+      past: "%{time} ago"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/en-TT.yml
+++ b/rails/locale/en-TT.yml
@@ -106,6 +106,9 @@ en-TT:
       month: Month
       second: Seconds
       year: Year
+    relative:
+      future: "in %{time}"
+      past: "%{time} ago"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/en-US.yml
+++ b/rails/locale/en-US.yml
@@ -106,6 +106,9 @@ en-US:
       day: Day
       month: Month
       year: Year
+    relative:
+      future: "in %{time}"
+      past: "%{time} ago"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/en-ZA.yml
+++ b/rails/locale/en-ZA.yml
@@ -106,6 +106,9 @@ en-ZA:
       day: Day
       month: Month
       year: Year
+    relative:
+      future: "in %{time}"
+      past: "%{time} ago"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/en.yml
+++ b/rails/locale/en.yml
@@ -106,6 +106,9 @@ en:
       day: Day
       month: Month
       year: Year
+    relative:
+      future: "in %{time}"
+      past: "%{time} ago"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/es-419.yml
+++ b/rails/locale/es-419.yml
@@ -107,6 +107,9 @@ es-419:
       day: Día
       month: Mes
       year: Año
+    relative:
+      future: "en %{time}"
+      past: "hace %{time}"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/es-AR.yml
+++ b/rails/locale/es-AR.yml
@@ -106,6 +106,9 @@ es-AR:
       day: Día
       month: Mes
       year: Año
+    relative:
+      future: "en %{time}"
+      past: "hace %{time}"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/es-CL.yml
+++ b/rails/locale/es-CL.yml
@@ -106,6 +106,9 @@ es-CL:
       day: Día
       month: Mes
       year: Año
+    relative:
+      future: "en %{time}"
+      past: "hace %{time}"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/es-CO.yml
+++ b/rails/locale/es-CO.yml
@@ -106,6 +106,9 @@ es-CO:
       day: Día
       month: Mes
       year: Año
+    relative:
+      future: "en %{time}"
+      past: "hace %{time}"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/es-CR.yml
+++ b/rails/locale/es-CR.yml
@@ -106,6 +106,9 @@ es-CR:
       day: Día
       month: Mes
       year: Año
+    relative:
+      future: "en %{time}"
+      past: "hace %{time}"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/es-EC.yml
+++ b/rails/locale/es-EC.yml
@@ -107,6 +107,9 @@ es-EC:
       day: Día
       month: Mes
       year: Año
+    relative:
+      future: "en %{time}"
+      past: "hace %{time}"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/es-ES.yml
+++ b/rails/locale/es-ES.yml
@@ -106,6 +106,9 @@ es-ES:
       day: Día
       month: Mes
       year: Año
+    relative:
+      future: "en %{time}"
+      past: "hace %{time}"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/es-MX.yml
+++ b/rails/locale/es-MX.yml
@@ -106,6 +106,9 @@ es-MX:
       day: Día
       month: Mes
       year: Año
+    relative:
+      future: "en %{time}"
+      past: "hace %{time}"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/es-NI.yml
+++ b/rails/locale/es-NI.yml
@@ -106,6 +106,9 @@ es-NI:
       day: Día
       month: Mes
       year: Año
+    relative:
+      future: "en %{time}"
+      past: "hace %{time}"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/es-PA.yml
+++ b/rails/locale/es-PA.yml
@@ -107,6 +107,9 @@ es-PA:
       day: Día
       month: Mes
       year: Año
+    relative:
+      future: "en %{time}"
+      past: "hace %{time}"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/es-PE.yml
+++ b/rails/locale/es-PE.yml
@@ -106,6 +106,9 @@ es-PE:
       day: Día
       month: Mes
       year: Año
+    relative:
+      future: "en %{time}"
+      past: "hace %{time}"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/es-US.yml
+++ b/rails/locale/es-US.yml
@@ -106,6 +106,9 @@ es-US:
       day: Día
       month: Mes
       year: Año
+    relative:
+      future: "en %{time}"
+      past: "hace %{time}"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/es-VE.yml
+++ b/rails/locale/es-VE.yml
@@ -106,6 +106,9 @@ es-VE:
       day: Día
       month: Mes
       year: Año
+    relative:
+      future: "en %{time}"
+      past: "hace %{time}"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/es.yml
+++ b/rails/locale/es.yml
@@ -106,6 +106,9 @@ es:
       day: Día
       month: Mes
       year: Año
+    relative:
+      future: "en %{time}"
+      past: "hace %{time}"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/pt-BR.yml
+++ b/rails/locale/pt-BR.yml
@@ -106,6 +106,9 @@ pt-BR:
       day: Dia
       month: Mês
       year: Ano
+    relative:
+      future: "em %{time}"
+      past: "há %{time}"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/pt.yml
+++ b/rails/locale/pt.yml
@@ -106,6 +106,9 @@ pt:
       day: Dia
       month: Mês
       year: Ano
+    relative:
+      future: "em %{time}"
+      past: "há %{time}"
   errors:
     format: "%{attribute} %{message}"
     messages:


### PR DESCRIPTION
this adds translations used by the `relative_time_in_words` helper added in rails/rails#55405 for

- english
- german
- spanish
- portuguese

those are the only languages i'm comfortable with. i'll leave the rest to you, world.