### PR TITLE
Cache Arabic pluralization ranges

### DIFF
--- a/lib/rails_i18n/pluralization.rb
+++ b/lib/rails_i18n/pluralization.rb
@@ -1,6 +1,9 @@
 module RailsI18n
   module Pluralization
     module Arabic
+      FROM_3_TO_10 = (3..10).to_a.freeze
+      FROM_11_TO_99 = (11..99).to_a.freeze
+
       def self.rule
         lambda do |n|
           return :other unless n.is_a?(Numeric)
@@ -13,9 +16,9 @@ module RailsI18n
             :one
           elsif n == 2
             :two
-          elsif (3..10).to_a.include?(mod100)
+          elsif FROM_3_TO_10.include?(mod100)
             :few
-          elsif (11..99).to_a.include?(mod100)
+          elsif FROM_11_TO_99.include?(mod100)
             :many
           else
             :other


### PR DESCRIPTION
Move the 3..10 and 11..99 lookup arrays into frozen constants instead of rebuilding them on every Arabic pluralization check.

The rule runs during translation lookups, so allocating those arrays on each call adds avoidable work in a hot path. Local benchmarking shows the rule path rising from about 1.7k i/s to 8.7k i/s while eliminating its per-call allocations.

---

> [!WARNING]
> Hello, 
>
> this PR and the code in this PR are human generated because I was checking Arabic translation rules and I've noticed this behavior and did some research for my own interest.
>
> I've double checked `git blame` and, at the best of my knowledge, it is not intentional to avoid constants. I also understand that `11..99` is quite big
>
> Please triple check if this is a good change and it is worth to commit or not. I understand that this adds some extra retained memory and slower initialization time
>
> The benchmark and the following investigation are AI generated

### Overview

The Arabic pluralization rule currently rebuilds the lookup arrays for 3..10 and 11..99 on every invocation.

That work is unnecessary. Pluralization runs during translation lookups, so these allocations happen on a hot path and add avoidable CPU and memory overhead whenever Arabic translations are resolved with a count.

The main drawback is a small readability and maintainability tradeoff, plus a tiny amount of permanently retained memory for the cached constants

This PR fixes that by hoisting those arrays into frozen constants and reusing them across calls. The change is small, behavior-preserving, and directly removes repeated allocation from a performance-sensitive path.

This is also consistent with patterns already present elsewhere in rails-i18n. Shared pluralization helpers such as OneFewOther, EastSlavic, and Romanian already cache lookup ranges in frozen constants instead of rebuilding them repeatedly. There are also still a few inline allocation sites in the main pluralization file, notably in the Lithuanian and Polish rules, so Arabic is not an isolated case.

### Why this change is worth merging

- It removes avoidable per-call allocations from the Arabic pluralization rule.
- It improves throughput in the rule itself substantially.
- It reduces allocation pressure in end-to-end translation lookups.
- It does not change pluralization semantics.
- It follows an optimization style that is already used in other pluralization helpers in this repository.

### Benchmarks

Benchmarks were executed on an Apple M5 Pro with Ruby 4.0.3.

Benchmark source code: https://gist.github.com/tagliala/170ca1c8f1be747b33fe3371b2155bed

#### IPS

| Workload | master | this branch | delta |
|---|---:|---:|---:|
| Rule only | 1,716.3 i/s | 8,679 i/s | 5.06x faster |
| Translations | 7,111.2 i/s | 8,624 i/s | 21.3% faster |

#### Benchmark.memory

| Workload | master | this branch | delta |
|---|---:|---:|---:|
| Rule only | 482.4 KB, 900 objects | 0 B, 0 objects | eliminated allocations |
| Translations | 70,192 B, 434 objects | 41,248 B, 380 objects | 41.2% less memory, 12.4% fewer objects |

#### Memory profiler

| Workload | master | this branch | delta |
|---|---:|---:|---:|
| Rule only | 22,500 alloc, 11.50 MiB | 0 alloc, 0 B | eliminated allocations |
| Translations | 10,802 alloc, 1.67 MiB | 9,452 alloc, 1005.16 KiB | 12.5% fewer allocs, 41.2% less memory |

### Codebase context

- Existing cached lookup constants:
  https://github.com/svenfuchs/rails-i18n/blob/d88d78de6317041b3e154b8d260c4cb35e1f8d36/lib/rails_i18n/common_pluralizations/one_few_other.rb#L4-L5
  https://github.com/svenfuchs/rails-i18n/blob/d88d78de6317041b3e154b8d260c4cb35e1f8d36/lib/rails_i18n/common_pluralizations/east_slavic.rb#L9-L12
  https://github.com/svenfuchs/rails-i18n/blob/d88d78de6317041b3e154b8d260c4cb35e1f8d36/lib/rails_i18n/common_pluralizations/romanian.rb#L6
- Remaining inline allocation sites:
  pluralization.rb

### Expected impact

This is a focused hot-path optimization with very low risk. The biggest gain is in the pluralization rule itself, where repeated array construction was dominating cost. The full translation path also benefits through lower allocation pressure and better throughput.
