### PR TITLE
Add datetime.relative translations for all locales that are used by relative_time_in_words helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Fix constant resolution failures when rules are evaluated in another scope
 - Update to Rails 8.1.x, and run `thor locales:normalize_from_rails`
+- Add `datetime.relative` translations for all locales that are used by `relative_time_in_words` helper
 
 ## 8.1.0 (2025-11-24)
 

--- a/rails/locale/af.yml
+++ b/rails/locale/af.yml
@@ -106,6 +106,9 @@ af:
       day: Dag
       month: Maand
       year: Jaar
+    relative:
+      future: oor %{time}
+      past: "%{time} gelede"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/ar.yml
+++ b/rails/locale/ar.yml
@@ -147,6 +147,9 @@ ar:
       day: اليوم
       month: الشهر
       year: السنة
+    relative:
+      future: بعد %{time}
+      past: منذ %{time}
   errors:
     format: "%{message}"
     messages:

--- a/rails/locale/az.yml
+++ b/rails/locale/az.yml
@@ -103,6 +103,9 @@ az:
       day: Gün
       month: Ay
       year: İl
+    relative:
+      future: "%{time} sonra"
+      past: "%{time} əvvəl"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/be.yml
+++ b/rails/locale/be.yml
@@ -130,6 +130,9 @@ be:
       day: Дзень
       month: Месяц
       year: Год
+    relative:
+      future: праз %{time}
+      past: "%{time} таму"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/bg.yml
+++ b/rails/locale/bg.yml
@@ -100,6 +100,9 @@ bg:
       day: Ден
       month: Месец
       year: Година
+    relative:
+      future: след %{time}
+      past: преди %{time}
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/bn.yml
+++ b/rails/locale/bn.yml
@@ -96,6 +96,9 @@ bn:
       day: দিন
       month: মাস
       year: বছর
+    relative:
+      future: "%{time} পরে"
+      past: "%{time} আগে"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/bs.yml
+++ b/rails/locale/bs.yml
@@ -125,6 +125,9 @@ bs:
       day: dan
       month: mjesec
       year: godina
+    relative:
+      future: za %{time}
+      past: prije %{time}
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/ca.yml
+++ b/rails/locale/ca.yml
@@ -106,6 +106,9 @@ ca:
       day: dia
       month: mes
       year: any
+    relative:
+      future: en %{time}
+      past: fa %{time}
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/cnr.yml
+++ b/rails/locale/cnr.yml
@@ -125,6 +125,9 @@ cnr:
       day: dan
       month: mjesec
       year: godina
+    relative:
+      future: za %{time}
+      past: prije %{time}
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/cs.yml
+++ b/rails/locale/cs.yml
@@ -114,6 +114,9 @@ cs:
       day: Den
       month: Měsíc
       year: Rok
+    relative:
+      future: za %{time}
+      past: před %{time}
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/cy.yml
+++ b/rails/locale/cy.yml
@@ -154,6 +154,9 @@ cy:
       day: Diwrnod
       month: Mis
       year: Blwyddyn
+    relative:
+      future: ymhen %{time}
+      past: "%{time} yn ôl"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/da.yml
+++ b/rails/locale/da.yml
@@ -106,6 +106,9 @@ da:
       day: Dag
       month: Måned
       year: År
+    relative:
+      future: om %{time}
+      past: for %{time} siden
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/de-AT.yml
+++ b/rails/locale/de-AT.yml
@@ -104,6 +104,9 @@ de-AT:
       day: Tag
       month: Monat
       year: Jahr
+    relative:
+      future: in %{time}
+      past: vor %{time}
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/de-CH.yml
+++ b/rails/locale/de-CH.yml
@@ -104,6 +104,9 @@ de-CH:
       day: Tag
       month: Monat
       year: Jahr
+    relative:
+      future: in %{time}
+      past: vor %{time}
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/de-DE.yml
+++ b/rails/locale/de-DE.yml
@@ -104,6 +104,9 @@ de-DE:
       day: Tag
       month: Monat
       year: Jahr
+    relative:
+      future: in %{time}
+      past: vor %{time}
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/de.yml
+++ b/rails/locale/de.yml
@@ -107,6 +107,9 @@ de:
       day: Tag
       month: Monat
       year: Jahr
+    relative:
+      future: in %{time}
+      past: vor %{time}
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/dz.yml
+++ b/rails/locale/dz.yml
@@ -104,6 +104,9 @@ dz:
       day: ཉིནམ
       month: ཟླཝ
       year: ལོ
+    relative:
+      future: "%{time} ནང་"
+      past: "%{time} སྔོན་ལ་"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/el-CY.yml
+++ b/rails/locale/el-CY.yml
@@ -106,6 +106,9 @@ el-CY:
       day: Ημέρα
       month: Μήνας
       year: Έτος
+    relative:
+      future: σε %{time}
+      past: πριν από %{time}
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/el.yml
+++ b/rails/locale/el.yml
@@ -106,6 +106,9 @@ el:
       day: Ημέρα
       month: Μήνας
       year: Έτος
+    relative:
+      future: σε %{time}
+      past: πριν από %{time}
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/en-AU.yml
+++ b/rails/locale/en-AU.yml
@@ -106,6 +106,9 @@ en-AU:
       day: Day
       month: Month
       year: Year
+    relative:
+      future: in %{time}
+      past: "%{time} ago"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/en-CA.yml
+++ b/rails/locale/en-CA.yml
@@ -106,6 +106,9 @@ en-CA:
       day: Day
       month: Month
       year: Year
+    relative:
+      future: in %{time}
+      past: "%{time} ago"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/en-CY.yml
+++ b/rails/locale/en-CY.yml
@@ -106,6 +106,9 @@ en-CY:
       day: Day
       month: Month
       year: Year
+    relative:
+      future: in %{time}
+      past: "%{time} ago"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/en-GB.yml
+++ b/rails/locale/en-GB.yml
@@ -106,6 +106,9 @@ en-GB:
       day: Day
       month: Month
       year: Year
+    relative:
+      future: in %{time}
+      past: "%{time} ago"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/en-IE.yml
+++ b/rails/locale/en-IE.yml
@@ -106,6 +106,9 @@ en-IE:
       day: Day
       month: Month
       year: Year
+    relative:
+      future: in %{time}
+      past: "%{time} ago"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/en-IN.yml
+++ b/rails/locale/en-IN.yml
@@ -106,6 +106,9 @@ en-IN:
       day: Day
       month: Month
       year: Year
+    relative:
+      future: in %{time}
+      past: "%{time} ago"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/en-NZ.yml
+++ b/rails/locale/en-NZ.yml
@@ -106,6 +106,9 @@ en-NZ:
       day: Day
       month: Month
       year: Year
+    relative:
+      future: in %{time}
+      past: "%{time} ago"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/en-TT.yml
+++ b/rails/locale/en-TT.yml
@@ -106,6 +106,9 @@ en-TT:
       month: Month
       second: Seconds
       year: Year
+    relative:
+      future: in %{time}
+      past: "%{time} ago"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/en-US.yml
+++ b/rails/locale/en-US.yml
@@ -106,6 +106,9 @@ en-US:
       day: Day
       month: Month
       year: Year
+    relative:
+      future: in %{time}
+      past: "%{time} ago"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/en-ZA.yml
+++ b/rails/locale/en-ZA.yml
@@ -106,6 +106,9 @@ en-ZA:
       day: Day
       month: Month
       year: Year
+    relative:
+      future: in %{time}
+      past: "%{time} ago"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/eo.yml
+++ b/rails/locale/eo.yml
@@ -102,6 +102,9 @@ eo:
       day: Tago
       month: Monato
       year: Jaro
+    relative:
+      future: post %{time}
+      past: antaŭ %{time}
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/es-419.yml
+++ b/rails/locale/es-419.yml
@@ -107,6 +107,9 @@ es-419:
       day: Día
       month: Mes
       year: Año
+    relative:
+      future: en %{time}
+      past: hace %{time}
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/es-AR.yml
+++ b/rails/locale/es-AR.yml
@@ -106,6 +106,9 @@ es-AR:
       day: Día
       month: Mes
       year: Año
+    relative:
+      future: en %{time}
+      past: hace %{time}
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/es-CL.yml
+++ b/rails/locale/es-CL.yml
@@ -106,6 +106,9 @@ es-CL:
       day: Día
       month: Mes
       year: Año
+    relative:
+      future: en %{time}
+      past: hace %{time}
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/es-CO.yml
+++ b/rails/locale/es-CO.yml
@@ -106,6 +106,9 @@ es-CO:
       day: Día
       month: Mes
       year: Año
+    relative:
+      future: en %{time}
+      past: hace %{time}
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/es-CR.yml
+++ b/rails/locale/es-CR.yml
@@ -106,6 +106,9 @@ es-CR:
       day: Día
       month: Mes
       year: Año
+    relative:
+      future: en %{time}
+      past: hace %{time}
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/es-EC.yml
+++ b/rails/locale/es-EC.yml
@@ -107,6 +107,9 @@ es-EC:
       day: Día
       month: Mes
       year: Año
+    relative:
+      future: en %{time}
+      past: hace %{time}
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/es-ES.yml
+++ b/rails/locale/es-ES.yml
@@ -106,6 +106,9 @@ es-ES:
       day: Día
       month: Mes
       year: Año
+    relative:
+      future: en %{time}
+      past: hace %{time}
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/es-MX.yml
+++ b/rails/locale/es-MX.yml
@@ -106,6 +106,9 @@ es-MX:
       day: Día
       month: Mes
       year: Año
+    relative:
+      future: en %{time}
+      past: hace %{time}
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/es-NI.yml
+++ b/rails/locale/es-NI.yml
@@ -106,6 +106,9 @@ es-NI:
       day: Día
       month: Mes
       year: Año
+    relative:
+      future: en %{time}
+      past: hace %{time}
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/es-PA.yml
+++ b/rails/locale/es-PA.yml
@@ -107,6 +107,9 @@ es-PA:
       day: Día
       month: Mes
       year: Año
+    relative:
+      future: en %{time}
+      past: hace %{time}
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/es-PE.yml
+++ b/rails/locale/es-PE.yml
@@ -106,6 +106,9 @@ es-PE:
       day: Día
       month: Mes
       year: Año
+    relative:
+      future: en %{time}
+      past: hace %{time}
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/es-US.yml
+++ b/rails/locale/es-US.yml
@@ -106,6 +106,9 @@ es-US:
       day: Día
       month: Mes
       year: Año
+    relative:
+      future: en %{time}
+      past: hace %{time}
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/es-VE.yml
+++ b/rails/locale/es-VE.yml
@@ -106,6 +106,9 @@ es-VE:
       day: Día
       month: Mes
       year: Año
+    relative:
+      future: en %{time}
+      past: hace %{time}
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/es.yml
+++ b/rails/locale/es.yml
@@ -106,6 +106,9 @@ es:
       day: Día
       month: Mes
       year: Año
+    relative:
+      future: en %{time}
+      past: hace %{time}
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/et.yml
+++ b/rails/locale/et.yml
@@ -106,6 +106,9 @@ et:
       day: Päev
       month: Kuu
       year: Aasta
+    relative:
+      future: "%{time} pärast"
+      past: "%{time} tagasi"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/eu.yml
+++ b/rails/locale/eu.yml
@@ -103,6 +103,9 @@ eu:
       day: Egun
       month: Hilabete
       year: Urte
+    relative:
+      future: "%{time} barruan"
+      past: duela %{time}
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/fa.yml
+++ b/rails/locale/fa.yml
@@ -107,6 +107,9 @@ fa:
       day: روز
       month: ماه
       year: سال
+    relative:
+      future: در %{time}
+      past: "%{time} پیش"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/fi.yml
+++ b/rails/locale/fi.yml
@@ -106,6 +106,9 @@ fi:
       day: Päivä
       month: Kuukausi
       year: Vuosi
+    relative:
+      future: "%{time} kuluttua"
+      past: "%{time} sitten"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/fy.yml
+++ b/rails/locale/fy.yml
@@ -106,6 +106,9 @@ fy:
       day: dei
       month: moanne
       year: jier
+    relative:
+      future: oer %{time}
+      past: "%{time} ferlyn"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/gd.yml
+++ b/rails/locale/gd.yml
@@ -131,6 +131,9 @@ gd:
       day: Latha
       month: Mìos
       year: Bliadhna
+    relative:
+      future: an ceann %{time}
+      past: bho chionn %{time}
   errors:
     format: "%{attribute}: %{message}"
     messages:

--- a/rails/locale/gl.yml
+++ b/rails/locale/gl.yml
@@ -89,6 +89,9 @@ gl:
       x_months:
         one: "%{count} mes"
         other: "%{count} meses"
+    relative:
+      future: en %{time}
+      past: hai %{time}
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/he.yml
+++ b/rails/locale/he.yml
@@ -102,6 +102,9 @@ he:
       day: יום
       month: חודש
       year: שנה
+    relative:
+      future: בעוד %{time}
+      past: לפני %{time}
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/hi-IN.yml
+++ b/rails/locale/hi-IN.yml
@@ -100,6 +100,9 @@ hi-IN:
       day: दिन
       month: माह
       year: वर्ष
+    relative:
+      future: "%{time} में"
+      past: "%{time} पहले"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/hi.yml
+++ b/rails/locale/hi.yml
@@ -100,6 +100,9 @@ hi:
       day: दिन
       month: माह
       year: वर्ष
+    relative:
+      future: "%{time} में"
+      past: "%{time} पहले"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/hr.yml
+++ b/rails/locale/hr.yml
@@ -130,6 +130,9 @@ hr:
       day: Dan
       month: Mjesec
       year: Godina
+    relative:
+      future: za %{time}
+      past: prije %{time}
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/hu.yml
+++ b/rails/locale/hu.yml
@@ -100,6 +100,9 @@ hu:
       day: Nap
       month: Hónap
       year: Év
+    relative:
+      future: "%{time} múlva"
+      past: "%{time} ezelőtt"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/hy.yml
+++ b/rails/locale/hy.yml
@@ -105,6 +105,9 @@ hy:
       day: Օր
       month: Ամիս
       year: Տարի
+    relative:
+      future: "%{time} հետո"
+      past: "%{time} առաջ"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/id.yml
+++ b/rails/locale/id.yml
@@ -106,6 +106,9 @@ id:
       day: Hari
       month: Bulan
       year: Tahun
+    relative:
+      future: dalam %{time}
+      past: "%{time} yang lalu"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/is.yml
+++ b/rails/locale/is.yml
@@ -103,6 +103,9 @@ is:
       day: Dagur
       month: Mánuður
       year: Ár
+    relative:
+      future: eftir %{time}
+      past: fyrir %{time} síðan
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/it-CH.yml
+++ b/rails/locale/it-CH.yml
@@ -106,6 +106,9 @@ it-CH:
       day: Giorno
       month: Mese
       year: Anno
+    relative:
+      future: tra %{time}
+      past: "%{time} fa"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/it.yml
+++ b/rails/locale/it.yml
@@ -106,6 +106,9 @@ it:
       day: Giorno
       month: Mese
       year: Anno
+    relative:
+      future: tra %{time}
+      past: "%{time} fa"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/ja.yml
+++ b/rails/locale/ja.yml
@@ -82,6 +82,9 @@ ja:
       day: 日
       month: 月
       year: 年
+    relative:
+      future: "%{time}後"
+      past: "%{time}前"
   errors:
     format: "%{attribute}%{message}"
     messages:

--- a/rails/locale/ka.yml
+++ b/rails/locale/ka.yml
@@ -103,6 +103,9 @@ ka:
       day: დღე
       month: თვე
       year: წელი
+    relative:
+      future: "%{time} შემდეგ"
+      past: "%{time} წინ"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/kk.yml
+++ b/rails/locale/kk.yml
@@ -106,6 +106,9 @@ kk:
       day: Күн
       month: Ай
       year: Жыл
+    relative:
+      future: "%{time} кейін"
+      past: "%{time} бұрын"
   errors:
     format: '%{attribute} %{message}'
     messages:

--- a/rails/locale/km.yml
+++ b/rails/locale/km.yml
@@ -81,6 +81,9 @@ km:
       day: ថ្ងៃ
       month: ខែ
       year: ឆ្នាំ
+    relative:
+      future: ក្នុង %{time}
+      past: "%{time} មុន"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/kn.yml
+++ b/rails/locale/kn.yml
@@ -100,6 +100,9 @@ kn:
       day: ದಿನ
       month: ತಿಂಗಳು
       year: ವರುಷ
+    relative:
+      future: "%{time} ನಲ್ಲಿ"
+      past: "%{time} ಹಿಂದೆ"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/ko.yml
+++ b/rails/locale/ko.yml
@@ -82,6 +82,9 @@ ko:
       day: 일
       month: 월
       year: 년
+    relative:
+      future: "%{time} 후"
+      past: "%{time} 전"
   errors:
     format: "%{message}"
     messages:

--- a/rails/locale/lb.yml
+++ b/rails/locale/lb.yml
@@ -105,6 +105,9 @@ lb:
       day: Dag
       month: Mount
       year: Joer
+    relative:
+      future: an %{time}
+      past: virun %{time}
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/lo.yml
+++ b/rails/locale/lo.yml
@@ -78,6 +78,9 @@ lo:
       day: ວັນ
       month: ເດືອນ
       year: ປີ
+    relative:
+      future: ໃນ %{time}
+      past: "%{time}ກ່ອນ"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/lt.yml
+++ b/rails/locale/lt.yml
@@ -118,6 +118,9 @@ lt:
       day: Diena
       month: Mėnuo
       year: Metai
+    relative:
+      future: po %{time}
+      past: prieš %{time}
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/lv.yml
+++ b/rails/locale/lv.yml
@@ -114,6 +114,9 @@ lv:
       day: diena
       month: mēnesis
       year: gads
+    relative:
+      future: pēc %{time}
+      past: pirms %{time}
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/mg.yml
+++ b/rails/locale/mg.yml
@@ -110,6 +110,9 @@ mg:
       day: Andro
       month: Volana
       year: Taona
+    relative:
+      future: afaka %{time}
+      past: "%{time} lasa"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/mk.yml
+++ b/rails/locale/mk.yml
@@ -100,6 +100,9 @@ mk:
       day: Ден
       month: Месец
       year: Година
+    relative:
+      future: за %{time}
+      past: пред %{time}
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/ml.yml
+++ b/rails/locale/ml.yml
@@ -106,6 +106,9 @@ ml:
       day: ദിവസം
       month: സുക്ഷ്മ
       year: വർഷം
+    relative:
+      future: "%{time} ൽ"
+      past: "%{time} മുൻപ്"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/mn.yml
+++ b/rails/locale/mn.yml
@@ -100,6 +100,9 @@ mn:
       day: Өдөр
       month: Сар
       year: Жил
+    relative:
+      future: "%{time} дараа"
+      past: "%{time} өмнө"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/mr-IN.yml
+++ b/rails/locale/mr-IN.yml
@@ -103,6 +103,9 @@ mr-IN:
       day: दिवस
       month: महिना
       year: वर्ष
+    relative:
+      future: "%{time} मध्ये"
+      past: "%{time} पूर्वी"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/ms.yml
+++ b/rails/locale/ms.yml
@@ -100,6 +100,9 @@ ms:
       day: Hari
       month: Bulan
       year: Tahun
+    relative:
+      future: dalam %{time}
+      past: "%{time} yang lalu"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/nb.yml
+++ b/rails/locale/nb.yml
@@ -106,6 +106,9 @@ nb:
       day: dag
       month: måned
       year: år
+    relative:
+      future: om %{time}
+      past: for %{time} siden
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/ne.yml
+++ b/rails/locale/ne.yml
@@ -103,6 +103,9 @@ ne:
       day: दिन
       month: महिना
       year: बर्ष
+    relative:
+      future: "%{time} पछि"
+      past: "%{time} पहिले"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/nl.yml
+++ b/rails/locale/nl.yml
@@ -106,6 +106,9 @@ nl:
       day: dag
       month: maand
       year: jaar
+    relative:
+      future: over %{time}
+      past: "%{time} geleden"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/nn.yml
+++ b/rails/locale/nn.yml
@@ -101,6 +101,9 @@ nn:
       day: Dag
       month: Månad
       year: År
+    relative:
+      future: om %{time}
+      past: for %{time} sidan
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/oc.yml
+++ b/rails/locale/oc.yml
@@ -106,6 +106,9 @@ oc:
       day: jorn
       month: mes
       year: an
+    relative:
+      future: "d'aicí %{time}"
+      past: fa %{time}
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/or.yml
+++ b/rails/locale/or.yml
@@ -100,6 +100,9 @@ or:
       day: ଦିନ
       month: ମାସ
       year: ବର୍ଷ
+    relative:
+      future: "%{time} ରେ"
+      past: "%{time} ପୂର୍ବରୁ"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/pa.yml
+++ b/rails/locale/pa.yml
@@ -103,6 +103,9 @@ pa:
       day: ਦਿਨ
       month: ਮਹੀਨਾ
       year: ਸਾਲ
+    relative:
+      future: "%{time} ਵਿੱਚ"
+      past: "%{time} ਪਹਿਲਾਂ"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/pap-AW.yml
+++ b/rails/locale/pap-AW.yml
@@ -106,6 +106,9 @@ pap-AW:
       month: Luna
       second: Sekònde
       year: Aña
+    relative:
+      future: den %{time}
+      past: "%{time} pasá"
   errors:
     format: '%{attribute} %{message}'
     messages:

--- a/rails/locale/pap-CW.yml
+++ b/rails/locale/pap-CW.yml
@@ -106,6 +106,9 @@ pap-CW:
       month: Luna
       second: Sekònde
       year: Aña
+    relative:
+      future: den %{time}
+      past: "%{time} pasá"
   errors:
     format: '%{attribute} %{message}'
     messages:

--- a/rails/locale/pl.yml
+++ b/rails/locale/pl.yml
@@ -125,6 +125,9 @@ pl:
       day: Dzień
       month: Miesiąc
       year: Rok
+    relative:
+      future: za %{time}
+      past: "%{time} temu"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/pt-BR.yml
+++ b/rails/locale/pt-BR.yml
@@ -106,6 +106,9 @@ pt-BR:
       day: Dia
       month: Mês
       year: Ano
+    relative:
+      future: em %{time}
+      past: há %{time}
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/pt.yml
+++ b/rails/locale/pt.yml
@@ -106,6 +106,9 @@ pt:
       day: Dia
       month: Mês
       year: Ano
+    relative:
+      future: em %{time}
+      past: há %{time}
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/rm.yml
+++ b/rails/locale/rm.yml
@@ -133,6 +133,9 @@ rm:
       day: dis
       month: mais
       year: onns
+    relative:
+      future: en %{time}
+      past: avant %{time}
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/ro.yml
+++ b/rails/locale/ro.yml
@@ -111,6 +111,9 @@ ro:
       day: ziua
       month: luna
       year: anul
+    relative:
+      future: "în %{time}"
+      past: "%{time} în urmă"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/ru.yml
+++ b/rails/locale/ru.yml
@@ -130,6 +130,9 @@ ru:
       day: День
       month: Месяц
       year: Год
+    relative:
+      future: через %{time}
+      past: "%{time} назад"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/sc.yml
+++ b/rails/locale/sc.yml
@@ -106,6 +106,9 @@ sc:
       day: Die
       month: Mese
       year: Annu
+    relative:
+      future: intr'a %{time}
+      past: "%{time} a como"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/sk.yml
+++ b/rails/locale/sk.yml
@@ -111,6 +111,9 @@ sk:
       day: Deň
       month: Mesiac
       year: Rok
+    relative:
+      future: o %{time}
+      past: pred %{time}
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/sl.yml
+++ b/rails/locale/sl.yml
@@ -122,6 +122,9 @@ sl:
       day: Dan
       month: Mesec
       year: Leto
+    relative:
+      future: čez %{time}
+      past: pred %{time}
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/sq.yml
+++ b/rails/locale/sq.yml
@@ -103,6 +103,9 @@ sq:
       day: Ditë
       month: Muaj
       year: Vit
+    relative:
+      future: në %{time}
+      past: "%{time} më parë"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/sr.yml
+++ b/rails/locale/sr.yml
@@ -125,6 +125,9 @@ sr:
       day: Дан
       month: Месец
       year: Година
+    relative:
+      future: за %{time}
+      past: пре %{time}
   errors:
     format: "Поље %{attribute} %{message}"
     messages:

--- a/rails/locale/st.yml
+++ b/rails/locale/st.yml
@@ -106,6 +106,9 @@ st:
       day: Letsatsi
       month: Khoeli
       year: Selemo
+    relative:
+      future: ka mora %{time}
+      past: "%{time} e fetileng"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/sv-FI.yml
+++ b/rails/locale/sv-FI.yml
@@ -103,6 +103,9 @@ sv-FI:
       day: Dag
       month: Månad
       year: År
+    relative:
+      future: om %{time}
+      past: för %{time} sedan
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/sv-SE.yml
+++ b/rails/locale/sv-SE.yml
@@ -106,6 +106,9 @@ sv-SE:
       day: Dag
       month: Månad
       year: År
+    relative:
+      future: om %{time}
+      past: för %{time} sedan
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/sv.yml
+++ b/rails/locale/sv.yml
@@ -106,6 +106,9 @@ sv:
       day: Dag
       month: Månad
       year: År
+    relative:
+      future: om %{time}
+      past: för %{time} sedan
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/sw.yml
+++ b/rails/locale/sw.yml
@@ -100,6 +100,9 @@ sw:
       day: Siku
       month: Mwezi
       year: Mwaka
+    relative:
+      future: baada ya %{time}
+      past: "%{time} iliyopita"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/ta.yml
+++ b/rails/locale/ta.yml
@@ -103,6 +103,9 @@ ta:
       day: நாள்
       month: மாதம்
       year: ஆண்டு
+    relative:
+      future: "%{time} இல்"
+      past: "%{time} முன்"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/te.yml
+++ b/rails/locale/te.yml
@@ -106,6 +106,9 @@ te:
       day: రోజు
       month: నెల
       year: సంవత్సరం
+    relative:
+      future: "%{time} లో"
+      past: "%{time} క్రితం"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/th.yml
+++ b/rails/locale/th.yml
@@ -78,6 +78,9 @@ th:
       day: วัน
       month: เดือน
       year: ปี
+    relative:
+      future: ใน %{time}
+      past: "%{time}ที่แล้ว"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/tl.yml
+++ b/rails/locale/tl.yml
@@ -100,6 +100,9 @@ tl:
       day: araw
       month: buwan
       year: taon
+    relative:
+      future: sa %{time}
+      past: "%{time} ang nakalipas"
   errors:
     format: "%{attribute} ay %{message}"
     messages:

--- a/rails/locale/tr.yml
+++ b/rails/locale/tr.yml
@@ -106,6 +106,9 @@ tr:
       day: Gün
       month: Ay
       year: Yıl
+    relative:
+      future: "%{time} sonra"
+      past: "%{time} önce"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/tt.yml
+++ b/rails/locale/tt.yml
@@ -103,6 +103,9 @@ tt:
       day: Көн
       month: Ай
       year: Ел
+    relative:
+      future: "%{time} соң"
+      past: "%{time} элек"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/ug.yml
+++ b/rails/locale/ug.yml
@@ -103,6 +103,9 @@ ug:
       day: كۈن
       month: ئاي
       year: يىل
+    relative:
+      future: "%{time} كېيىن"
+      past: "%{time} بۇرۇن"
   errors:
     format: "%{attribute}%{message}"
     messages:

--- a/rails/locale/uk.yml
+++ b/rails/locale/uk.yml
@@ -130,6 +130,9 @@ uk:
       day: День
       month: Місяць
       year: Рік
+    relative:
+      future: через %{time}
+      past: "%{time} тому"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/ur.yml
+++ b/rails/locale/ur.yml
@@ -105,6 +105,9 @@ ur:
       day: دن
       month: ماہ
       year: سال
+    relative:
+      future: "%{time} میں"
+      past: "%{time} پہلے"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/uz.yml
+++ b/rails/locale/uz.yml
@@ -122,6 +122,9 @@ uz:
       day: kun
       month: oy
       year: yil
+    relative:
+      future: "%{time} dan keyin"
+      past: "%{time} oldin"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/vi.yml
+++ b/rails/locale/vi.yml
@@ -81,6 +81,9 @@ vi:
       day: Ngày
       month: Tháng
       year: Năm
+    relative:
+      future: trong %{time}
+      past: "%{time} trước"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/wo.yml
+++ b/rails/locale/wo.yml
@@ -106,6 +106,9 @@ wo:
       day: Day
       month: Month
       year: Year
+    relative:
+      future: ci %{time}
+      past: "%{time} ci ginaaw"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/rails/locale/zh-CN.yml
+++ b/rails/locale/zh-CN.yml
@@ -82,6 +82,9 @@ zh-CN:
       day: 日
       month: 月
       year: 年
+    relative:
+      future: "%{time}后"
+      past: "%{time}前"
   errors:
     format: "%{attribute}%{message}"
     messages:

--- a/rails/locale/zh-HK.yml
+++ b/rails/locale/zh-HK.yml
@@ -82,6 +82,9 @@ zh-HK:
       day: 日
       month: 月
       year: 年
+    relative:
+      future: "%{time}後"
+      past: "%{time}前"
   errors:
     format: "%{attribute}%{message}"
     messages:

--- a/rails/locale/zh-TW.yml
+++ b/rails/locale/zh-TW.yml
@@ -82,6 +82,9 @@ zh-TW:
       day: 日
       month: 月
       year: 年
+    relative:
+      future: "%{time}後"
+      past: "%{time}前"
   errors:
     format: "%{attribute}%{message}"
     messages:

--- a/rails/locale/zh-YUE.yml
+++ b/rails/locale/zh-YUE.yml
@@ -82,6 +82,9 @@ zh-YUE:
       day: 日
       month: 月
       year: 年
+    relative:
+      future: "%{time}後"
+      past: "%{time}前"
   errors:
     format: "%{attribute}%{message}"
     messages:


### PR DESCRIPTION
A few months ago Rails added a new`relative_time_in_words` helper (https://github.com/rails/rails/pull/55405) that uses `datetime.relative` locale keys, which are currently missing from most available locales.

Translations were generated with Claude AI and cross-verified with ChatGPT & Gemini. While AI-assisted translation isn't ideal, I believe it's better to have baseline translations that can be refined by native speakers than to have no translations at all.
