### PR TITLE
Bump Bundler to 4.0.12 to fix ruby-head CI

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,4 +171,4 @@ DEPENDENCIES
   tsort
 
 BUNDLED WITH
-   2.6.9
+   4.0.12


### PR DESCRIPTION
CI on ruby-head was failing with:

```
NameError: uninitialized constant Pathname::SEPARATOR_PAT
```

Update Gemfile.lock to use Bundler 4.0.12, which includes an upstream fix for this issue

Ref: ruby/rubygems#9529