### PR TITLE
Reduce allocation overhead in pluralization hot paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Fix incorrect `ja.number.currency.format.negative_format` definition
 - Fix constant resolution failures when rules are evaluated in another scope
+- Make Arabic and Lithuanian pluralization faster
 - Update to Rails 8.1.x, and run `thor locales:normalize_from_rails`
 - English: Add missing keys
 - Spanish: Add missing keys

--- a/lib/rails_i18n/pluralization.rb
+++ b/lib/rails_i18n/pluralization.rb
@@ -1,6 +1,9 @@
 module RailsI18n
   module Pluralization
     module Arabic
+      FROM_3_TO_10 = (3..10).to_a.freeze
+      FROM_11_TO_99 = (11..99).to_a.freeze
+
       def self.rule
         lambda do |n|
           return :other unless n.is_a?(Numeric)
@@ -13,9 +16,9 @@ module RailsI18n
             :one
           elsif n == 2
             :two
-          elsif (3..10).to_a.include?(mod100)
+          elsif FROM_3_TO_10.include?(mod100)
             :few
-          elsif (11..99).to_a.include?(mod100)
+          elsif FROM_11_TO_99.include?(mod100)
             :many
           else
             :other
@@ -62,6 +65,9 @@ module RailsI18n
     end
 
     module Lithuanian
+      FROM_2_TO_9 = (2..9).to_a.freeze
+      FROM_11_TO_19 = (11..19).to_a.freeze
+
       def self.rule
         lambda do |n|
           return :other unless n.is_a?(Numeric)
@@ -69,9 +75,9 @@ module RailsI18n
           mod10 = n % 10
           mod100 = n % 100
 
-          if mod10 == 1 && !(11..19).to_a.include?(mod100)
+          if mod10 == 1 && !FROM_11_TO_19.include?(mod100)
             :one
-          elsif (2..9).to_a.include?(mod10) && !(11..19).to_a.include?(mod100)
+          elsif FROM_2_TO_9.include?(mod10) && !FROM_11_TO_19.include?(mod100)
             :few
           else
             :other


### PR DESCRIPTION
Supersede #1170

Pluralization rules run for every counted translation, so avoidable transient allocations in those checks add overhead directly to a hot path.

Reducing that allocation pressure lowers memory use and improves translation throughput where the extra work was measurable.

---

### Benchmark harness

Commands used:

- `WARMUP_SECONDS=1 MEASURE_SECONDS=5 RULE_INNER_REPS=50 PROFILE_SWEEPS=10 ruby benchmark_pluralization_arrays.rb --ref master --locales ar,lt`
- `WARMUP_SECONDS=1 MEASURE_SECONDS=5 RULE_INNER_REPS=50 PROFILE_SWEEPS=10 ruby benchmark_pluralization_arrays.rb --ref HEAD --locales ar,lt`

<details>
<summary>Benchmark source</summary>

```ruby
#!/usr/bin/env ruby
# frozen_string_literal: true

require 'bundler/inline'
require 'fileutils'
require 'open3'
require 'optparse'

begin
  gemfile(true) do
    source 'https://rubygems.org'

    gem 'benchmark-ips', '~> 2.8.0'
    gem 'benchmark-memory', '~> 0.1.2'
    gem 'memory_profiler'
    gem 'i18n'
  end

  require 'benchmark/ips'
  require 'benchmark/memory'
  require 'memory_profiler'
  require 'i18n'
  require 'i18n/backend/pluralization'
rescue Gem::LoadError => error
  warn "\nMissing Dependency:\n#{error.backtrace.first} #{error.message}"
  exit 1
rescue LoadError => error
  warn "\nError:\n#{error.backtrace.first} #{error.message}"
  warn DATA.read
  exit 1
end

module PluralizationArrayBenchmark
  module_function

  REPO_ROOT = __dir__
  PLURALIZATION_PATH = 'lib/rails_i18n/pluralization.rb'
  TRANSLATION_UNITS = {
    x_seconds: 'seconds',
    x_minutes: 'minutes',
    about_x_hours: 'hours'
  }.freeze

  SCENARIOS = {
    ar: {
      name: 'Arabic',
      module_name: 'Arabic',
      plural_keys: %i[zero one two few many other],
      counts: [0, 1, 2, 3, 7, 10, 11, 42, 99, 100, 101, 102, 103, 111, 3.0, 10.0, 11.0, 99.0].freeze,
      expected_categories: {
        0 => :zero,
        1 => :one,
        2 => :two,
        3 => :few,
        7 => :few,
        10 => :few,
        11 => :many,
        42 => :many,
        99 => :many,
        100 => :other,
        101 => :other,
        102 => :other,
        103 => :few,
        111 => :many,
        3.0 => :few,
        10.0 => :few,
        11.0 => :many,
        99.0 => :many
      }.freeze
    },
    lt: {
      name: 'Lithuanian',
      module_name: 'Lithuanian',
      plural_keys: %i[one few other],
      counts: [1, 2, 5, 9, 10, 11, 15, 20, 21, 22, 29, 30, 101, 109, 111, 1.0, 2.0, 11.0, 22.0].freeze,
      expected_categories: {
        1 => :one,
        2 => :few,
        5 => :few,
        9 => :few,
        10 => :other,
        11 => :other,
        15 => :other,
        20 => :other,
        21 => :one,
        22 => :few,
        29 => :few,
        30 => :other,
        101 => :one,
        109 => :few,
        111 => :other,
        1.0 => :one,
        2.0 => :few,
        11.0 => :other,
        22.0 => :few
      }.freeze
    },
    pl: {
      name: 'Polish',
      module_name: 'Polish',
      plural_keys: %i[one few many other],
      counts: [1, 2, 4, 5, 10, 11, 12, 14, 20, 21, 22, 24, 25, 31, 32, 114, 1.0, 2.0, 12.0, 22.0].freeze,
      expected_categories: {
        1 => :one,
        2 => :few,
        4 => :few,
        5 => :many,
        10 => :many,
        11 => :many,
        12 => :many,
        14 => :many,
        20 => :many,
        21 => :many,
        22 => :few,
        24 => :few,
        25 => :many,
        31 => :many,
        32 => :few,
        114 => :many,
        1.0 => :one,
        2.0 => :few,
        12.0 => :many,
        22.0 => :few
      }.freeze
    }
  }.freeze

  DEFAULT_LOCALES = SCENARIOS.keys.freeze
  WARMUP_SECONDS = ENV.fetch('WARMUP_SECONDS', '1').to_f
  MEASURE_SECONDS = ENV.fetch('MEASURE_SECONDS', '2').to_f
  RULE_INNER_REPS = ENV.fetch('RULE_INNER_REPS', '50').delete('_').to_i
  PROFILE_SWEEPS = ENV.fetch('PROFILE_SWEEPS', '10').delete('_').to_i

  def run(argv = ARGV)
    Dir.chdir(REPO_ROOT)

    options = parse_options(argv)
    revision = resolve_revision(options[:ref])

    load_pluralization_source!(revision)
    boot_i18n!

    puts
    puts "Ruby version: #{RUBY_VERSION}"
    puts 'Pluralization array benchmark'
    puts "Repo root: #{REPO_ROOT}"
    puts "Ref: #{revision[:label]}"
    puts "Scenarios: #{options[:locales].map { |locale| format_scenario_label(locale) }.join(', ')}"
    puts "Warmup: #{WARMUP_SECONDS}s | Measure: #{MEASURE_SECONDS}s | Rule inner reps: #{RULE_INNER_REPS} | Profile sweeps: #{PROFILE_SWEEPS}"
    puts

    options[:locales].each do |locale|
      scenario = SCENARIOS.fetch(locale)
      run_scenario(scenario, File.join(options[:profile_dir], locale.to_s))
    end
  end

  def parse_options(argv)
    options = {
      ref: 'HEAD',
      locales: DEFAULT_LOCALES,
      profile_dir: File.join('tmp', 'pluralization_benchmarks')
    }

    OptionParser.new do |parser|
      parser.banner = 'Usage: ruby benchmark_pluralization_arrays.rb [options]'

      parser.on('--ref REF', 'Git ref to benchmark (default: HEAD)') do |ref|
        options[:ref] = ref
      end

      parser.on('--locales x,y,z', Array, 'Locales to benchmark (default: ar,lt,pl)') do |locales|
        options[:locales] = locales.map(&:to_sym)
      end

      parser.on('--profile-dir DIR', 'Directory for memory profiler reports') do |profile_dir|
        options[:profile_dir] = profile_dir
      end
    end.parse!(argv)

    unknown_locales = options[:locales] - DEFAULT_LOCALES
    raise ArgumentError, "Unknown locales: #{unknown_locales.join(', ')}" unless unknown_locales.empty?

    options
  end

  def resolve_revision(ref)
    if ref == 'working-tree'
      sha = capture!('git', 'rev-parse', '--short', 'HEAD').strip

      {
        ref: ref,
        sha: sha,
        label: "working-tree (#{sha})",
        source: File.read(PLURALIZATION_PATH),
        profile_slug: "working_tree_#{sha}"
      }
    else
      sha = capture!('git', 'rev-parse', '--short', ref).strip

      {
        ref: ref,
        sha: sha,
        label: "#{ref} (#{sha})",
        source: capture!('git', 'show', "#{ref}:#{PLURALIZATION_PATH}"),
        profile_slug: sanitize_slug(ref)
      }
    end
  end

  def load_pluralization_source!(revision)
    Object.send(:remove_const, :RailsI18n) if Object.const_defined?(:RailsI18n, false)
    eval(revision[:source], TOPLEVEL_BINDING, "#{revision[:ref]}:#{PLURALIZATION_PATH}")
  end

  def boot_i18n!
    unless I18n::Backend::Simple.ancestors.include?(I18n::Backend::Pluralization)
      I18n::Backend::Simple.include(I18n::Backend::Pluralization)
    end

    I18n.enforce_available_locales = false
  end

  def run_scenario(scenario, profile_dir)
    rule = load_rule(scenario)

    verify_rule!(scenario, rule)
    setup_backend!(scenario, rule)

    puts "Scenario: #{scenario[:name]} (#{scenario_locale(scenario)})"
    print_samples(scenario, rule)
    run_ips_benchmark(scenario, rule)
    run_memory_benchmark(scenario, rule)
    run_profiler(scenario, rule, profile_dir)
  end

  def load_rule(scenario)
    ::RailsI18n::Pluralization.const_get(scenario[:module_name]).rule
  end

  def verify_rule!(scenario, rule)
    mismatches = scenario[:expected_categories].filter_map do |count, expected|
      actual = rule.call(count)
      next if actual == expected

      "#{count.inspect}: expected #{expected}, got #{actual}"
    end

    return if mismatches.empty?

    raise "#{scenario[:name]} rule sanity check failed:\n#{mismatches.join("\n")}"
  end

  def setup_backend!(scenario, rule)
    locale = scenario_locale(scenario)

    I18n.available_locales = [locale]
    I18n.backend = I18n::Backend::Simple.new
    I18n.backend.store_translations(locale, translations_for(scenario, rule))
  end

  def translations_for(scenario, rule)
    forms = TRANSLATION_UNITS.each_with_object({}) do |(key, unit), memo|
      memo[key] = translation_forms(scenario[:plural_keys], unit)
    end

    {
      i18n: {
        plural: {
          keys: scenario[:plural_keys],
          rule: rule
        }
      },
      benchmark: forms
    }
  end

  def translation_forms(plural_keys, unit)
    plural_keys.each_with_object({}) do |key, memo|
      memo[key] = "#{key} #{unit}: %{count}"
    end
  end

  def print_samples(scenario, rule)
    puts 'Sample categories and x_seconds translations:'

    scenario[:counts].each do |count|
      category = rule.call(count)
      translation = I18n.t('benchmark.x_seconds', locale: scenario_locale(scenario), count: count)
      puts format('  %8s -> %-5s %s', count, category, translation)
    end

    puts
  end

  def run_ips_benchmark(scenario, rule)
    puts "IPS: #{scenario[:name]}"

    Benchmark.ips do |benchmark|
      benchmark.warmup = WARMUP_SECONDS
      benchmark.time = MEASURE_SECONDS

      benchmark.report(rule_label(scenario)) { rule_sweep(scenario, rule) }
      benchmark.report(translation_label(scenario)) { translation_sweep(scenario) }
      benchmark.compare!
    end

    puts
  end

  def run_memory_benchmark(scenario, rule)
    puts "Memory: #{scenario[:name]}"

    Benchmark.memory do |benchmark|
      benchmark.report(rule_label(scenario)) { rule_sweep(scenario, rule) }
      benchmark.report(translation_label(scenario)) { translation_sweep(scenario) }
      benchmark.compare!
    end

    puts
  end

  def run_profiler(scenario, rule, profile_dir)
    puts "Profiler: #{scenario[:name]}"

    FileUtils.mkdir_p(profile_dir)

    profile_workloads(scenario, rule, profile_dir).each do |label, path, workload|
      report = MemoryProfiler.report do
        PROFILE_SWEEPS.times { workload.call }
      end

      report.pretty_print(to_file: path)

      puts format(
        '  %-15s alloc=%8d (%10s) retained=%8d (%10s) report=%s',
        label,
        report.total_allocated,
        format_bytes(report.total_allocated_memsize),
        report.total_retained,
        format_bytes(report.total_retained_memsize),
        path
      )
    end

    puts
  end

  def profile_workloads(scenario, rule, profile_dir)
    locale = scenario_locale(scenario)

    [
      ["#{locale}_rule", File.join(profile_dir, "#{locale}_rule_only.memory_profiler.txt"), -> { rule_sweep(scenario, rule) }],
      ["#{locale}_translations", File.join(profile_dir, "#{locale}_translations.memory_profiler.txt"), -> { translation_sweep(scenario) }]
    ]
  end

  def rule_sweep(scenario, rule)
    checksum = 0

    RULE_INNER_REPS.times do
      scenario[:counts].each do |count|
        checksum ^= rule.call(count).hash
      end
    end

    checksum
  end

  def translation_sweep(scenario)
    checksum = 0
    locale = scenario_locale(scenario)

    TRANSLATION_UNITS.each_key do |key|
      scenario[:counts].each do |count|
        checksum += I18n.t("benchmark.#{key}", locale: locale, count: count).bytesize
      end
    end

    checksum
  end

  def rule_label(scenario)
    "#{scenario_locale(scenario)} rule x#{scenario[:counts].size * RULE_INNER_REPS}"
  end

  def translation_label(scenario)
    "#{scenario_locale(scenario)} translations x#{scenario[:counts].size * TRANSLATION_UNITS.size}"
  end

  def scenario_locale(scenario)
    SCENARIOS.key(scenario)
  end

  def format_scenario_label(locale)
    scenario = SCENARIOS.fetch(locale)
    "#{scenario[:name]} (#{locale})"
  end

  def sanitize_slug(value)
    value.gsub(/[^A-Za-z0-9._-]+/, '_')
  end

  def capture!(*command)
    stdout, stderr, status = Open3.capture3(*command)
    return stdout if status.success?

    raise "Command failed (#{command.join(' ')}): #{stderr.strip}"
  end

  def format_bytes(bytes)
    units = %w[B KiB MiB GiB]
    value = bytes.to_f
    unit = units.first

    units[1..].each do |next_unit|
      break if value < 1024

      value /= 1024
      unit = next_unit
    end

    format('%.2f %s', value, unit)
  end
end

PluralizationArrayBenchmark.run if $PROGRAM_NAME == __FILE__

__END__
Run this script with plain ruby so bundler/inline can manage its own gems:

  ruby benchmark_pluralization_arrays.rb --ref HEAD
  ruby benchmark_pluralization_arrays.rb --ref master

Useful environment overrides:

  WARMUP_SECONDS=1 MEASURE_SECONDS=5 RULE_INNER_REPS=50 PROFILE_SWEEPS=10 ruby benchmark_pluralization_arrays.rb --ref HEAD --locales ar,lt,pl
```

</details>

### Throughput comparison

| Locale | Workload | master i/s | this branch i/s | delta |
| --- | --- | ---: | ---: | ---: |
| Arabic | Rule | 1,132.4 | 4,163.3 | +267.6% (3.68x) |
| Arabic | Translations | 4,885.6 | 6,206.9 | +27.0% (1.27x) |
| Lithuanian | Rule | 2,355.5 | 6,686.0 | +183.8% (2.84x) |
| Lithuanian | Translations | 5,427.5 | 6,135.0 | +13.0% (1.13x) |

### benchmark-memory comparison

| Locale | Workload | master memsize | this branch memsize | memsize delta | master objects | this branch objects | object delta |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Arabic | Rule | 628,800 B | 0 B | -100.0% | 1,200 | 0 | -100.0% |
| Arabic | Translations | 107,912 B | 70,184 B | -35.0% | 779 | 707 | -9.2% |
| Lithuanian | Rule | 310,000 B | 0 B | -100.0% | 1,550 | 0 | -100.0% |
| Lithuanian | Translations | 92,792 B | 74,192 B | -20.0% | 842 | 749 | -11.0% |

### MemoryProfiler comparison

| Locale | Workload | master allocated bytes | this branch allocated bytes | byte delta | master allocated objects | this branch allocated objects | object delta |
| --- | --- | --- | --- | ---: | ---: | ---: | ---: |
| Arabic | Rule | 6.00 MiB | 0 B | -100.0% | 12,000 | 0 | -100.0% |
| Arabic | Translations | 1.03 MiB | 684.69 KiB | -35.1% | 7,772 | 7,052 | -9.3% |
| Lithuanian | Rule | 2.96 MiB | 0 B | -100.0% | 15,500 | 0 | -100.0% |
| Lithuanian | Translations | 905.47 KiB | 723.83 KiB | -20.1% | 8,402 | 7,472 | -11.1% |

### Summary

- Arabic improves materially in both the rule-only and translation workloads, and removes all rule-path allocations in these measurements.
- Lithuanian improves materially in both the rule-only and translation workloads, and removes all rule-path allocations in these measurements.
