### PR TITLE
Fix incorrect `negative_format` in ja.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Fix incorrect `ja.number.currency.format.negative_format` definition
 - Fix constant resolution failures when rules are evaluated in another scope
 - Update to Rails 8.1.x, and run `thor locales:normalize_from_rails`
 - English: Add missing keys

--- a/rails/locale/ja.yml
+++ b/rails/locale/ja.yml
@@ -126,7 +126,7 @@ ja:
       format:
         delimiter: ","
         format: "%n%u"
-        negative_format: "-%u%n"
+        negative_format: "-%n%u"
         precision: 0
         separator: "."
         significant: false


### PR DESCRIPTION
The definition of `ja.number.currency.format.negative_format` was added in https://github.com/svenfuchs/rails-i18n/pull/1151 , but the symbol order is wrong. The current format results in values like "-円100", but "-100円" is correct. The `ja.number.currency.format.format` defined just above already uses the correct order.
