### PR TITLE
Add negative_format for currency in Dutch locale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - German (de, de-\*): Add new key (`datetime.relative`, see rails/rails#55405)
 - Portuguese (pt, pt-\*): Add new key (`datetime.relative`, see rails/rails#55405)
 - Spanish (es, es-\*): Add new key (`datetime.relative`, see rails/rails#55405)
+- Dutch (nl): Add missing key (`number.currency.format.negative_format`)
 
 ## 8.1.0 (2025-11-24)
 

--- a/rails/locale/nl.yml
+++ b/rails/locale/nl.yml
@@ -156,6 +156,7 @@ nl:
       format:
         delimiter: "."
         format: "%u %n"
+        negative_format: "%u -%n"
         precision: 2
         separator: ","
         significant: false


### PR DESCRIPTION
This is for example also the same format as used by Excel in the Dutch locale.

<img width="133" height="77" alt="afbeelding" src="https://github.com/user-attachments/assets/b091c6dd-4d83-4fdf-91ff-522403c063c7" />
