### PR TITLE
Update hu.yml – currency should have delimiter

### DIFF
--- a/rails/locale/hu.yml
+++ b/rails/locale/hu.yml
@@ -138,15 +138,15 @@ hu:
   number:
     currency:
       format:
-        delimiter: ''
-        format: "%n %u"
+        delimiter: ' ' # U+2007 FIGURE SPACE – https://en.wikipedia.org/wiki/Figure_space
+        format: "%n %u" # U+00A0 NO-BREAK SPACE
         precision: 0
         separator: ","
         significant: true
         strip_insignificant_zeros: true
         unit: Ft
     format:
-      delimiter: " "
+      delimiter: ' ' # U+2007 FIGURE SPACE – https://en.wikipedia.org/wiki/Figure_space
       precision: 2
       separator: ","
       significant: true
@@ -167,7 +167,7 @@ hu:
         significant: true
         strip_insignificant_zeros: true
       storage_units:
-        format: "%n %u"
+        format: "%n %u" # U+00A0 NO-BREAK SPACE
         units:
           byte:
             one: bájt

--- a/rails/locale/hu.yml
+++ b/rails/locale/hu.yml
@@ -138,15 +138,15 @@ hu:
   number:
     currency:
       format:
-        delimiter: ' ' # U+2007 FIGURE SPACE – https://en.wikipedia.org/wiki/Figure_space
-        format: "%n %u" # U+00A0 NO-BREAK SPACE
+        delimiter: ' '
+        format: "%n %u"
         precision: 0
         separator: ","
         significant: true
         strip_insignificant_zeros: true
         unit: Ft
     format:
-      delimiter: ' ' # U+2007 FIGURE SPACE – https://en.wikipedia.org/wiki/Figure_space
+      delimiter: ' '
       precision: 2
       separator: ","
       significant: true


### PR DESCRIPTION
In Hungarian, both non-currency numbers and currency numbers should have some kind of space as delimiter for digit grouping. (Well, with the difference from current behaviour that numbers  as parts of continuous text –  e.g. a price mentioned as part of a sentence – should have no delimiter up to four (4) digits, delimiter only starting from five (5) digits; examples: 100 Ft, 1000 Ft, 10 000 Ft, 100 000 Ft. But numbers lined up under each other – e.g. accounting – should perform digit grouping as implemented currently: 100 Ft, 1 000 Ft, 10 000 Ft, 100 000 Ft, so that the digit grouping is visually consistent among all rows.)

For some reason however, the delimiter for currency numbers was set to empty string, while for regular numbers it was a space. Looking into "git blame" of the affected lines, I found no trace of discussion for this discrepancy. So I assume it is a mistake or oversight.

Therefore I hereby propose to make the currency delimiter a space.

To be typographically correct (including not allowing breaks) I propose U+2007 FIGURE SPACE as delimiter, and U+00A0 NO-BREAK SPACE to join the currency unit. For consistency I also changed the delimiter of non-currency numbers to U+2007 FIGURE SPACE to match currency numbers.

(If you ever need to re-parse suchly formatted numbers, please use the Unicode-aware `[[:space:]]` character class to properly match these space characters, instead of the ASCII-only `\s` which will not match them. As a bonus, because two separate characters are used now, cutting off the currency unit vs. deleting the delimiter spaces to join the digits together for parsing becomes unambiguous.)